### PR TITLE
feat: all OpenClaw provider API keys in Pinokio installer

### DIFF
--- a/install.js
+++ b/install.js
@@ -67,6 +67,13 @@ module.exports = {
             required: false,
           },
           {
+            key: "CEREBRAS_API_KEY",
+            title: "Cerebras API Key",
+            description: "cloud.cerebras.ai",
+            placeholder: "",
+            required: false,
+          },
+          {
             key: "TOGETHER_API_KEY",
             title: "Together AI API Key",
             description: "api.together.xyz/settings/api-keys",
@@ -274,6 +281,7 @@ module.exports = {
           "MISTRAL_API_KEY={{input.MISTRAL_API_KEY}}",
           "XAI_API_KEY={{input.XAI_API_KEY}}",
           "ZAI_API_KEY={{input.ZAI_API_KEY}}",
+          "CEREBRAS_API_KEY={{input.CEREBRAS_API_KEY}}",
           "TOGETHER_API_KEY={{input.TOGETHER_API_KEY}}",
           "HF_TOKEN={{input.HF_TOKEN}}",
           "MOONSHOT_API_KEY={{input.MOONSHOT_API_KEY}}",


### PR DESCRIPTION
## Summary
- Pinokio install form now includes all 25 OpenClaw provider API keys + Groq for TTS
- Anthropic, OpenAI, Gemini, OpenRouter, Mistral, xAI, Z.AI, Cerebras, Together, HuggingFace, Moonshot, Kimi, MiniMax, Qianfan, Alibaba ModelStudio, Xiaomi, Volcano Engine, BytePlus, Synthetic, Venice, OpenCode, Kilocode, Vercel AI Gateway, Cloudflare AI Gateway, LiteLLM
- All keys written to .env and passed to openclaw container