### PR TITLE
fix: Pinokio device pairing — pre-pair at install, inject at start

### DIFF
--- a/auto-approve-devices.js
+++ b/auto-approve-devices.js
@@ -2,12 +2,15 @@
 // auto-approve-devices.js — Approve all pending OpenClaw devices.
 // Runs on the host, execs into the openclaw container to move pending → paired.
 // Called by start.js after containers are healthy.
-// Retries up to 3 times with 5s delay to wait for OpenVoiceUI's first connect attempt.
+//
+// Polls for up to 2 minutes (24 retries × 5s) because OpenVoiceUI doesn't
+// connect to OpenClaw until the user opens the browser — which happens AFTER
+// Pinokio shows the "Open" button. We need to wait for that.
 
 const { execSync } = require("child_process");
 
 const COMPOSE = "docker compose -f docker-compose.yml -f docker-compose.pinokio.yml";
-const MAX_ATTEMPTS = 3;
+const MAX_ATTEMPTS = 24;  // 24 × 5s = 2 minutes
 const DELAY_MS = 5000;
 
 // Node one-liner that runs INSIDE the openclaw container
@@ -20,6 +23,7 @@ try {
   let paired = {};
   try { pending = JSON.parse(fs.readFileSync(pendingPath, 'utf8')); } catch(e) {}
   try { paired = JSON.parse(fs.readFileSync(pairedPath, 'utf8')); } catch(e) {}
+  const pairedCount = Object.keys(paired).length;
   let count = 0;
   for (const entry of Object.values(pending)) {
     if (entry.deviceId && entry.publicKey) {
@@ -40,6 +44,8 @@ try {
     fs.writeFileSync(pairedPath, JSON.stringify(paired, null, 2));
     fs.writeFileSync(pendingPath, '{}');
     console.log('APPROVED:' + count);
+  } else if (pairedCount > 0) {
+    console.log('ALREADY_PAIRED:' + pairedCount);
   } else {
     console.log('APPROVED:0');
   }
@@ -53,6 +59,8 @@ function sleep(ms) {
 }
 
 async function run() {
+  console.log("  Waiting for browser to connect (up to 2 minutes)...");
+
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     try {
       const result = execSync(
@@ -60,21 +68,35 @@ async function run() {
         { encoding: "utf8", timeout: 15000 }
       ).trim();
 
-      const match = result.match(/APPROVED:(\d+)/);
-      if (match && parseInt(match[1]) > 0) {
-        console.log(`  Auto-approved ${match[1]} device(s) (attempt ${attempt})`);
+      // New device(s) approved
+      const approvedMatch = result.match(/APPROVED:(\d+)/);
+      if (approvedMatch && parseInt(approvedMatch[1]) > 0) {
+        console.log(`  Auto-approved ${approvedMatch[1]} device(s) — ready to use!`);
         return;
       }
 
+      // Device already paired from a previous session
+      const pairedMatch = result.match(/ALREADY_PAIRED:(\d+)/);
+      if (pairedMatch && parseInt(pairedMatch[1]) > 0) {
+        console.log(`  Device already paired (${pairedMatch[1]} device(s)) — ready to use!`);
+        return;
+      }
+
+      // Nothing yet — keep polling
       if (attempt < MAX_ATTEMPTS) {
-        console.log(`  No pending devices yet (attempt ${attempt}/${MAX_ATTEMPTS}), waiting ${DELAY_MS/1000}s...`);
+        // Only log every 4th attempt to avoid spam
+        if (attempt % 4 === 0) {
+          const remaining = Math.round((MAX_ATTEMPTS - attempt) * DELAY_MS / 1000);
+          console.log(`  Still waiting for browser connection... (${remaining}s remaining)`);
+        }
         await sleep(DELAY_MS);
       } else {
-        console.log("  No pending devices after all attempts (device may already be paired)");
+        console.log("  Timeout: No device connected after 2 minutes.");
+        console.log("  If you see NOT_PAIRED errors, open the browser and restart the app.");
       }
     } catch (e) {
       if (attempt < MAX_ATTEMPTS) {
-        console.log(`  Auto-approve attempt ${attempt} failed, retrying...`);
+        // Container might still be starting — retry silently
         await sleep(DELAY_MS);
       } else {
         console.log("  Device auto-approve failed:", e.message.split("\n")[0]);

--- a/inject-device-identity.js
+++ b/inject-device-identity.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// inject-device-identity.js — Inject pre-paired device identity into OpenVoiceUI container.
+//
+// Called by start.js AFTER containers are up but BEFORE the user opens the browser.
+// This pipes the identity file (generated during install by setup-config.js) into
+// the OpenVoiceUI container via docker exec, avoiding the Windows named-volume
+// bind-mount issue that broke the old file-mount approach.
+//
+// The identity is also pre-registered in openclaw-data/devices/paired.json (which
+// is a bind mount into the openclaw container), so OpenClaw already trusts this
+// device. No auto-approval or browser interaction needed.
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+
+const COMPOSE = "docker compose -f docker-compose.yml -f docker-compose.pinokio.yml";
+const IDENTITY_FILE = "openclaw-data/pre-paired-device.json";
+const CONTAINER_PATH = "/app/runtime/uploads/.device-identity.json";
+
+if (!fs.existsSync(IDENTITY_FILE)) {
+  console.log("  No pre-paired device identity found — skipping injection");
+  console.log("  (Run install again to generate one, or device will need manual approval)");
+  process.exit(0);
+}
+
+const identity = fs.readFileSync(IDENTITY_FILE, "utf8");
+
+try {
+  // Create the uploads dir (may not exist on first run) and write the identity file.
+  // Uses stdin pipe to avoid shell escaping issues with JSON content.
+  execSync(
+    `${COMPOSE} exec -T openvoiceui sh -c 'mkdir -p /app/runtime/uploads && cat > ${CONTAINER_PATH}'`,
+    { input: identity, timeout: 15000, stdio: ["pipe", "pipe", "pipe"] }
+  );
+  const deviceId = JSON.parse(identity).deviceId || "unknown";
+  console.log(`  Injected device identity into OpenVoiceUI (${deviceId.slice(0, 16)}...)`);
+} catch (e) {
+  console.log("  Warning: Could not inject device identity:", e.message.split("\n")[0]);
+  console.log("  Device will need to be approved manually or via auto-approve on first browser connect.");
+}

--- a/setup-config.js
+++ b/setup-config.js
@@ -174,6 +174,86 @@ fs.writeFileSync(
 console.log(`  Wrote auth-profiles.json (${keyCount} provider(s))`);
 
 // ---------------------------------------------------------------------------
+// 4. Pre-generate device identity and pre-pair it
+// ---------------------------------------------------------------------------
+// OpenClaw requires device pairing for WebSocket connections. Even with
+// dangerouslyDisableDeviceAuth:true, the gateway still requires pairing for
+// the WS protocol (that flag only affects the control UI).
+//
+// Fix: generate an Ed25519 keypair at install time, register the public key
+// in OpenClaw's devices/paired.json, and save the full identity so start.js
+// can inject it into the OpenVoiceUI container via docker exec.
+
+// Generate Ed25519 keypair
+const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+
+// Raw 32-byte public key — extract via JWK.x (most reliable cross-platform)
+const devJwk = publicKey.export({ format: "jwk" });
+const rawPub = Buffer.from(devJwk.x, "base64url");
+
+// deviceId = SHA256(raw public key) — matches Python's hashlib.sha256(raw_pub).hexdigest()
+const deviceId = crypto.createHash("sha256").update(rawPub).digest("hex");
+
+// PEM formats — OpenVoiceUI Python client uses PEM for signing
+const pubPem = publicKey.export({ type: "spki", format: "pem" });
+const privPem = privateKey.export({ type: "pkcs8", format: "pem" });
+
+// base64url of raw Ed25519 bytes — this is what the gateway compares during WS handshake
+const pubB64url = rawPub.toString("base64url");
+
+// Save full identity for injection into OpenVoiceUI container at start time
+// (Python client reads PEM format for Ed25519 signing)
+const deviceIdentity = {
+  deviceId: deviceId,
+  publicKeyPem: pubPem,
+  privateKeyPem: privPem,
+};
+fs.writeFileSync(
+  "openclaw-data/pre-paired-device.json",
+  JSON.stringify(deviceIdentity, null, 2) + "\n"
+);
+console.log(`  Generated device identity: ${deviceId.slice(0, 16)}...`);
+
+// Pre-register in OpenClaw's devices/paired.json so it accepts this device.
+// Format must match what approveDevicePairing() writes:
+//   - publicKey: base64url of raw Ed25519 bytes (NOT PEM — gateway compares literally)
+//   - role/roles/scopes/approvedScopes: authorization metadata
+//   - tokens: per-role auth tokens for verifyDeviceToken() calls
+fs.mkdirSync("openclaw-data/devices", { recursive: true });
+const nowMs = Date.now();
+const pairingToken = crypto.randomBytes(32).toString("hex");
+const pairedDevices = {};
+pairedDevices[deviceId] = {
+  deviceId: deviceId,
+  publicKey: pubB64url,
+  displayName: "pinokio-openvoiceui",
+  platform: "linux",
+  clientId: "cli",
+  clientMode: "cli",
+  role: "operator",
+  roles: ["operator"],
+  scopes: ["operator.read", "operator.write"],
+  approvedScopes: ["operator.read", "operator.write"],
+  tokens: {
+    operator: {
+      token: pairingToken,
+      role: "operator",
+      scopes: ["operator.read", "operator.write"],
+      createdAtMs: nowMs,
+    },
+  },
+  createdAtMs: nowMs,
+  approvedAtMs: nowMs,
+};
+fs.writeFileSync(
+  "openclaw-data/devices/paired.json",
+  JSON.stringify(pairedDevices, null, 2) + "\n"
+);
+// Clear pending.json — stale entries with silent:false permanently block auto-approval
+fs.writeFileSync("openclaw-data/devices/pending.json", "{}\n");
+console.log("  Wrote devices/paired.json (pre-paired)");
+
+// ---------------------------------------------------------------------------
 // Done
 // ---------------------------------------------------------------------------
 

--- a/start.js
+++ b/start.js
@@ -14,22 +14,35 @@ module.exports = {
       },
     },
 
-    // Auto-approve any pending device pairing requests.
-    // OpenClaw requires device pairing for WebSocket connections.
-    // dangerouslyDisableDeviceAuth only affects the control UI, not WS.
-    // This approves whatever device OpenVoiceUI auto-generates on first connect.
+    // Inject the pre-paired device identity into the OpenVoiceUI container.
+    // This was generated during install (setup-config.js) and pre-registered
+    // in openclaw-data/devices/paired.json. We docker exec it in because
+    // file bind-mounts into Docker named volumes break on Windows.
+    // This runs BEFORE the user can open the browser, so the identity is
+    // already in place when OpenVoiceUI first connects to OpenClaw.
     {
       method: "shell.run",
       params: {
-        message: "node auto-approve-devices.js",
+        message: "node inject-device-identity.js",
       },
     },
 
-    // Set URL so pinokio.js shows "Open" button (uses port from install)
+    // Set URL so Pinokio shows "Open" button.
+    // Device is already pre-paired — no approval step needed.
     {
       method: "local.set",
       params: {
         url: "http://localhost:{{local.PORT||5001}}",
+      },
+    },
+
+    // Safety fallback: if inject failed (e.g. container restarted and lost
+    // the injected file), auto-approve will catch the device when the user
+    // opens the browser. Runs in background with long poll.
+    {
+      method: "shell.run",
+      params: {
+        message: "node auto-approve-devices.js",
       },
     },
   ],


### PR DESCRIPTION
## Summary
- Pre-generates Ed25519 device identity during install (`setup-config.js`) and writes `paired.json` with correct base64url format + full schema so OpenClaw trusts the device before containers start
- New `inject-device-identity.js` uses `docker exec` to pipe the identity into the OpenVoiceUI container after startup — avoids the Windows named-volume bind-mount issue that broke the previous file-mount approach
- Reorders `start.js`: inject identity → set URL → auto-approve fallback
- Upgrades `auto-approve-devices.js` to 2-minute poll with already-paired detection as safety net

## Why
Fresh Pinokio installs hit NOT_PAIRED errors because the auto-approve script ran before the user could open the browser. `dangerouslyDisableDeviceAuth` only disables control UI auth, not WebSocket device pairing. The old bind-mount fix (6a8118e) worked on Linux/Mac but broke on Windows Docker named volumes.