### PR TITLE
fix(ui): show thinking indicator immediately on call activation

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2569,6 +2569,11 @@ inject();
                 this.sessionId = `session_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
                 console.log('New conversation session:', this.sessionId);
 
+                // Show thinking state immediately so user sees feedback before any async work
+                FaceModule.setMood('thinking');
+                StatusModule.update('thinking', 'CONNECTING...');
+                document.getElementById('thought-bubbles')?.classList.add('active');
+
                 // Unlock AudioContext for iOS — MUST happen synchronously within the user
                 // gesture call stack, before any await. iOS suspends AudioContext by default
                 // and blocks async audio.play() calls that arrive via network responses.
@@ -4720,6 +4725,11 @@ inject();
                         }
                     }
 
+                    // Show thinking immediately — user gets feedback before async startup
+                    FaceModule.setMood('thinking');
+                    StatusModule.update('thinking', 'CONNECTING...');
+                    document.getElementById('thought-bubbles')?.classList.add('active');
+
                     // Flash buttons and start conversation
                     callButton.classList.add('auto-triggered');
                     wakeButton.classList.add('active');
@@ -4820,6 +4830,11 @@ inject();
                                 return;
                             }
                         }
+                    } else {
+                        // No camera — show thinking immediately so user gets instant feedback
+                        FaceModule.setMood('thinking');
+                        StatusModule.update('thinking', 'CONNECTING...');
+                        document.getElementById('thought-bubbles')?.classList.add('active');
                     }
                     agent.toggle();
                 });


### PR DESCRIPTION
## What does this PR do?
Fixes the silent gap between activating a call and the agent responding. The UI now shows a thinking indicator the instant the call button is clicked or the wake word fires.

## Why?
When camera was off, both the click and wake word paths jumped straight into async work (AudioContext creation, STT setup, greeting fetch) with zero visual feedback. Users saw nothing, then suddenly heard the greeting. With camera on it already showed `IDENTIFYING...` immediately — camera-off had no equivalent.

## Changes

**`src/app.js` — 3 targeted changes:**

1. `startVoiceInput()` — set `FaceModule.setMood('thinking')` + `StatusModule.update('thinking', 'CONNECTING...')` + thought-bubbles at the very top, before AudioContext or any async work. This is the single convergence point for both activation paths.

2. Wake word handler — same three lines immediately before `ModeManager.toggleVoice()` so thinking shows the instant the wake word fires.

3. Click handler — added `else` branch for the camera-off case (camera-on already shows `IDENTIFYING...`) so clicking immediately shows thinking before `agent.toggle()`.

The state then progresses naturally: `CONNECTING...` → `THINKING` (when greeting fetch starts) → `LISTENING` (when response plays back).

## Type of change
- [x] Bug fix
- [x] Frontend / UI

## Testing
- [x] Tested locally with voice input
- [x] 457 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)