### PR TITLE
fix: gateway auth token + full provider keys for Pinokio

### DIFF
--- a/docker-compose.pinokio.yml
+++ b/docker-compose.pinokio.yml
@@ -1,7 +1,6 @@
 # Pinokio local install override
-# Swaps the openclaw-data named volume for a local directory so the
-# pre-configured openclaw.json (written by install.js) is picked up.
-# Also injects .env so openclaw gets API keys (ANTHROPIC_API_KEY, etc.)
+# - Swaps openclaw-data volume for local dir (pre-configured openclaw.json)
+# - Injects .env into both containers so API keys + auth token are available
 services:
   openclaw:
     env_file:
@@ -9,3 +8,6 @@ services:
     volumes:
       - ./openclaw-data:/root/.openclaw
       - canvas-pages:/root/.openclaw/workspace/canvas-pages
+  openvoiceui:
+    environment:
+      - CLAWDBOT_AUTH_TOKEN=pinokio-local-token


### PR DESCRIPTION
## Summary
- Fix: pass CLAWDBOT_AUTH_TOKEN directly to openvoiceui container in Pinokio override — fixes "Gateway 'openclaw' is not configured" error
- All 25 OpenClaw provider API keys in install form + Groq for TTS