### PR TITLE
chore(release): pre-release setup hardening and documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,25 +11,27 @@ DOMAIN=your-domain.com
 # Required for persistent sessions. If unset, a random key is generated per restart.
 SECRET_KEY=your-secret-key-here
 
-# Canvas pages directory — each instance should have its own isolated path.
-# Created by setup-sudo.sh. Default (if unset): canvas-pages/ inside app dir.
-CANVAS_PAGES_DIR=/var/www/openvoiceui/canvas-pages
+# Canvas pages directory
+# VPS/systemd install: set to the path created by setup-sudo.sh
+# Docker install:      leave UNSET — defaults to canvas-pages/ inside the container
+#                      (matches the docker-compose volume mount)
+# CANVAS_PAGES_DIR=/var/www/openvoiceui/canvas-pages
 
 # =============================================================================
-# OpenClaw Gateway (required for LLM)
-# Run OpenClaw locally: https://openclaw.ai
+# OpenClaw Gateway (required for LLM / voice conversations)
+# Download and install OpenClaw: https://openclaw.ai
 # =============================================================================
 CLAWDBOT_GATEWAY_URL=ws://127.0.0.1:18791
 CLAWDBOT_AUTH_TOKEN=your-openclaw-gateway-token
 
-# Session key prefix — change if running multiple instances
+# Session key prefix — change if running multiple instances on the same gateway
 GATEWAY_SESSION_KEY=voice-main-1
 
 # =============================================================================
 # TTS — choose one or more providers
 # =============================================================================
 
-# Groq Orpheus (recommended — fast, high quality)
+# Groq Orpheus (recommended — fast, high quality, free tier available)
 # Get key: https://console.groq.com
 GROQ_API_KEY=your-groq-api-key
 USE_GROQ=true
@@ -39,10 +41,10 @@ USE_GROQ_TTS=true
 # Get key: https://fal.ai/dashboard
 # FAL_KEY=your-fal-key
 
-# Brave Search (optional — enables web_search tool in the OpenClaw agent)
-# Free tier: 2,000 queries/month. Get key: https://brave.com/search/api/
-# Must also be set in the OpenClaw gateway service environment.
-# BRAVE_API_KEY=your-brave-search-api-key
+# Hume EVI (optional — expressive, emotion-aware TTS)
+# Get keys: https://platform.hume.ai/settings/keys
+# HUME_API_KEY=your-hume-api-key
+# HUME_SECRET_KEY=your-hume-secret-key
 
 # Supertonic (optional — local ONNX, free, requires model download)
 # SUPERTONIC_MODEL_PATH=/path/to/supertonic/assets/onnx
@@ -71,8 +73,17 @@ USE_GROQ_TTS=true
 # =============================================================================
 # SUNO_API_KEY=your-suno-key
 # SUNO_CALLBACK_URL=https://your-domain.com/api/suno/callback
+# SUNO_WEBHOOK_SECRET=your-webhook-secret   # optional HMAC verification
 
 # =============================================================================
-# Z.AI / GLM Models (optional — if using Z.AI gateway)
+# Search (optional — Brave Search for web_search tool in OpenClaw agent)
+# Free tier: 2,000 queries/month. Get key: https://brave.com/search/api/
+# Must also be set in the OpenClaw gateway service environment.
 # =============================================================================
-# ZAI_API_KEY=your-zai-key
+# BRAVE_API_KEY=your-brave-search-api-key
+
+# =============================================================================
+# Rate limiting (optional — overrides defaults set in app.py)
+# Format: "N per period" e.g. "500 per day" or "500 per day;100 per hour"
+# =============================================================================
+# RATELIMIT_DEFAULT=200 per day;50 per hour

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# System deps for cryptography, audio, and DeepFace/OpenCV
+# System deps for cryptography, audio processing, vision, and canvas features
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential libffi-dev libgl1 libglib2.0-0 && \
+    build-essential libffi-dev \
+    libgl1 libglib2.0-0 \
+    ffmpeg \
+    libsndfile1 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY backend/requirements.txt .

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,4 +1,4 @@
-# ai-eyes2 Default Configuration
+# OpenVoiceUI Default Configuration
 # All values here can be overridden by environment variables.
 # Env var naming: SECTION__KEY (double underscore), e.g. SERVER__PORT=5002
 # Or use the direct env var names listed in comments.
@@ -10,45 +10,32 @@ server:
   debug: false
   threaded: true
 
-# ── Gateway (Clawdbot) ────────────────────────────────────────────────────────
+# ── Gateway (OpenClaw) ────────────────────────────────────────────────────────
 gateway:
   url: "ws://127.0.0.1:18791"         # env: CLAWDBOT_GATEWAY_URL
   auth_token: ""                       # env: CLAWDBOT_AUTH_TOKEN (required)
-  session_key: "voice-main-2"          # env: GATEWAY_SESSION_KEY
+  session_key: "voice-main-1"          # env: GATEWAY_SESSION_KEY
 
 # ── LLM Models ────────────────────────────────────────────────────────────────
 models:
-  zai_default: "glm-4.5-flash"         # direct Z.AI model
-  zai_gateway: "zai/glm-4.7-flash"     # gateway-routed Z.AI model
-  gemini: "gemini-2.0-flash"           # env: GEMINI_MODEL
   whisper: "tiny"                      # Faster-Whisper model size
   whisper_device: "cpu"                # cpu or cuda
   whisper_compute: "float32"           # float32, float16, int8
 
 # ── TTS ───────────────────────────────────────────────────────────────────────
 tts:
-  provider: "supertonic"               # env: TTS_PROVIDER (supertonic or groq-orpheus)
-  use_groq: false                      # env: USE_GROQ_TTS (true = groq-orpheus)
+  provider: "groq"                     # env: TTS_PROVIDER (groq or supertonic)
 
 # ── Conversation ──────────────────────────────────────────────────────────────
 conversation:
   max_history_messages: 20             # env: MAX_HISTORY_MESSAGES
-  active_profile: "flash-direct"       # flash-direct or gateway
-
-# ── Paths ─────────────────────────────────────────────────────────────────────
-paths:
-  openclaw_workspace: "~/.openclaw/workspace"   # env: OPENCLAW_WORKSPACE
-  clawdbot_memory_db: ""   # optional: path to clawdbot memory DB
-  canvas_display_dir: "/var/www/canvas-display"
-  canvas_pages_dir: "/var/www/canvas-display/pages"
-  canvas_images_dir: "/var/www/canvas-display/images"
-  canvas_live_html: "/var/www/canvas-display/canvas/live.html"
+  active_profile: "default"            # must match a filename in profiles/
 
 # ── Logging ───────────────────────────────────────────────────────────────────
 logging:
   level: "INFO"                        # env: LOG_LEVEL
 
-# ── Features (runtime toggles, separate from feature flags) ──────────────────
+# ── Features (runtime toggles) ────────────────────────────────────────────────
 features:
   enable_fts: true                     # env: ENABLE_FTS
   enable_briefing: true                # env: ENABLE_BRIEFING

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,18 @@ services:
     env_file:
       - .env
     volumes:
-      # Persist runtime data outside container
+      # Persist runtime data outside the container so it survives restarts.
+      # Note: if CANVAS_PAGES_DIR is set in .env, it must match this mount path.
+      # For Docker, leave CANVAS_PAGES_DIR unset in .env (defaults to /app/canvas-pages).
       - ./uploads:/app/uploads
       - ./canvas-pages:/app/canvas-pages
       - ./known_faces:/app/known_faces
       - ./music:/app/music
       - ./generated_music:/app/generated_music
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5001/health/live')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s

--- a/openvoiceui.service
+++ b/openvoiceui.service
@@ -1,16 +1,30 @@
+# =============================================================================
+# OpenVoiceUI systemd service template
+#
+# !! EDIT BEFORE USING !!
+# Replace all /path/to/OpenVoiceUI and YOUR_USER with real values, then:
+#
+#   sudo cp openvoiceui.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable openvoiceui
+#   sudo systemctl start openvoiceui
+#
+# Or use setup-sudo.sh which fills these in automatically.
+# =============================================================================
+
 [Unit]
 Description=OpenVoiceUI Voice Agent Server
 After=network.target
 
 [Service]
 Type=simple
-User=YOUR_USER
-WorkingDirectory=/path/to/OpenVoiceUI-public
-ExecStart=/path/to/OpenVoiceUI-public/venv/bin/python3 /path/to/OpenVoiceUI-public/server.py
+User=YOUR_USER                                              # ← your Linux username
+WorkingDirectory=/path/to/OpenVoiceUI                      # ← full path to repo
+ExecStart=/path/to/OpenVoiceUI/venv/bin/python3 /path/to/OpenVoiceUI/server.py
 Restart=always
 RestartSec=10
 Environment=PATH=/usr/bin:/usr/local/bin
-EnvironmentFile=/path/to/OpenVoiceUI-public/.env
+EnvironmentFile=/path/to/OpenVoiceUI/.env                  # ← full path to .env
 
 [Install]
 WantedBy=multi-user.target

--- a/setup-nginx.sh
+++ b/setup-nginx.sh
@@ -1,25 +1,50 @@
 #!/bin/bash
-# Setup nginx for your-domain.com
+# =============================================================================
+# OpenVoiceUI — quick nginx config for a single domain
+#
+# For a full setup (SSL, systemd service, www dirs) use setup-sudo.sh instead.
+# This script is for manual nginx-only configuration.
+#
+# Edit DOMAIN, PORT, and EMAIL before running.
+# Run as: sudo bash setup-nginx.sh
+# =============================================================================
 
-cat << 'NGINX' | sudo tee /etc/nginx/sites-available/your-domain.com
+DOMAIN="your-domain.com"        # ← EDIT: your actual domain
+PORT=5001                        # ← match PORT in your .env (default: 5001)
+EMAIL="your-email@example.com"  # ← EDIT: for Let's Encrypt notifications
+
+# Guard: refuse to run with placeholder values
+if [ "$DOMAIN" = "your-domain.com" ] || [ "$EMAIL" = "your-email@example.com" ]; then
+    echo "ERROR: Edit DOMAIN and EMAIL at the top of this script before running."
+    exit 1
+fi
+
+cat << NGINX | sudo tee /etc/nginx/sites-available/${DOMAIN}
 server {
     listen 80;
-    server_name your-domain.com;
+    listen [::]:80;
+    server_name ${DOMAIN};
 
     location / {
-        proxy_pass http://127.0.0.1:5000;
+        proxy_pass http://127.0.0.1:${PORT};
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass $http_upgrade;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_cache_bypass \$http_upgrade;
+        proxy_read_timeout 86400;
     }
+
+    client_max_body_size 100M;
 }
 NGINX
 
-sudo ln -sf /etc/nginx/sites-available/your-domain.com /etc/nginx/sites-enabled/
+sudo ln -sf /etc/nginx/sites-available/${DOMAIN} /etc/nginx/sites-enabled/
 sudo nginx -t && sudo systemctl reload nginx
-sudo certbot --nginx -d your-domain.com --non-interactive --agree-tos -m your-email@example.com
+sudo certbot --nginx -d ${DOMAIN} --non-interactive --agree-tos -m ${EMAIL}
+
+echo ""
+echo "Done. OpenVoiceUI accessible at https://${DOMAIN}"


### PR DESCRIPTION
## What does this PR do?
Full pre-release pass fixing all setup/install issues found in the readiness review, plus adding SETUP.md and an OpenClaw gateway check to the setup script.

## Why?
The VPS install path was broken in multiple places (wrong nginx port, placeholder guard missing, service file unclear). Docker users would get confused by the canvas path. No end-to-end setup guide existed.

## Type of change
- [x] Bug fix
- [x] Documentation

## Changes

**Bugs fixed:**
- `setup-nginx.sh`: hardcoded port was 5000, server default is 5001. Added variables and a guard against running with placeholder domain/email.
- `config/default.yaml`: `active_profile: "flash-direct"` referenced a profile that doesn't exist. Changed to `default`. Removed orphaned canvas path keys, stale model references, wrong title.
- `openvoiceui.service`: placeholders had no warning comments — users copy-pasted and got silent failures.
- `setup-sudo.sh`: no guard against running with `your-domain.com` / `your@email.com` placeholders.

**New:**
- `SETUP.md`: comprehensive install guide covering Docker, VPS, local dev, configuration reference, troubleshooting.
- `setup-sudo.sh`: OpenClaw gateway check — if `CLAWDBOT_AUTH_TOKEN` is missing or still the placeholder value, prints step-by-step OpenClaw setup instructions and confirms before continuing.
- `setup-sudo.sh`: checks `.env` exists before proceeding.
- `docker-compose.yml`: health check on `/health/live`.

**Improvements:**
- `Dockerfile`: added `ffmpeg` and `libsndfile1` (audio processing, canvas video, local STT, Supertonic TTS).
- `.env.example`: added `HUME_API_KEY`/`HUME_SECRET_KEY`, `RATELIMIT_DEFAULT`, `SUNO_WEBHOOK_SECRET`; canvas path now commented out with Docker vs VPS guidance.

## Testing
- [x] Tested locally with voice input
- [x] 457 tests pass, 0 failures

## Checklist
- [x] No API keys or secrets in my changes
- [x] `.env.example` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)