### PR TITLE
fix: Pinokio install marker and Docker daemon check

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,20 +1,19 @@
 module.exports = {
   run: [
-    // Step 1: Verify Docker is available and running
+    // Step 1: Verify Docker daemon is actually running (docker info fails if Desktop is not started)
     {
       method: "shell.run",
       params: {
-        message: "docker --version && docker compose version",
-        on: [{
-          event: "/error|not found|command not found/i",
-          done: true,
-          run: {
-            method: "notify",
-            params: {
-              html: "Docker is not installed or not running. Please install <a href='https://www.docker.com/products/docker-desktop/'>Docker Desktop</a> and start it, then try again."
-            }
-          }
-        }]
+        message: `node -e "
+const { execSync } = require('child_process');
+try {
+  execSync('docker info', { stdio: 'ignore' });
+  console.log('Docker is running');
+} catch(e) {
+  console.error('ERROR: Docker Desktop is not running. Open Docker Desktop, wait for it to fully start, then click Reinstall.');
+  process.exit(1);
+}
+"`,
       },
     },
 

--- a/pinokio.js
+++ b/pinokio.js
@@ -4,7 +4,7 @@ module.exports = {
   description: "AI Voice Assistant — voice conversations, animated face, canvas, music generation, and more.",
   icon: "icon.png",
   menu: async (kernel, info) => {
-    let installed = info.exists("env")
+    let installed = info.exists("openclaw-data")
     let running = {
       install: info.running("install.js"),
       start: info.running("start.js"),


### PR DESCRIPTION
- `pinokio.js`: change `info.exists("env")` → `info.exists("openclaw-data")` so Pinokio correctly detects a completed Docker-based install and shows Start/Update instead of Install
- `install.js`: replace `docker --version` check (which passes even when Docker Desktop is closed) with `docker info` via node.js, which actually connects to the daemon and exits with code 1 to halt the script cleanly