### PR TITLE
fix: remove invalid gateway.dangerouslyDisableDeviceAuth key

### DIFF
--- a/setup-config.js
+++ b/setup-config.js
@@ -41,7 +41,6 @@ const openclawConfig = {
     bind: "lan",
     auth: { mode: "token", token: token },
     trustedProxies: ["127.0.0.1", "172.16.0.0/12", "10.0.0.0/8"],
-    dangerouslyDisableDeviceAuth: true,
     controlUi: {
       allowInsecureAuth: true,
       dangerouslyDisableDeviceAuth: true,


### PR DESCRIPTION
Crashes OpenClaw on startup. Only valid under controlUi.