### PR TITLE
feat: Pinokio one-click installer + VS Code dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "OpenVoiceUI Dev",
+  "dockerComposeFile": [
+    "../docker-compose.yml",
+    "docker-compose.devcontainer.yml"
+  ],
+  "service": "openvoiceui",
+  "workspaceFolder": "/app",
+  "shutdownAction": "stopCompose",
+  "forwardPorts": [5001, 18791],
+  "portsAttributes": {
+    "5001": { "label": "OpenVoiceUI", "onAutoForward": "openBrowser" },
+    "18791": { "label": "OpenClaw Gateway" }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.debugpy",
+        "ms-python.pylint",
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "ms-azuretools.vscode-docker",
+        "humao.rest-client"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "editor.formatOnSave": true,
+        "[python]": {
+          "editor.defaultFormatter": "ms-python.python"
+        }
+      }
+    }
+  },
+  "postCreateCommand": "pip install -r requirements.txt"
+}

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -1,0 +1,13 @@
+# Dev container override — bind-mounts source code for live editing
+services:
+  openvoiceui:
+    volumes:
+      - ..:/app:cached
+      - openvoiceui-runtime:/app/runtime
+    environment:
+      - FLASK_DEBUG=1
+      - FLASK_ENV=development
+    # Keep container alive for VS Code to attach to
+    command: sleep infinity
+    healthcheck:
+      disable: true

--- a/docker-compose.pinokio.yml
+++ b/docker-compose.pinokio.yml
@@ -1,0 +1,8 @@
+# Pinokio local install override
+# Swaps the openclaw-data named volume for a local directory so the
+# pre-configured openclaw.json (written by install.js) is picked up.
+services:
+  openclaw:
+    volumes:
+      - ./openclaw-data:/root/.openclaw
+      - canvas-pages:/root/.openclaw/workspace/canvas-pages

--- a/install.js
+++ b/install.js
@@ -1,0 +1,105 @@
+module.exports = {
+  run: [
+    // Step 1: Verify Docker is available
+    {
+      method: "shell.run",
+      params: {
+        message: "docker --version && docker compose version",
+      },
+    },
+
+    // Step 2: Collect API keys from user
+    {
+      method: "input",
+      params: {
+        title: "OpenVoiceUI Setup",
+        form: [
+          {
+            key: "GROQ_API_KEY",
+            title: "Groq API Key (required — Text-to-Speech)",
+            description: "Free tier available at console.groq.com. Used for Orpheus voice synthesis.",
+            placeholder: "gsk_...",
+            required: true,
+          },
+          {
+            key: "PORT",
+            title: "Port (optional)",
+            description: "Port to run OpenVoiceUI on. Default is 5001.",
+            placeholder: "5001",
+            required: false,
+          },
+        ],
+      },
+    },
+
+    // Step 3: Create openclaw-data dir and write local openclaw config (auth disabled for local use)
+    {
+      method: "shell.run",
+      params: {
+        message: `node -e "
+const fs = require('fs');
+fs.mkdirSync('openclaw-data', { recursive: true });
+const config = {
+  allowInsecureAuth: true,
+  dangerouslyDisableDeviceAuth: true,
+  thinkingDefault: 'off',
+  trustedProxies: ['127.0.0.1', '172.0.0.0/8', '10.0.0.0/8'],
+  timeoutSeconds: 120
+};
+fs.writeFileSync('openclaw-data/openclaw.json', JSON.stringify(config, null, 2));
+console.log('openclaw-data/openclaw.json created');
+"`,
+      },
+    },
+
+    // Step 4: Generate .env from .env.example with keys filled in
+    {
+      method: "shell.run",
+      params: {
+        message: `node -e "
+const fs = require('fs');
+const crypto = require('crypto');
+let env = fs.readFileSync('.env.example', 'utf8');
+const port = process.env.PORT || '5001';
+const token = crypto.randomBytes(32).toString('hex');
+const secret = crypto.randomBytes(32).toString('hex');
+env = env.replace(/^GROQ_API_KEY=.*/m, 'GROQ_API_KEY=' + process.env.GROQ_API_KEY);
+env = env.replace(/^SECRET_KEY=.*/m, 'SECRET_KEY=' + secret);
+env = env.replace(/^PORT=.*/m, 'PORT=' + port);
+env = env.replace(/^DOMAIN=.*/m, 'DOMAIN=localhost');
+env = env.replace(/^CLAWDBOT_AUTH_TOKEN=.*/m, 'CLAWDBOT_AUTH_TOKEN=' + token);
+fs.writeFileSync('.env', env);
+console.log('.env created (port=' + port + ')');
+"`,
+        env: {
+          GROQ_API_KEY: "{{input.GROQ_API_KEY}}",
+          PORT: "{{input.PORT||5001}}",
+        },
+      },
+    },
+
+    // Step 5: Build Docker images (this takes a few minutes on first run)
+    {
+      method: "shell.run",
+      params: {
+        message: "docker compose -f docker-compose.yml -f docker-compose.pinokio.yml build",
+      },
+    },
+
+    // Step 6: Mark as installed and store port
+    {
+      method: "local.set",
+      params: {
+        installed: true,
+        PORT: "{{input.PORT||5001}}",
+      },
+    },
+
+    {
+      method: "notify",
+      params: {
+        html: "OpenVoiceUI installed! Click <b>▶ Start</b> to launch.<br><br>On first start you will be guided to configure your AI provider (Anthropic, OpenAI, Ollama, etc.) through the OpenClaw setup wizard.",
+      },
+    },
+  ],
+}

--- a/pinokio.js
+++ b/pinokio.js
@@ -1,0 +1,33 @@
+module.exports = {
+  version: "2.5",
+  title: "OpenVoiceUI",
+  description: "AI Voice Assistant — voice conversations, animated face, canvas, music generation, and more.",
+  icon: "icon.png",
+  menu: [
+    {
+      when: "!local.installed",
+      html: "Install",
+      href: "install.js",
+    },
+    {
+      when: "local.installed && !local.running",
+      html: "▶ Start",
+      href: "start.js",
+    },
+    {
+      when: "local.running",
+      html: "Open",
+      href: "http://localhost:{{local.PORT||5001}}",
+    },
+    {
+      when: "local.running",
+      html: "⏹ Stop",
+      href: "stop.js",
+    },
+    {
+      when: "local.installed",
+      html: "Update",
+      href: "update.js",
+    },
+  ],
+}

--- a/start.js
+++ b/start.js
@@ -1,0 +1,57 @@
+module.exports = {
+  run: [
+    // Start all containers
+    {
+      method: "shell.run",
+      params: {
+        message: "docker compose -f docker-compose.yml -f docker-compose.pinokio.yml up -d",
+      },
+    },
+
+    // Wait for OpenVoiceUI to be ready
+    {
+      method: "shell.run",
+      params: {
+        message: `node -e "
+const http = require('http');
+const port = process.env.PORT || 5001;
+let attempts = 0;
+const check = () => {
+  attempts++;
+  http.get('http://localhost:' + port + '/health/ready', (r) => {
+    if (r.statusCode < 400) {
+      console.log('Ready after ' + attempts + ' attempts');
+    } else {
+      if (attempts < 30) setTimeout(check, 2000);
+      else { console.log('Timeout — opening anyway'); }
+    }
+  }).on('error', () => {
+    if (attempts < 30) setTimeout(check, 2000);
+    else { console.log('Timeout — opening anyway'); }
+  });
+};
+check();
+"`,
+        env: {
+          PORT: "{{local.PORT||5001}}",
+        },
+      },
+    },
+
+    // Mark as running
+    {
+      method: "local.set",
+      params: {
+        running: true,
+      },
+    },
+
+    // Open OpenVoiceUI in browser
+    {
+      method: "browser.open",
+      params: {
+        url: "http://localhost:{{local.PORT||5001}}",
+      },
+    },
+  ],
+}

--- a/stop.js
+++ b/stop.js
@@ -1,0 +1,16 @@
+module.exports = {
+  run: [
+    {
+      method: "shell.run",
+      params: {
+        message: "docker compose -f docker-compose.yml -f docker-compose.pinokio.yml down",
+      },
+    },
+    {
+      method: "local.set",
+      params: {
+        running: false,
+      },
+    },
+  ],
+}

--- a/update.js
+++ b/update.js
@@ -1,0 +1,49 @@
+module.exports = {
+  run: [
+    // Stop if running
+    {
+      method: "shell.run",
+      params: {
+        message: "docker compose -f docker-compose.yml -f docker-compose.pinokio.yml down",
+      },
+    },
+
+    // Pull latest code
+    {
+      method: "shell.run",
+      params: {
+        message: "git pull",
+      },
+    },
+
+    // Rebuild images
+    {
+      method: "shell.run",
+      params: {
+        message: "docker compose -f docker-compose.yml -f docker-compose.pinokio.yml build",
+      },
+    },
+
+    // Start back up
+    {
+      method: "shell.run",
+      params: {
+        message: "docker compose -f docker-compose.yml -f docker-compose.pinokio.yml up -d",
+      },
+    },
+
+    {
+      method: "local.set",
+      params: {
+        running: true,
+      },
+    },
+
+    {
+      method: "browser.open",
+      params: {
+        url: "http://localhost:{{local.PORT||5001}}",
+      },
+    },
+  ],
+}


### PR DESCRIPTION
## Summary

- Adds **Pinokio** support so non-technical users can install and run the full stack (OpenVoiceUI + OpenClaw + Supertonic TTS) with one click from the Pinokio desktop app
- Adds **VS Code dev container** for developers — full stack spins up automatically with source bind-mounted and hot reload
- Zero code changes to the app itself — Pinokio scripts are a launcher layer on top of the existing docker-compose stack

## How it works (end user)

1. Install [Pinokio](https://pinokio.computer) desktop app
2. Paste the GitHub repo URL into Pinokio
3. Click **Install** — enter Groq API key (for TTS), everything else is auto-configured
4. Click **▶ Start** → browser opens to localhost:5001
5. First run: OpenClaw wizard at localhost:18791 to pick LLM provider (Anthropic, OpenAI, Ollama, etc.)

## Files added

| File | Purpose |
|------|---------|
| pinokio.js | App manifest — state-aware menu buttons |
| install.js | Prompts for keys, generates .env + openclaw-data/openclaw.json, builds images |
| start.js | docker compose up, health poll, open browser |
| stop.js | docker compose down |
| update.js | git pull → rebuild → restart |
| docker-compose.pinokio.yml | Override: local ./openclaw-data/ dir instead of named volume |
| .devcontainer/devcontainer.json | VS Code dev container config |
| .devcontainer/docker-compose.devcontainer.yml | Dev override: source bind-mount, FLASK_DEBUG=1 |

## Design notes

- OpenClaw auth is disabled for local single-user installs (allowInsecureAuth + dangerouslyDisableDeviceAuth) — no manual token copying required
- CLAWDBOT_AUTH_TOKEN and SECRET_KEY are auto-generated random values at install time
- The docker-compose.pinokio.yml override swaps the named openclaw-data volume for a local directory so the pre-seeded config is picked up on first boot