### PR TITLE
fix(stt): prevent TTS echo loop — keep _ttsPlaying guard through mic restart delay

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2574,6 +2574,11 @@ inject();
                 StatusModule.update('thinking', 'CONNECTING...');
                 document.getElementById('thought-bubbles')?.classList.add('active');
 
+                // Guard mic from the start — greeting fetch + TTS play will set this properly
+                // via onSpeaking, but setting it here prevents any STT results that arrive
+                // between stt.start() and the first onSpeaking callback from slipping through
+                this._ttsPlaying = true;
+
                 // Unlock AudioContext for iOS — MUST happen synchronously within the user
                 // gesture call stack, before any await. iOS suspends AudioContext by default
                 // and blocks async audio.play() calls that arrive via network responses.
@@ -3450,17 +3455,20 @@ inject();
                         WaveformModule.setAmplitude(0);
                         MusicModule.duck(false);
                         document.getElementById('stop-button').style.display = 'none';
-                        // Restart microphone after DJ finishes speaking (with 1s delay to avoid picking up tail of TTS)
-                        this.clawdbotMode._ttsPlaying = false;
+                        // Keep _ttsPlaying = true through the entire delay window so the
+                        // stt.onResult filter blocks any echo/reverb that STT picks up
+                        // the moment the mic restarts. Clearing it here (before the timeout)
+                        // was the root cause of the self-echo loop.
                         setTimeout(() => {
+                            this.clawdbotMode._ttsPlaying = false;  // clear AFTER delay
                             if (this.clawdbotMode._voiceActive && this.clawdbotMode.stt && !this.clawdbotMode.stt.isListening) {
-                                console.log('🎤 Unmuting mic after TTS (delayed 1s)');
+                                console.log('🎤 Unmuting mic after TTS (echo guard expired)');
                                 if (this.clawdbotMode.stt && this.clawdbotMode.stt.resetProcessing) {
                                     this.clawdbotMode.stt.resetProcessing();
                                 }
                                 this.clawdbotMode.stt.start();
                             }
-                        }, 1000);
+                        }, 1500);
                     },
                     onMessage: (role, text) => {
                         console.log(`Clawdbot ${role}:`, text);


### PR DESCRIPTION
## What does this PR do?
Fixes the agent hearing its own TTS audio and sending it back to itself as user speech (echo loop).

## Root cause
In `onListening()`, `_ttsPlaying` was cleared to `false` immediately when TTS audio ended, then the mic restarted 1 second later. During that full 1-second window the echo filter (`if (this._ttsPlaying) return` in `stt.onResult`) was already disabled, so speaker reverb passed straight through and was sent to the agent as a user utterance.

## Changes
1. **`onListening()`** — move `_ttsPlaying = false` INSIDE the setTimeout so the flag stays true for the full 1.5s delay. Also increased delay from 1000ms → 1500ms.
2. **`startVoiceInput()`** — set `_ttsPlaying = true` immediately at session start to cover the greeting fetch window before the first `onSpeaking` callback fires.

## Type of change
- [x] Bug fix

## Testing
- [x] Tested locally with voice input
- [x] 457 tests pass