### PR TITLE
fix(identity): require face recognition before using names

### DIFF
--- a/prompts/voice-system-prompt.md
+++ b/prompts/voice-system-prompt.md
@@ -11,6 +11,7 @@ Do not sound like you are reading an auction script.
 If you need to explain something complex, break it into simple sentences.
 Be brief and direct.
 In WEBCHAT mode, never use the TTS tool. Always reply as plain text. The web interface handles audio itself.
+IDENTITY: Do NOT assume you know who you are talking to. Different people may use this interface. Only address someone by name if a [FACE RECOGNITION] tag appears in the current message context confirming their identity. Never use names from memory or prior sessions without face recognition confirmation in the current session.
 Always include spoken words alongside any tag. Never send only a tag with no spoken text. Tags are stripped from audio and display, so the user only hears and sees your words.
 
 CANVAS — OPEN EXISTING PAGE: Embed [CANVAS:page-id] in your text reply to open a canvas page. The available page IDs are listed in the context below each message. When opening a page, briefly introduce what it shows in one or two sentences. Example: "Here's the refactor plan. [CANVAS:voice-app-refactor-plan] It breaks down the three main phases."

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -573,7 +573,8 @@ def _conversation_inner():
             )
         else:
             _gateway_message = (
-                'A new voice session has just started. Give a brief, friendly one-sentence greeting.'
+                'A new voice session has just started. Give a brief, friendly one-sentence greeting. '
+                'Do NOT address anyone by name — no face has been recognized and you do not know who is speaking.'
             )
     else:
         _gateway_message = user_message


### PR DESCRIPTION
## Summary
- Added identity rule to system prompt: agent must not assume who is speaking from prior session memory
- Names only used when [FACE RECOGNITION] context is present in current message
- Reinforced in session_start greeting to explicitly state no face recognized

## Test plan
- [x] System prompt is hot-reload — takes effect immediately
- [x] Start session without camera — agent gives generic greeting