### PR TITLE
fix: Pinokio install + March dev rollup

### DIFF
--- a/deploy/supertonic/Dockerfile
+++ b/deploy/supertonic/Dockerfile
@@ -6,14 +6,16 @@ RUN apt-get update \
 
 RUN pip install --no-cache-dir supertonic==1.1.2 fastapi uvicorn soundfile numpy
 
-# Pre-download models so they're baked into the image
-RUN python3 -c "from supertonic import TTS; tts = TTS(auto_download=True)"
-
 RUN useradd -r -m appuser
-USER appuser
 
 WORKDIR /app
 COPY server.py .
+RUN chown -R appuser:appuser /app
+
+USER appuser
+
+# Pre-download models as appuser so the cache path matches runtime
+RUN python3 -c "from supertonic import TTS; tts = TTS(auto_download=True)"
 
 EXPOSE 8765
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ services:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8765/health')"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 30s
+      retries: 5
+      start_period: 120s
 
   openvoiceui:
     build: .

--- a/install.js
+++ b/install.js
@@ -50,10 +50,19 @@ module.exports = {
             mode: "local",
             port: 18791,
             bind: "lan",
+            auth: {
+              token: "pinokio-local-token",
+            },
             trustedProxies: ["127.0.0.1", "172.16.0.0/12", "10.0.0.0/8"],
             controlUi: {
               allowInsecureAuth: true,
               dangerouslyDisableDeviceAuth: true,
+              allowedOrigins: [
+                "http://localhost:18791",
+                "http://127.0.0.1:18791",
+                "http://localhost:5001",
+                "http://127.0.0.1:5001",
+              ],
             },
           },
           agents: {
@@ -106,7 +115,7 @@ module.exports = {
     {
       method: "notify",
       params: {
-        html: "OpenVoiceUI installed! Click <b>Start</b> to launch.<br><br>On first start, open <code>http://localhost:18791</code> to configure your AI provider through the OpenClaw setup wizard.",
+        html: "OpenVoiceUI installed! Click <b>Start</b> to launch.<br><br>The app opens at <code>http://localhost:5001</code>.<br>To configure your AI provider, open <code>http://localhost:18791</code> and paste the gateway token: <code>pinokio-local-token</code>",
       },
     },
   ],

--- a/start.js
+++ b/start.js
@@ -7,7 +7,8 @@ module.exports = {
       params: {
         message: "docker compose -f docker-compose.yml -f docker-compose.pinokio.yml up",
         on: [{
-          event: "/Listening on.*\\d+|Running on http|Uvicorn running on/i",
+          // Match OpenVoiceUI's startup message (not OpenClaw's earlier "listening on ws://")
+          event: "/OpenVoiceUI starting on port/i",
           done: true,
         }],
       },


### PR DESCRIPTION
## Summary
- **Pinokio install fixes**: supertonic model cache built as wrong user (re-downloaded every start), gateway auth token mismatch (`token_missing` rejection), healthcheck timeout too short, start.js early-match on OpenClaw instead of OpenVoiceUI
- **Core default pages**: desktop, file-explorer, ai-image-creator, bulk-image-uploader, style-guide shipped as repo defaults
- **Canvas auth token bridge**: parent pushes fresh Clerk JWT to iframe via postMessage
- **OpenClaw compat layer**: protocol abstraction for upgrade resilience across openclaw versions
- **Stop button fix**: mutes TTS audio instead of killing session
- **VS Code dev container**: devcontainer.json + compose override for local dev
- **Misc**: S&S Activewear proxy removed (client-specific), game pages removed from defaults, icon gen route, workspace API, onboarding route, Deepgram/Groq STT providers