### PR TITLE
fix: default TTS provider supertonic → groq across all code paths

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -637,7 +637,7 @@ def conversation():
 
     Request JSON:
         message      : str  — transcribed user speech (required)
-        tts_provider : str  — 'supertonic' | 'groq' (default: supertonic)
+        tts_provider : str  — 'supertonic' | 'groq' (default: env DEFAULT_TTS_PROVIDER or groq)
         voice        : str  — voice ID, e.g. 'M1' (default: M1)
         session_id   : str  — session identifier (default: default)
         ui_context   : dict — canvas/music state from frontend (optional)
@@ -680,7 +680,7 @@ def _conversation_inner():
     logger.info(f'Received conversation request: {data}')
 
     user_message = data.get('message', '').strip()
-    tts_provider = data.get('tts_provider', 'supertonic')
+    tts_provider = data.get('tts_provider') or os.getenv('DEFAULT_TTS_PROVIDER', 'groq')
     voice = data.get('voice', 'M1')
     session_id = data.get('session_id', 'default')
     ui_context = data.get('ui_context', {})

--- a/services/tts.py
+++ b/services/tts.py
@@ -201,7 +201,7 @@ def _generate_with_provider(tts_provider: str, text: str, voice: str) -> bytes:
 def generate_tts_b64(
     text: str,
     voice: Optional[str] = None,
-    tts_provider: str = 'supertonic',
+    tts_provider: str = 'groq',
     **kwargs,
 ) -> Optional[str]:
     """

--- a/src/app.js
+++ b/src/app.js
@@ -4687,7 +4687,7 @@ inject();
                     this.stt = new WebSpeechSTT();
                     console.log('STT provider: Chrome Web Speech');
                 }
-                this.ttsProvider = 'supertonic';
+                this.ttsProvider = 'groq';
                 this.ttsVoice = 'F3';
                 this.audioContext = null;
                 this.analyser = null;

--- a/src/core/Config.js
+++ b/src/core/Config.js
@@ -21,7 +21,7 @@ import { eventBus } from './EventBus.js';
 /** Compile-time defaults — must not contain secrets */
 const DEFAULTS = {
     tts: {
-        provider: 'supertonic',
+        provider: 'groq',
         volume: 1.0,
         rate: 1.0,
     },

--- a/src/core/VoiceSession.js
+++ b/src/core/VoiceSession.js
@@ -199,7 +199,7 @@ export class VoiceSession {
         eventBus.emit('session:thinking', {});
         faceManager.setMood('thinking');
 
-        const provider = localStorage.getItem('voice_provider') || 'supertonic';
+        const provider = localStorage.getItem('voice_provider') || 'groq';
         const voice = localStorage.getItem('voice_voice') || 'M1';
 
         try {
@@ -372,7 +372,7 @@ export class VoiceSession {
 
         return new Promise(async (resolve) => {
             try {
-                const provider = localStorage.getItem('voice_provider') || 'supertonic';
+                const provider = localStorage.getItem('voice_provider') || 'groq';
                 const voice = localStorage.getItem('voice_voice') || 'M1';
 
                 const response = await fetch(`${this.serverUrl}/api/tts/generate`, {


### PR DESCRIPTION
## Summary
- Changes hardcoded default TTS provider from `supertonic` to `groq` in 5 files (backend + frontend)
- `conversation.py` now reads `DEFAULT_TTS_PROVIDER` env var instead of hardcoding
- Supertonic remains as automatic fallback if Groq fails (via `_FALLBACK_CHAIN`)
- Also includes: remove openclaw restart from device inject (broke shared network namespace)