### PR TITLE
security: WebSocket auth, path traversal, SSRF protection

### DIFF
--- a/routes/suno.py
+++ b/routes/suno.py
@@ -16,14 +16,17 @@ Agent trigger:
 
 import hashlib
 import hmac
+import ipaddress
 import json
 import logging
 import os
+import socket
 import threading
 import time
 import uuid
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import urlparse
 
 import requests as http_requests
 from flask import Blueprint, jsonify, request
@@ -59,6 +62,27 @@ completed_songs_queue: list = []  # [{song_id, title, job_id, completed_at, url}
 _suno_lock = threading.Lock()
 
 logger = logging.getLogger(__name__)
+
+
+def _is_safe_download_url(url: str) -> bool:
+    """Reject URLs that point to private/reserved IP ranges (SSRF protection)."""
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+        if not hostname or parsed.scheme not in ('http', 'https'):
+            return False
+        # Resolve hostname to IP and check if private/reserved
+        for info in socket.getaddrinfo(hostname, parsed.port or 443, proto=socket.IPPROTO_TCP):
+            addr = info[4][0]
+            ip = ipaddress.ip_address(addr)
+            if ip.is_private or ip.is_reserved or ip.is_loopback or ip.is_link_local:
+                logger.warning(f'SSRF blocked: {url} resolves to private IP {addr}')
+                return False
+        return True
+    except (ValueError, socket.gaierror, OSError) as exc:
+        logger.warning(f'SSRF check failed for {url}: {exc}')
+        return False
+
 
 # ---------------------------------------------------------------------------
 # Blueprint
@@ -367,6 +391,8 @@ def _action_status(job_id: str):
                         save_path = GENERATED_MUSIC_DIR / filename
 
                         if not save_path.exists():
+                            if not _is_safe_download_url(audio_url):
+                                continue
                             audio_resp = http_requests.get(audio_url, timeout=60, stream=True)
                             if audio_resp.status_code == 200:
                                 content_length = int(audio_resp.headers.get('Content-Length', 0))
@@ -507,6 +533,8 @@ def suno_callback():
                     save_path = GENERATED_MUSIC_DIR / filename
 
                     if audio_url and not save_path.exists():
+                        if not _is_safe_download_url(audio_url):
+                            continue
                         try:
                             audio_resp = http_requests.get(audio_url, timeout=60, stream=True)
                             if audio_resp.status_code == 200:

--- a/routes/transcripts.py
+++ b/routes/transcripts.py
@@ -15,6 +15,7 @@ import os
 import re
 import json
 from datetime import datetime
+from pathlib import Path
 from flask import Blueprint, jsonify, request
 
 transcripts_bp = Blueprint('transcripts', __name__)
@@ -110,14 +111,17 @@ def list_transcripts():
 
 @transcripts_bp.route('/api/transcripts/<date_dir>/<filename>', methods=['GET'])
 def get_transcript(date_dir, filename):
-    # Sanitize path components
-    if '..' in date_dir or '..' in filename:
+    # Resolve and verify path stays within TRANSCRIPTS_DIR
+    base = Path(TRANSCRIPTS_DIR).resolve()
+    try:
+        resolved = (base / date_dir / filename).resolve()
+    except (ValueError, OSError):
         return jsonify({'error': 'Invalid path'}), 400
-    filepath = os.path.join(TRANSCRIPTS_DIR, date_dir, filename)
-    if not os.path.isfile(filepath):
+    if base not in resolved.parents and resolved != base:
+        return jsonify({'error': 'Invalid path'}), 400
+    if not resolved.is_file():
         return jsonify({'error': 'Not found'}), 404
-    with open(filepath, 'r', encoding='utf-8') as f:
-        return f.read(), 200, {'Content-Type': 'text/plain; charset=utf-8'}
+    return resolved.read_text(encoding='utf-8'), 200, {'Content-Type': 'text/plain; charset=utf-8'}
 
 
 import logging as _transcript_logger

--- a/server.py
+++ b/server.py
@@ -915,6 +915,17 @@ def clawdbot_websocket(ws):
     then bridges messages bidirectionally — generating TTS audio for every
     assistant response before forwarding to the client.
     """
+    # --- Clerk auth check (uses same cookie/header as HTTP routes) ---
+    from services.auth import verify_clerk_token, get_token_from_request
+    token = get_token_from_request()
+    user_id = verify_clerk_token(token) if token else None
+    if not user_id:
+        logger.warning("WebSocket rejected — no valid Clerk token")
+        ws.send(json.dumps({"type": "error", "message": "Unauthorized"}))
+        ws.close()
+        return
+    logger.info(f"WebSocket authenticated: user_id={user_id}")
+
     gateway_url = os.getenv("CLAWDBOT_GATEWAY_URL", "ws://127.0.0.1:18791")
     auth_token = os.getenv("CLAWDBOT_AUTH_TOKEN")
 


### PR DESCRIPTION
## Summary
- **WebSocket Clerk auth** — `/ws/clawdbot` now verifies Clerk JWT before accepting connections. Rejects unauthorized users with proper error message.
- **Transcript path traversal fix** — Replaced weak `'..'` string check with `Path.resolve()` + parent directory validation (same pattern used in canvas/upload routes).
- **SSRF protection on Suno downloads** — Added `_is_safe_download_url()` helper that resolves hostnames and rejects private/reserved/loopback IPs before downloading audio from webhook callbacks. Applied to both download sites in suno.py.

## Files Changed
- `server.py` — Added Clerk auth check at top of WebSocket handler (+8 lines)
- `routes/transcripts.py` — Replaced path sanitization with resolve+parent check (+7/-4 lines)
- `routes/suno.py` — Added SSRF helper + applied to 2 download call sites (+20 lines)

## Test plan
- [ ] Verify voice UI still connects via WebSocket when logged in via Clerk
- [ ] Verify WebSocket rejects connection without valid Clerk token
- [ ] Verify transcript API still returns transcripts for valid date/filename
- [ ] Verify transcript API rejects path traversal attempts (`../etc/passwd`)
- [ ] Verify Suno song generation still downloads audio from suno API URLs
- [ ] Verify Suno download rejects URLs pointing to private IPs (10.x, 172.x, 127.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)