### PR TITLE
fix: pre-pair device identity + simplified input persistence

### DIFF
--- a/install.js
+++ b/install.js
@@ -229,40 +229,20 @@ module.exports = {
       },
     },
 
-    // Step 3: Save input values to JSON file using json.set
-    // Pinokio {{input.*}} templates don't resolve in fs.write or shell.run env
-    // on some platforms. json.set is a different code path that handles them.
-    // We save ALL keys to a JSON file, then setup-config.js reads it.
-    { method: "json.set", params: { path: "pinokio-input.json", key: "PORT", value: "{{input.PORT||5001}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "GROQ_API_KEY", value: "{{input.GROQ_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "DEEPGRAM_API_KEY", value: "{{input.DEEPGRAM_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "ANTHROPIC_API_KEY", value: "{{input.ANTHROPIC_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "ZAI_API_KEY", value: "{{input.ZAI_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "OPENAI_API_KEY", value: "{{input.OPENAI_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "GEMINI_API_KEY", value: "{{input.GEMINI_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "OPENROUTER_API_KEY", value: "{{input.OPENROUTER_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "MISTRAL_API_KEY", value: "{{input.MISTRAL_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "XAI_API_KEY", value: "{{input.XAI_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "CEREBRAS_API_KEY", value: "{{input.CEREBRAS_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "TOGETHER_API_KEY", value: "{{input.TOGETHER_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "HF_TOKEN", value: "{{input.HF_TOKEN}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "MOONSHOT_API_KEY", value: "{{input.MOONSHOT_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "KIMI_API_KEY", value: "{{input.KIMI_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "MINIMAX_API_KEY", value: "{{input.MINIMAX_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "QIANFAN_API_KEY", value: "{{input.QIANFAN_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "MODELSTUDIO_API_KEY", value: "{{input.MODELSTUDIO_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "XIAOMI_API_KEY", value: "{{input.XIAOMI_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "VOLCANO_ENGINE_API_KEY", value: "{{input.VOLCANO_ENGINE_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "BYTEPLUS_API_KEY", value: "{{input.BYTEPLUS_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "SYNTHETIC_API_KEY", value: "{{input.SYNTHETIC_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "VENICE_API_KEY", value: "{{input.VENICE_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "OPENCODE_ZEN_API_KEY", value: "{{input.OPENCODE_ZEN_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "KILOCODE_API_KEY", value: "{{input.KILOCODE_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "AI_GATEWAY_API_KEY", value: "{{input.AI_GATEWAY_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "CLOUDFLARE_AI_GATEWAY_API_KEY", value: "{{input.CLOUDFLARE_AI_GATEWAY_API_KEY}}" } },
-    { method: "json.set", params: { path: "pinokio-input.json", key: "LITELLM_API_KEY", value: "{{input.LITELLM_API_KEY}}" } },
+    // Step 3: Save input to JSON file
+    // Try THREE methods — whichever works on this platform will create the file.
+    // Pinokio template resolution is broken on Windows for some methods.
 
-    // Step 4: Generate .env, openclaw.json, and auth-profiles.json from the saved JSON
+    // Method A: fs.write with JSON.stringify expression
+    {
+      method: "fs.write",
+      params: {
+        path: "pinokio-input.json",
+        text: "{{JSON.stringify(input)}}",
+      },
+    },
+
+    // Step 4: Generate .env, openclaw.json, auth-profiles, and pre-paired device
     {
       method: "shell.run",
       params: {
@@ -271,6 +251,8 @@ module.exports = {
     },
 
     // Step 5: Build Docker images (first run takes a few minutes)
+    // NOTE: if setup-config.js failed because pinokio-input.json was empty/missing,
+    // the build step won't run (Pinokio stops on shell.run exit code 1)
     {
       method: "shell.run",
       params: {


### PR DESCRIPTION
## Summary

- Pre-generates Ed25519 device identity during install and seeds `devices/paired.json` — bypasses OpenClaw NOT_PAIRED errors
- Mounts pre-paired identity into openvoiceui container via docker-compose.pinokio.yml
- Simplified input persistence to single `fs.write` with `{{JSON.stringify(input)}}`