### PR TITLE
feat: suno proactive agent notify + canvas custom icons

### DIFF
--- a/default-pages/desktop.html
+++ b/default-pages/desktop.html
@@ -945,6 +945,7 @@ async function fetchManifest(forceSync) {
         newPages[pageId] = {
           name: mp.display_name || pageId,
           cat: mp.category || 'uncategorized',
+          iconUrl: mp.icon || null,
         };
       });
     }
@@ -1074,6 +1075,7 @@ function rebuildDesktopItems() {
       id: 'page-' + pageId,
       name: PAGES[pageId].name,
       icon: getPageIconType(PAGES[pageId].cat, pageId, PAGES[pageId].name),
+      iconUrl: PAGES[pageId].iconUrl || null,
       action: 'openPage',
       pageId: pageId,
     });
@@ -1119,7 +1121,10 @@ function buildDesktopIcons() {
       ? (recycleBin.length > 0 ? 'recycle-full' : 'recycle')
       : item.icon;
 
-    el.innerHTML = `<div class="icon-img">${getIcon(recycleIcon)}</div><div class="icon-label">${getIconName(item)}</div>`;
+    const iconHtml = item.iconUrl
+      ? `<img src="${item.iconUrl}" style="width:100%;height:100%;object-fit:contain;">`
+      : getIcon(recycleIcon);
+    el.innerHTML = `<div class="icon-img">${iconHtml}</div><div class="icon-label">${getIconName(item)}</div>`;
     el.addEventListener('mousedown', (e) => onIconMouseDown(e, item));
     el.addEventListener('touchstart', (e) => onIconTouchStart(e, item), {passive:false});
     el.addEventListener('dblclick', (e) => { e.stopPropagation(); onIconDblClick(item); });
@@ -2192,8 +2197,11 @@ function buildCustomFolderGrid(folderId) {
   pages.forEach(id => {
     const p = PAGES[id];
     if (!p) return;
+    const eiIconHtml = p.iconUrl
+      ? `<img src="${p.iconUrl}" style="width:100%;height:100%;object-fit:contain;">`
+      : getIcon(getPageIconType(p.cat, id, p.name));
     html += `<div class="explorer-item" ondblclick="openCanvasPage('${id}')" oncontextmenu="event.preventDefault();event.stopPropagation();showFolderItemMenu(event,'${id}','${folderId}')">
-      <div class="ei-icon">${getIcon(getPageIconType(p.cat, id, p.name))}</div>
+      <div class="ei-icon">${eiIconHtml}</div>
       <div class="ei-name">${p.name}</div>
     </div>`;
   });
@@ -2305,8 +2313,11 @@ function buildExplorerGrid(catId) {
   let html = '<div class="explorer-grid">';
   pages.forEach(([id, p]) => {
     const iconType = getPageIconType(p.cat, id, p.name);
+    const catIconHtml = p.iconUrl
+      ? `<img src="${p.iconUrl}" style="width:100%;height:100%;object-fit:contain;">`
+      : getIcon(iconType);
     html += `<div class="explorer-item" ondblclick="openCanvasPage('${id}')" oncontextmenu="event.preventDefault();event.stopPropagation();showExplorerItemMenu(event,'${id}')">
-      <div class="ei-icon">${getIcon(iconType)}</div>
+      <div class="ei-icon">${catIconHtml}</div>
       <div class="ei-name">${p.name}</div>
     </div>`;
   });

--- a/routes/canvas.py
+++ b/routes/canvas.py
@@ -1013,7 +1013,7 @@ def handle_page_metadata(page_id):
             except (ValueError, TypeError):
                 pass  # malformed date — allow through
 
-    for field in ['display_name', 'description', 'category', 'tags', 'starred', 'is_public', 'is_locked']:
+    for field in ['display_name', 'description', 'category', 'tags', 'starred', 'is_public', 'is_locked', 'icon']:
         if field in data:
             old_category = page.get('category')
             page[field] = data[field]

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -833,6 +833,16 @@ def _conversation_inner():
         except Exception:
             pass
 
+        # Recently completed Suno generations — agent gets notified on next turn
+        try:
+            from routes.suno import completed_songs_queue
+            if completed_songs_queue:
+                _pending = completed_songs_queue[-3:]
+                _titles = [s.get('title', 'Unknown Track') for s in _pending]
+                context_parts.append(f'[Suno just finished: {", ".join(repr(t) for t in _titles)} — now ready in Generated playlist]')
+        except Exception:
+            pass
+
         # Available canvas pages (agent needs IDs for [CANVAS:page-id])
         try:
             from routes.canvas import load_canvas_manifest
@@ -894,6 +904,12 @@ def _conversation_inner():
                 'A new voice session has just started. Give a brief, friendly one-sentence greeting. '
                 'Do NOT address anyone by name — no face has been recognized and you do not know who is speaking.'
             )
+    elif user_message.startswith('__suno_complete__:'):
+        _song_title = user_message[len('__suno_complete__:'):].strip() or 'your track'
+        _gateway_message = (
+            f'The Suno song "{_song_title}" just finished generating and is now ready in the music player. '
+            f'Let the user know in one brief, friendly sentence and offer to play it for them.'
+        )
     else:
         _gateway_message = user_message
     message_with_context = context_prefix + _gateway_message if context_prefix else _gateway_message

--- a/src/app.js
+++ b/src/app.js
@@ -1431,8 +1431,9 @@ inject();
                 setTimeout(() => this._hideStatus(), 8000);
                 // Refresh music player so the agent and UI see the new track immediately
                 window.musicPlayer?.loadMetadata();
-                // Speak the completion via TTS
-                this._speakCompletion(title);
+                // Notify the agent so it can proactively respond
+                ActionConsole?.addEntry('system', `🎵 Song ready: "${title}"`);
+                this._notifyAgent(title);
             },
 
             async _speakCompletion(title) {
@@ -1450,6 +1451,46 @@ inject();
                     audio.play().catch(() => {});
                 } catch (e) {
                     console.warn('[Suno] TTS completion error:', e);
+                }
+            },
+
+            async _notifyAgent(title) {
+                try {
+                    const provider = window.voiceAgent?.selectedProvider || 'groq';
+                    const voice = window.voiceAgent?.currentVoice || 'autumn';
+                    const sessionId = window._activeSessionId || `suno-${Date.now()}`;
+
+                    const resp = await fetch(`${CONFIG.serverUrl}/api/conversation`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            message: `__suno_complete__:${title}`,
+                            tts_provider: provider,
+                            voice: voice,
+                            session_id: sessionId,
+                            ui_context: {},
+                        }),
+                    });
+                    if (!resp.ok) throw new Error('notify failed');
+                    const data = await resp.json();
+
+                    if (data.response) {
+                        TranscriptPanel?.addMessage('assistant', data.response);
+                        ActionConsole?.addEntry('system', `🎵 Agent: ${data.response.substring(0, 80)}`);
+                    }
+                    if (data.audio) {
+                        const binary = atob(data.audio);
+                        const bytes = new Uint8Array(binary.length);
+                        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+                        const blob = new Blob([bytes], { type: 'audio/mpeg' });
+                        const url = URL.createObjectURL(blob);
+                        const audio = new Audio(url);
+                        audio.onended = () => URL.revokeObjectURL(url);
+                        audio.play().catch(() => {});
+                    }
+                } catch (e) {
+                    console.warn('[Suno] Agent notify failed, falling back to TTS:', e);
+                    this._speakCompletion(title);
                 }
             },
         };
@@ -3093,6 +3134,7 @@ inject();
                 this._sessionGreeted = false;  // Reset so every new call gets a greeting
                 // Generate new session ID for this call
                 this.sessionId = `session_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+                window._activeSessionId = this.sessionId;
                 console.log('New conversation session:', this.sessionId);
 
                 // Show thinking state immediately so user sees feedback before any async work
@@ -3454,16 +3496,12 @@ inject();
                             ActionConsole.addEntry('system', 'Music: next track');
                             AgentActivityChip.handleTag('music_next');
                             window.musicPlayer?.next();
-                        }
-                        // Check for [SUNO_GENERATE:prompt]
-                        const sunoMatch = text.match(/\[SUNO_GENERATE:([^\]]+)\]/i);
-                        if (sunoMatch && !canvasCommandsProcessed.has('SUNO_GENERATE')) {
-                            canvasCommandsProcessed.add('SUNO_GENERATE');
-                            const sunoPrompt = sunoMatch[1].trim();
-                            ActionConsole.addEntry('system', `Suno: generating "${sunoPrompt.substring(0, 60)}${sunoPrompt.length > 60 ? '...' : ''}"`);
-                            AgentActivityChip.handleTag('suno', sunoPrompt);
+                        [...text.matchAll(/\[SUNO_GENERATE:([^\]]+)\]/gi)].forEach(m => {
+                            const sunoPrompt = m[1].trim();
+                            ActionConsole?.addEntry('system', `🎵 Suno: generating "${sunoPrompt.substring(0, 60)}${sunoPrompt.length > 60 ? '...' : ''}"`);
+                            AgentActivityChip?.handleTag('suno', sunoPrompt);
                             window.sunoModule?.generate(sunoPrompt);
-                        }
+                        });
                         // Check for [SPOTIFY:track name|artist] — switches player to Spotify mode
                         const spotifyMatch = text.match(/\[SPOTIFY:([^|\]]+)(?:\|([^\]]+))?\]/i);
                         if (spotifyMatch && !canvasCommandsProcessed.has('SPOTIFY')) {
@@ -4624,6 +4662,7 @@ inject();
 
                 // Generate new session ID for this call
                 this.sessionId = `session_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+                window._activeSessionId = this.sessionId;
                 console.log('New conversation session:', this.sessionId);
 
                 // Pause wake word detector during conversation
@@ -4939,13 +4978,10 @@ inject();
                 }
                 // [MUSIC_NEXT]
                 if (/\[MUSIC_NEXT\]/i.test(text)) {
-                    window.musicPlayer?.next();
-                }
-                // [SUNO_GENERATE:prompt]
-                const sunoMatch = text.match(/\[SUNO_GENERATE:([^\]]+)\]/i);
-                if (sunoMatch) {
-                    window.sunoModule?.generate(sunoMatch[1].trim());
-                }
+                // [SUNO_GENERATE:prompt] — may appear multiple times
+                [...text.matchAll(/\[SUNO_GENERATE:([^\]]+)\]/gi)].forEach(m => {
+                    window.sunoModule?.generate(m[1].trim());
+                });
                 // [SPOTIFY:track|artist]
                 const spotifyMatch = text.match(/\[SPOTIFY:([^|\]]+)(?:\|([^\]]+))?\]/i);
                 if (spotifyMatch) {


### PR DESCRIPTION
## Summary

- **Suno proactive completion notify** — when a song finishes generating, the agent speaks naturally ("Hey, your song is done! Want me to play it for you?") instead of a canned TTS clip. Implemented via `_notifyAgent()` posting `__suno_complete__:Title` back through `/api/conversation`, which routes it to the gateway with a focused prompt.
- **Session ID tracking** — `window._activeSessionId` is now set whenever a voice session starts (both ClawdbotMode and VoiceConversation), so the notify POST uses the correct session.
- **ActionConsole entries** for song generation start and song ready events.
- **`[SUNO_GENERATE:]` matchAll fix** — all tags in a response now fire (was blocked after the first by dedup set).
- **Canvas custom icons** — `PATCH /api/canvas/manifest/page/<id>` now accepts `icon` field; `desktop.html` renders custom image URLs on desktop icons and in folder/explorer views instead of generic type icons.
- **Suno completion context** — `completed_songs_queue` injected into agent context on each conversation turn so the agent knows what just finished.