### PR TITLE
fix: empty response fallback chain + canvas error auto-injection

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -739,6 +739,11 @@ def _conversation_inner():
             context_parts.append('[Canvas CLOSED]')
         if ui_context.get('canvasMenuOpen'):
             context_parts.append('[Canvas menu visible to user]')
+        # Canvas JS errors — auto-injected from browser error buffer
+        canvas_errors = ui_context.get('canvasErrors', [])
+        if canvas_errors:
+            err_str = ' | '.join(canvas_errors)
+            context_parts.append(f'[Canvas JS Errors: {err_str}]')
 
         # Music state (server-side is authoritative)
         _srv_track = _music_state.get('current_track')
@@ -1109,7 +1114,7 @@ def _conversation_inner():
                             # Instead: yield {'type':'retrying'} to keep the
                             # client alive, then swap the event queue.
                             _is_empty = not full_response or not full_response.strip()
-                            if _is_empty and metrics.get('llm_inference_ms', 9999) < 500 \
+                            if _is_empty and metrics.get('llm_inference_ms', 9999) < 5000 \
                                     and not getattr(stream_response, '_retried', False):
                                 stream_response._retried = True
                                 logger.warning(
@@ -1352,29 +1357,55 @@ def _conversation_inner():
         except Exception as e:
             logger.error(f'Failed to call Clawdbot Gateway: {e}')
 
-    # ── FALLBACK: Z.AI direct (glm-4.5-flash, no tools) ──────────────────
+    # ── FALLBACK: Z.AI direct (Anthropic-compatible endpoint) ──────────────
     if not ai_response:
-        if metrics.get('profile') == 'gateway':
-            logger.warning('No text response from Gateway, falling back to Z.AI flash...')
-            metrics['fallback_used'] = 1
-        else:
-            logger.info('Using Z.AI flash direct (primary path)')
+        logger.warning('No text from Gateway — trying Z.AI direct fallback...')
+        metrics['fallback_used'] = 1
         t_flash_start = time.time()
-        # Lazy import to avoid circular dependency (server.py imports this blueprint)
         try:
-            import server as _server
-            ai_response = _server.get_zai_direct_response(message_with_context, session_id)
-        except Exception as e:
-            logger.error(f'Z.AI direct call failed: {e}')
-            ai_response = None
-        metrics['profile'] = 'flash-direct'
-        metrics['model'] = 'glm-4.5-flash'
+            import requests as _req
+            import os as _os
+            _zai_key = _os.getenv('ZAI_API_KEY', '')
+            if not _zai_key:
+                raise ValueError('ZAI_API_KEY not set')
+            _zai_resp = _req.post(
+                'https://api.z.ai/api/anthropic/v1/messages',
+                headers={
+                    'x-api-key': _zai_key,
+                    'anthropic-version': '2023-06-01',
+                    'content-type': 'application/json',
+                },
+                json={
+                    'model': 'glm-4.7',
+                    'max_tokens': 400,
+                    'messages': [{'role': 'user', 'content': user_message}],
+                },
+                timeout=20,
+            )
+            if _zai_resp.status_code == 200:
+                _zdata = _zai_resp.json()
+                _zcontent = _zdata.get('content', [])
+                if _zcontent and _zcontent[0].get('text'):
+                    ai_response = _zcontent[0]['text']
+                    metrics['profile'] = 'zai-direct'
+                    metrics['model'] = 'glm-4.7'
+                    logger.info(f'Z.AI direct fallback OK: {len(ai_response)} chars')
+            else:
+                logger.error(f'Z.AI direct fallback HTTP {_zai_resp.status_code}')
+        except Exception as _e:
+            logger.error(f'Z.AI direct fallback failed: {_e}')
         metrics['llm_inference_ms'] = int((time.time() - t_flash_start) * 1000)
 
-    # ── LAST RESORT ───────────────────────────────────────────────────────
+    # ── LAST RESORT: write restart flag + tell user ───────────────────────
     if not ai_response:
-        logger.warning('Both Gateway and Z.AI flash failed, using generic fallback')
-        ai_response = "Hmm, my brain glitched for a second there. Try that again?"
+        logger.warning('Both Gateway and Z.AI direct failed — writing restart flag')
+        try:
+            _flag = Path('/app/runtime/restart-openclaw.flag')
+            _flag.write_text(str(time.time()))
+            logger.info('restart-openclaw.flag written — host cron will restart container')
+        except Exception as _fe:
+            logger.warning(f'Could not write restart flag: {_fe}')
+        ai_response = "I lost my connection for a moment. I'm reconnecting now — please try again in a few seconds."
 
     # Clean text for TTS
     tts_text = clean_for_tts(ai_response)

--- a/src/app.js
+++ b/src/app.js
@@ -2668,6 +2668,12 @@ inject();
                     context.componentsOpen.push('thought-bubbles');
                 }
 
+                // Recent canvas JS errors (last 5, auto-cleared after send)
+                const _now = Date.now();
+                const _recentErrors = (window._canvasErrorBuffer || [])
+                    .filter(e => _now - e.ts < 30000)
+                    .map(e => `${e.error} (line ${e.line})`);
+                if (_recentErrors.length > 0) context.canvasErrors = _recentErrors;
                 return context;
             }
 
@@ -2961,6 +2967,7 @@ inject();
                 window.HaloSmokeFace?.setThinking(true);
 
                 ActionConsole.addEntry('chat', `Sent: "${text.substring(0, 80)}${text.length > 80 ? '...' : ''}"`);
+                window._canvasErrorBuffer = []; // clear after send
 
                 let messageToSend = text.trim();
 
@@ -5641,11 +5648,15 @@ inject();
                 });
 
                 // Canvas error bridge: catch JS errors from sandboxed canvas pages
+                window._canvasErrorBuffer = [];
                 window.addEventListener('message', (event) => {
                     if (!event.data || event.data.type !== 'canvas-error') return;
                     const { error, source, line, col } = event.data;
                     console.error(`[Canvas JS Error] ${error} at ${source}:${line}:${col}`);
                     ActionConsole.addEntry('error', `Canvas JS: ${error} (line ${line})`);
+                    // Buffer for auto-injection into next agent message
+                    window._canvasErrorBuffer.push({ error, line, col, ts: Date.now() });
+                    if (window._canvasErrorBuffer.length > 5) window._canvasErrorBuffer.shift();
                 });
 
                 // Auto-refresh polling: detect when agent edits the current canvas page


### PR DESCRIPTION
## Summary

- **Fix broken fallback chain** — `get_zai_direct_response()` was deleted from `server.py` months ago but still called in `conversation.py`, crashing silently on every empty gateway response and falling straight to "Sorry". Replaced with a real Z.AI direct call to the working `api.z.ai/api/anthropic/v1/messages` endpoint.
- **Widen retry threshold** — Empty-response retry was gated at `< 500ms`. Bad Z.AI session states often return empty in 1-3s, bypassing the retry entirely. Widened to `< 5000ms`.
- **Auto-restart on double-empty** — When both gateway and Z.AI direct fail, writes `restart-openclaw.flag` to `/app/runtime/` so a host-side cron can restart the openclaw container automatically. User hears "I'm reconnecting" instead of "Sorry".
- **Canvas error auto-injection** — Canvas JS errors from the iframe are now buffered in `window._canvasErrorBuffer` (max 5, 30s TTL) and automatically included as `canvasErrors` in `ui_context` on every message send. Agent sees errors without user copy-pasting from the Actions console.

## Test plan

- [ ] Trigger empty response (rapid interrupts) — verify Z.AI direct fallback responds instead of "Sorry"
- [ ] Trigger double-empty — verify `restart-openclaw.flag` appears in `/app/runtime/` and host cron restarts container
- [ ] Cause a canvas JS error — verify next message to agent includes `[Canvas JS Errors: ...]` in server logs
- [ ] Normal conversation — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)