### PR TITLE
chore: add development-notes/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,9 @@ TOOLS.md
 prompts/dj_prompt_*.txt
 prompts/hume_config_snapshot*.txt
 
-# Claude Code project instructions (private dev notes — keep local only)
+# Claude Code project instructions and local dev notes — never commit these
 CLAUDE.md
+development-notes/
 
 # Netlify
 .netlify/


### PR DESCRIPTION
Adds `development-notes/` to .gitignore. Local developer notes folder (sprint tracking, decisions log) — should never be committed to the public repo.