### PR TITLE
fix: restore MUSIC_NEXT closing braces + Pinokio start sentinel fix

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3496,6 +3496,7 @@ inject();
                             ActionConsole.addEntry('system', 'Music: next track');
                             AgentActivityChip.handleTag('music_next');
                             window.musicPlayer?.next();
+                        }
                         [...text.matchAll(/\[SUNO_GENERATE:([^\]]+)\]/gi)].forEach(m => {
                             const sunoPrompt = m[1].trim();
                             ActionConsole?.addEntry('system', `🎵 Suno: generating "${sunoPrompt.substring(0, 60)}${sunoPrompt.length > 60 ? '...' : ''}"`);
@@ -4978,6 +4979,8 @@ inject();
                 }
                 // [MUSIC_NEXT]
                 if (/\[MUSIC_NEXT\]/i.test(text)) {
+                    window.musicPlayer?.next();
+                }
                 // [SUNO_GENERATE:prompt] — may appear multiple times
                 [...text.matchAll(/\[SUNO_GENERATE:([^\]]+)\]/gi)].forEach(m => {
                     window.sunoModule?.generate(m[1].trim());


### PR DESCRIPTION
## Summary

- **Black screen fix**: The suno matchAll patch script cut too far back into the `[MUSIC_NEXT]` if-block in both streaming and non-streaming paths, removing closing `}` braces. This caused a JS parse error that broke the entire page (black screen) for all clients. Restored the missing braces.
- **Pinokio start fix**: Changed sentinel from `READY url=` to `OVU_OPEN=` to prevent false match against the node script source text. Increased health poll timeout from 3 min to 10 min for first launch (Supertonic downloads its model at first boot).