### PR TITLE
fix: clear pending.json to prevent stale repair blocking pairing

### DIFF
--- a/setup-config.js
+++ b/setup-config.js
@@ -245,6 +245,8 @@ paired[deviceId] = {
   paired: true, pairedAt: new Date().toISOString(), autoApproved: true,
 };
 fs.writeFileSync("openclaw-data/devices/paired.json", JSON.stringify(paired, null, 2) + "\n");
+// Clear pending.json — stale repair requests block pairing even when paired.json is correct
+fs.writeFileSync("openclaw-data/devices/pending.json", "{}\n");
 console.log(`  Pre-paired device: ${deviceId.slice(0, 16)}...`);
 
 console.log("\n  Configuration complete!\n");


### PR DESCRIPTION
Stale pending repair requests override paired.json. Install now clears pending.json.