### PR TITLE
Pinokio start fix, canvas auth, PTT mute, icon gen, fallback messages

### DIFF
--- a/start.js
+++ b/start.js
@@ -7,7 +7,7 @@ module.exports = {
       params: {
         message: "docker compose -f docker-compose.yml -f docker-compose.pinokio.yml up",
         on: [{
-          event: "/Listening on|Running on|ready|Uvicorn running|started server/i",
+          event: "/Listening on.*\\d+|Running on http|Uvicorn running on/i",
           done: true,
         }],
       },


### PR DESCRIPTION
## Summary
- **Pinokio start.js** — event regex matched supertonic's "Started server process" before TTS model was loaded, showing Open button too early. Fixed to only match actual readiness messages with addresses/ports.
- **Pinokio install** — Docker check extracted to `check-docker.js` with Windows PATH discovery and clear error messages. Fixes `{{.Server.Version}}` template collision.
- **Canvas auth** — skip auth for non-HTML assets (images, icons, CSS) blocked by `CANVAS_REQUIRE_AUTH`.
- **PTT mute clearing** — clear stale TTS mute on PTT activate across all STT providers.
- **WebSpeechSTT** — PTT release waits for Chrome's async isFinal event (400ms grace).
- **Icon gen** — upgrade to gemini-2.5-flash-image, drop deprecated imageDimension.
- **Fallback messages** — soften from "sorry/glitched" to "One moment, still working."