### PR TITLE
fix: openclaw config schema for v2026.3.2 + brace fixes + Pinokio start

### DIFF
--- a/install.js
+++ b/install.js
@@ -50,11 +50,16 @@ try {
 const fs = require('fs');
 fs.mkdirSync('openclaw-data', { recursive: true });
 const config = {
-  allowInsecureAuth: true,
-  dangerouslyDisableDeviceAuth: true,
-  thinkingDefault: 'off',
   trustedProxies: ['127.0.0.1', '172.0.0.0/8', '10.0.0.0/8'],
-  timeoutSeconds: 120
+  controlUi: {
+    allowInsecureAuth: true,
+    dangerouslyDisableDeviceAuth: true,
+  },
+  agents: {
+    defaults: {
+      thinkingDefault: 'off',
+    },
+  },
 };
 fs.writeFileSync('openclaw-data/openclaw.json', JSON.stringify(config, null, 2));
 console.log('openclaw-data/openclaw.json created');


### PR DESCRIPTION
## Summary

- **openclaw config schema fix**: Keys `allowInsecureAuth` and `dangerouslyDisableDeviceAuth` moved under `controlUi` object, `thinkingDefault` moved under `agents.defaults` — these were at root level which is invalid in v2026.3.2. `timeoutSeconds` removed (not a valid gateway config key).
- **Black screen fix**: Restored missing closing `}` braces in `[MUSIC_NEXT]` if-blocks in both streaming and non-streaming paths after the matchAll patch cut too far.
- **Pinokio start health check**: Changed sentinel to `OVU_OPEN=` to prevent false match against command source text. Increased timeout to 10 min for first launch.