### PR TITLE
fix: auto-approve device pairing on startup for Pinokio install

### DIFF
--- a/auto-approve-devices.js
+++ b/auto-approve-devices.js
@@ -2,17 +2,24 @@
 // auto-approve-devices.js — Approve all pending OpenClaw devices.
 // Runs on the host, execs into the openclaw container to move pending → paired.
 // Called by start.js after containers are healthy.
+// Retries up to 3 times with 5s delay to wait for OpenVoiceUI's first connect attempt.
 
 const { execSync } = require("child_process");
 
 const COMPOSE = "docker compose -f docker-compose.yml -f docker-compose.pinokio.yml";
+const MAX_ATTEMPTS = 3;
+const DELAY_MS = 5000;
 
 // Node one-liner that runs INSIDE the openclaw container
 const script = `
 const fs = require('fs');
 try {
-  const pending = JSON.parse(fs.readFileSync('/root/.openclaw/devices/pending.json', 'utf8'));
-  const paired = JSON.parse(fs.readFileSync('/root/.openclaw/devices/paired.json', 'utf8'));
+  const pendingPath = '/root/.openclaw/devices/pending.json';
+  const pairedPath = '/root/.openclaw/devices/paired.json';
+  let pending = {};
+  let paired = {};
+  try { pending = JSON.parse(fs.readFileSync(pendingPath, 'utf8')); } catch(e) {}
+  try { paired = JSON.parse(fs.readFileSync(pairedPath, 'utf8')); } catch(e) {}
   let count = 0;
   for (const entry of Object.values(pending)) {
     if (entry.deviceId && entry.publicKey) {
@@ -27,23 +34,50 @@ try {
     }
   }
   if (count > 0) {
-    fs.writeFileSync('/root/.openclaw/devices/paired.json', JSON.stringify(paired, null, 2));
-    fs.writeFileSync('/root/.openclaw/devices/pending.json', '{}');
-    console.log('Auto-approved ' + count + ' device(s)');
+    fs.writeFileSync(pairedPath, JSON.stringify(paired, null, 2));
+    fs.writeFileSync(pendingPath, '{}');
+    console.log('APPROVED:' + count);
   } else {
-    console.log('No pending devices to approve');
+    console.log('APPROVED:0');
   }
 } catch(e) {
-  console.log('Device approval skipped: ' + e.message);
+  console.log('ERROR:' + e.message);
 }
 `.replace(/\n/g, " ").trim();
 
-try {
-  const result = execSync(
-    `${COMPOSE} exec -T openclaw node -e "${script.replace(/"/g, '\\"')}"`,
-    { encoding: "utf8", timeout: 15000 }
-  );
-  console.log(result.trim());
-} catch (e) {
-  console.log("Device auto-approve failed (containers may still be starting):", e.message.split("\n")[0]);
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+async function run() {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const result = execSync(
+        `${COMPOSE} exec -T openclaw node -e "${script.replace(/"/g, '\\"')}"`,
+        { encoding: "utf8", timeout: 15000 }
+      ).trim();
+
+      const match = result.match(/APPROVED:(\d+)/);
+      if (match && parseInt(match[1]) > 0) {
+        console.log(`  Auto-approved ${match[1]} device(s) (attempt ${attempt})`);
+        return;
+      }
+
+      if (attempt < MAX_ATTEMPTS) {
+        console.log(`  No pending devices yet (attempt ${attempt}/${MAX_ATTEMPTS}), waiting ${DELAY_MS/1000}s...`);
+        await sleep(DELAY_MS);
+      } else {
+        console.log("  No pending devices after all attempts (device may already be paired)");
+      }
+    } catch (e) {
+      if (attempt < MAX_ATTEMPTS) {
+        console.log(`  Auto-approve attempt ${attempt} failed, retrying...`);
+        await sleep(DELAY_MS);
+      } else {
+        console.log("  Device auto-approve failed:", e.message.split("\n")[0]);
+      }
+    }
+  }
+}
+
+run();

--- a/setup-config.js
+++ b/setup-config.js
@@ -41,6 +41,7 @@ const openclawConfig = {
     bind: "lan",
     auth: { mode: "token", token: token },
     trustedProxies: ["127.0.0.1", "172.16.0.0/12", "10.0.0.0/8"],
+    dangerouslyDisableDeviceAuth: true,
     controlUi: {
       allowInsecureAuth: true,
       dangerouslyDisableDeviceAuth: true,

--- a/start.js
+++ b/start.js
@@ -14,6 +14,17 @@ module.exports = {
       },
     },
 
+    // Auto-approve any pending device pairing requests.
+    // OpenClaw requires device pairing for WebSocket connections.
+    // dangerouslyDisableDeviceAuth only affects the control UI, not WS.
+    // This approves whatever device OpenVoiceUI auto-generates on first connect.
+    {
+      method: "shell.run",
+      params: {
+        message: "node auto-approve-devices.js",
+      },
+    },
+
     // Set URL so pinokio.js shows "Open" button (uses port from install)
     {
       method: "local.set",


### PR DESCRIPTION
## Summary
- `dangerouslyDisableDeviceAuth` only disables control UI auth in OpenClaw 2026.3.13, NOT WebSocket device pairing. Connections rejected with `reason=pairing required`.
- Restores `auto-approve-devices.js` call in `start.js` — execs into openclaw container after startup, moves pending devices to paired.json. Retries 3x with 5s delay for timing.
- Also adds `dangerouslyDisableDeviceAuth` at gateway level in openclaw.json as future-proofing.