### PR TITLE
fix: music panel z-index above canvas overlay

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -959,7 +959,7 @@
             border-radius: 14px 14px 0 0;
             transform: translateX(-50%) translateY(100%);
             transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-            z-index: 100;
+            z-index: 200;
             overflow: hidden;
             box-shadow: 0 -4px 25px rgba(0, 229, 255, 0.25),
                         0 0 40px rgba(0, 229, 255, 0.12),


### PR DESCRIPTION
## Summary

- Music panel z-index raised from 100 to 200 so it renders above the canvas overlay (z-index: 150)

## Test plan

- [x] Verified on test-dev, brad, nick — music player visible over canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)