### PR TITLE
fix: start.js port from .env, not kernel.port()

### DIFF
--- a/start.js
+++ b/start.js
@@ -1,53 +1,57 @@
-module.exports = async (kernel) => {
-  let port = await kernel.port(5001)
-  return {
-    daemon: true,
-    run: [
-      // Start all containers
-      {
-        method: "shell.run",
-        params: {
-          message: `docker compose -f docker-compose.yml -f docker-compose.pinokio.yml up -d`,
-        },
+module.exports = {
+  daemon: true,
+  run: [
+    // Start all containers
+    {
+      method: "shell.run",
+      params: {
+        message: "docker compose -f docker-compose.yml -f docker-compose.pinokio.yml up -d",
       },
+    },
 
-      // Wait for OpenVoiceUI to be ready (polls /health/ready)
-      {
-        method: "shell.run",
-        params: {
-          message: `node -e "
+    // Wait for OpenVoiceUI to be ready (reads port from .env, polls /health/ready)
+    {
+      method: "shell.run",
+      params: {
+        message: `node -e "
 const http = require('http');
-const port = ${port};
+const fs = require('fs');
+let port = 5001;
+try {
+  const env = fs.readFileSync('.env', 'utf8');
+  const m = env.match(/^PORT=(\\d+)/m);
+  if (m) port = parseInt(m[1]);
+} catch(e) {}
+console.log('Waiting for OpenVoiceUI on port ' + port + '...');
 let attempts = 0;
 const check = () => {
   attempts++;
   const req = http.get('http://localhost:' + port + '/health/ready', (r) => {
     if (r.statusCode < 400) {
-      console.log('Ready on port ' + port + ' after ' + attempts + ' attempts');
+      console.log('READY url=http://localhost:' + port);
       process.exit(0);
     } else {
       if (attempts < 60) setTimeout(check, 3000);
-      else { console.log('Timed out waiting — check docker logs'); process.exit(0); }
+      else { console.log('Timed out — check docker logs'); process.exit(0); }
     }
   });
   req.on('error', () => {
     if (attempts < 60) setTimeout(check, 3000);
-    else { console.log('Timed out waiting — check docker logs'); process.exit(0); }
+    else { console.log('Timed out — check docker logs'); process.exit(0); }
   });
   req.end();
 };
 check();
 "`,
-        },
+        on: [{
+          event: "/READY url=(.+)/",
+          done: true,
+          run: {
+            method: "local.set",
+            params: { url: "{{event.matches.[0].[1]}}" }
+          }
+        }]
       },
-
-      // Store URL for the Open button in the menu
-      {
-        method: "local.set",
-        params: {
-          url: `http://localhost:${port}`,
-        },
-      },
-    ],
-  }
+    },
+  ],
 }


### PR DESCRIPTION
`kernel.port(5001)` returns `true` in Pinokio v3.7 instead of the port number, causing the health check URL to become `http://localhost:true/health/ready` and crash with `ERR_INVALID_URL`.

Fix: read PORT from the `.env` file written during install. Falls back to 5001 if not found. Also captures the URL via a regex `on` event pattern for the Open button rather than a separate `local.set` step.