### PR TITLE
fix(ui): route call button through ModeManager so voice uses streaming path

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,6 @@
 </head>
 <body>
     <!-- App entry point: injects DOM shell + initializes all modules -->
-    <script type="module" src="src/app.js?v=5"></script>
+    <script type="module" src="src/app.js?v=6"></script>
 </body>
 </html>

--- a/src/app.js
+++ b/src/app.js
@@ -5085,10 +5085,11 @@ inject();
             if (_callBtn) {
                 _callBtn.removeAttribute('onclick');
                 _callBtn.addEventListener('click', async () => {
-                    const agent = window.voiceAgent;
-                    if (!agent) return;
-                    // If already connected, just toggle off — no need to identify
-                    if (agent.isConnected) { agent.toggle(); return; }
+                    // If already listening, toggle off via ModeManager — no need to identify
+                    if (ModeManager.clawdbotMode?.stt?.isListening) {
+                        ModeManager.toggleVoice();
+                        return;
+                    }
 
                     const profile        = window._activeProfileData || {};
                     const identifyOnWake = profile?.stt?.identify_on_wake !== false;
@@ -5114,7 +5115,7 @@ inject();
                         StatusModule.update('thinking', 'CONNECTING...');
                         document.getElementById('thought-bubbles')?.classList.add('active');
                     }
-                    agent.toggle();
+                    ModeManager.toggleVoice();
                 });
             }
 


### PR DESCRIPTION
## Problem
The call button intercepted clicks and called `voiceConversation.toggle()` directly — the old non-streaming `VoiceConversation` class. This meant:

- **Action Console showed zero entries** — `handleUserTranscript` has no `ActionConsole.addEntry` calls
- **Double responses** — `__session_start__` went through `ClawdBotMode` (streaming) while voice went through `VoiceConversation` (non-streaming), so two separate requests fired
- **Auto-greeting unreliable** — streaming greeting would get cut off by the non-streaming voice path starting up

## Root Cause
The call button had a click listener override (added to handle face ID before connecting) that called `agent.toggle()` where `agent = window.voiceAgent = voiceConversation`. This bypassed `ModeManager.toggleVoice()` entirely.

## Fix
Replace `agent.toggle()` with `ModeManager.toggleVoice()` in both the connect and disconnect branches of the call button handler. Voice now always routes through `ClawdBotMode.sendMessage()` → streaming `/api/conversation?stream=1` → ActionConsole and TranscriptPanel both populated correctly.

Also bumps `app.js` cache buster v5→v6.

## Test plan
- [ ] Click call button — voice routes through streaming path (check browser console for `app.js:2757` not `app.js:3925`)
- [ ] Action Console shows entries: Sent, Connected, Response complete, Playing TTS
- [ ] No double responses on "hello"
- [ ] Auto-greeting fires on session start
- [ ] Disconnect (click call button again) works correctly
- [ ] 457 tests pass, 0 failed