### PR TITLE
feat: Pinokio registry checkin — auto-submit token + /checkpoints/snapshot

### DIFF
--- a/app.py
+++ b/app.py
@@ -119,6 +119,8 @@ def create_app(config_override: dict = None):
             '/api/music',     # music track list — loaded before Clerk init
             '/api/faces',     # face list — loaded before Clerk init
             '/api/icons/',    # icon library + generated icons — static images, no secrets
+            '/registry/',     # Pinokio registry check-in — accessed by Pinokio, not logged-in user
+            '/checkpoints/',  # Pinokio snapshot endpoint — called from /registry/checkin page JS
         )
         _PUBLIC_EXACT = {
             '/',           # main page — hosts the Clerk login gate itself

--- a/routes/registry.py
+++ b/routes/registry.py
@@ -2,22 +2,34 @@
 Pinokio registry check-in endpoint.
 
 When a user clicks "Check in" in Pinokio, it opens:
-  http://localhost:<port>/registry/checkin?return=<pinokio_checkin_url>&...
+  http://localhost:<port>/registry/checkin?return=<pinokio_checkin_url>&app=<slug>&registry=<api>&...#token=<one-time-token>
 
-This route shows a confirmation page verifying the install is healthy,
-then lets the user complete the check-in on Pinokio's platform.
+The #token is in the URL hash — it never reaches Flask. Client-side JS reads it,
+calls POST /checkpoints/snapshot with X-Registry-Token header, which posts the
+token + current git hash to api.pinokio.co, then redirects back to beta.pinokio.co.
 """
 
+import json
+import os
+import subprocess
 import time
-from flask import Blueprint, request, redirect, Response
+
+import requests
+from flask import Blueprint, Response, jsonify, request
 
 registry_bp = Blueprint('registry', __name__)
 
 
 @registry_bp.route('/registry/checkin')
 def registry_checkin():
-    return_url = request.args.get('return')
-    repo = request.args.get('repo', 'OpenVoiceUI')
+    return_url = request.args.get('return', '')
+    repo       = request.args.get('repo', 'OpenVoiceUI')
+    app_slug   = request.args.get('app', '')
+    registry   = request.args.get('registry', 'https://api.pinokio.co')
+
+    # Sanitize return_url — only allow http/https redirects
+    if return_url and not return_url.startswith(('http://', 'https://')):
+        return_url = ''
 
     # Quick health check
     try:
@@ -28,20 +40,19 @@ def registry_checkin():
         uptime = int(time.time() - health_checker.start_time)
         uptime_str = f"{uptime // 3600}h {(uptime % 3600) // 60}m {uptime % 60}s"
     except Exception:
-        is_healthy = True  # server is responding, so it's at least alive
+        is_healthy = True
         status_msg = "Server is running"
         uptime_str = "unknown"
 
-    status_icon = "&#10004;" if is_healthy else "&#9888;"
+    status_icon  = "&#10004;" if is_healthy else "&#9888;"
     status_color = "#4ade80" if is_healthy else "#fbbf24"
-    button_html = ""
-    if return_url:
-        button_html = f'''
-            <a href="{return_url}" class="checkin-btn">Complete Check-in on Pinokio</a>
-            <p class="hint">This will confirm your successful install on the Pinokio community page.</p>
-        '''
-    else:
-        button_html = '<p class="hint">No return URL provided — check-in confirmed locally.</p>'
+
+    # Pass values to JS safely via JSON encoding
+    js_config = json.dumps({
+        'returnUrl': return_url,
+        'registry':  registry,
+        'appSlug':   app_slug,
+    })
 
     html = f'''<!DOCTYPE html>
 <html lang="en">
@@ -69,21 +80,9 @@ def registry_checkin():
             width: 90%;
             text-align: center;
         }}
-        .logo {{
-            font-size: 48px;
-            margin-bottom: 8px;
-        }}
-        h1 {{
-            font-size: 24px;
-            font-weight: 600;
-            margin-bottom: 8px;
-            color: #fff;
-        }}
-        .subtitle {{
-            color: #888;
-            font-size: 14px;
-            margin-bottom: 32px;
-        }}
+        .logo {{ font-size: 48px; margin-bottom: 8px; }}
+        h1 {{ font-size: 24px; font-weight: 600; margin-bottom: 8px; color: #fff; }}
+        .subtitle {{ color: #888; font-size: 14px; margin-bottom: 32px; }}
         .status-row {{
             display: flex;
             align-items: center;
@@ -97,6 +96,12 @@ def registry_checkin():
         .status-row .label {{ color: #888; }}
         .status-row .value {{ font-weight: 500; }}
         .status-row .value.ok {{ color: {status_color}; }}
+        #status-msg {{
+            margin-top: 28px;
+            font-size: 14px;
+            color: #888;
+            min-height: 40px;
+        }}
         .checkin-btn {{
             display: inline-block;
             margin-top: 28px;
@@ -104,20 +109,19 @@ def registry_checkin():
             background: linear-gradient(135deg, #6366f1, #8b5cf6);
             color: #fff;
             text-decoration: none;
+            border: none;
             border-radius: 10px;
             font-size: 16px;
             font-weight: 600;
+            cursor: pointer;
             transition: transform 0.15s, box-shadow 0.15s;
         }}
         .checkin-btn:hover {{
             transform: translateY(-2px);
             box-shadow: 0 8px 24px rgba(99, 102, 241, 0.3);
         }}
-        .hint {{
-            color: #666;
-            font-size: 12px;
-            margin-top: 16px;
-        }}
+        .error {{ color: #f87171; margin-top: 16px; font-size: 13px; }}
+        .hint {{ color: #666; font-size: 12px; margin-top: 16px; }}
     </style>
 </head>
 <body>
@@ -139,9 +143,173 @@ def registry_checkin():
             <span class="value">{repo}</span>
         </div>
 
-        {button_html}
+        <div id="status-msg">Completing check-in&hellip;</div>
     </div>
+
+    <script>
+    (function() {{
+        var cfg = {js_config};
+
+        // Read token from URL hash (#token=...) — never sent to server
+        var hash = window.location.hash.slice(1);
+        var token = new URLSearchParams(hash).get('token');
+
+        // Clear token from URL bar immediately
+        if (token) history.replaceState(null, '', window.location.pathname + window.location.search);
+
+        var msgEl = document.getElementById('status-msg');
+
+        function showError(msg) {{
+            msgEl.innerHTML = '<span class="error">' + msg + '</span>';
+            if (cfg.returnUrl) {{
+                var sep = cfg.returnUrl.includes('?') ? '&' : '?';
+                setTimeout(function() {{
+                    window.location.href = cfg.returnUrl + sep + 'error=checkin_failed';
+                }}, 3000);
+            }}
+        }}
+
+        function showManualBtn() {{
+            if (cfg.returnUrl) {{
+                msgEl.innerHTML = '<a href="' + cfg.returnUrl + '" class="checkin-btn">Complete Check-in on Pinokio</a>' +
+                    '<p class="hint">Click to confirm your install on the Pinokio community page.</p>';
+            }} else {{
+                msgEl.innerHTML = '<p class="hint">Check-in confirmed locally (no return URL).</p>';
+            }}
+        }}
+
+        if (!token) {{
+            // No token — fall back to manual button (e.g. user navigated here directly)
+            showManualBtn();
+            return;
+        }}
+
+        // POST to our local /checkpoints/snapshot which handles the registry API call
+        fetch('/checkpoints/snapshot?publish=1&registry=' + encodeURIComponent(cfg.registry), {{
+            method: 'POST',
+            headers: {{ 'X-Registry-Token': token, 'Content-Type': 'application/json' }},
+        }})
+        .then(function(r) {{ return r.json().then(function(d) {{ return {{ ok: r.ok, data: d }}; }}); }})
+        .then(function(res) {{
+            if (!res.ok || !res.data.ok) {{
+                var err = (res.data && res.data.error) || 'snapshot_failed';
+                showError('Check-in failed: ' + err + '. Redirecting&hellip;');
+                if (cfg.returnUrl) {{
+                    var sep = cfg.returnUrl.includes('?') ? '&' : '?';
+                    setTimeout(function() {{
+                        window.location.href = cfg.returnUrl + sep + 'error=' + encodeURIComponent(err);
+                    }}, 2500);
+                }}
+                return;
+            }}
+            var hash = (res.data.created && res.data.created.hash) || '';
+            msgEl.innerHTML = '<span style="color:#4ade80">&#10004; Check-in complete!</span><p class="hint">Redirecting back to Pinokio&hellip;</p>';
+            if (cfg.returnUrl) {{
+                var sep = cfg.returnUrl.includes('?') ? '&' : '?';
+                setTimeout(function() {{
+                    window.location.href = cfg.returnUrl + sep + 'ok=1' + (hash ? '&hash=' + hash : '');
+                }}, 1000);
+            }}
+        }})
+        .catch(function(e) {{
+            showError('Network error during check-in. ' + e.message);
+        }});
+    }})();
+    </script>
 </body>
 </html>'''
 
     return Response(html, content_type='text/html')
+
+
+def _get_commit_hash() -> str:
+    """Return the current git commit hash using the best available method."""
+    app_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+    # 1. Try git directly (works on host / dev installs)
+    try:
+        return subprocess.check_output(
+            ['git', 'rev-parse', 'HEAD'],
+            cwd=app_root, stderr=subprocess.DEVNULL
+        ).decode().strip()
+    except Exception:
+        pass
+
+    # 2. GIT_COMMIT env var baked in at Docker build time
+    env_hash = os.getenv('GIT_COMMIT', '').strip()
+    if env_hash:
+        return env_hash
+
+    # 3. GIT_HASH file written during Docker build (via `git rev-parse HEAD > /app/GIT_HASH`)
+    hash_file = os.path.join(app_root, 'GIT_HASH')
+    if os.path.exists(hash_file):
+        return open(hash_file).read().strip()
+
+    # 4. Derive a stable hash from package.json version
+    try:
+        import hashlib
+        pkg = os.path.join(app_root, 'package.json')
+        version = json.load(open(pkg)).get('version', '0.0.0')
+        return hashlib.sha1(f'openvoiceui-{version}'.encode()).hexdigest()
+    except Exception:
+        pass
+
+    import hashlib
+    return hashlib.sha1(b'openvoiceui-unknown').hexdigest()
+
+
+@registry_bp.route('/checkpoints/snapshot', methods=['POST'])
+def checkpoints_snapshot():
+    """
+    Called by the /registry/checkin page JS.
+    Creates a git snapshot of the app and publishes it to api.pinokio.co.
+    """
+    token    = request.headers.get('X-Registry-Token', '').strip()
+    registry = request.args.get('registry', 'https://api.pinokio.co').rstrip('/')
+    publish  = request.args.get('publish', '0') == '1'
+
+    if not token:
+        return jsonify({'ok': False, 'error': 'missing_token'}), 400
+
+    # Get current git hash — try several strategies since git may not be in the container
+    commit_hash = _get_commit_hash()
+
+    created = {'hash': commit_hash}
+
+    if not publish:
+        return jsonify({'ok': True, 'created': created})
+
+    # Publish to Pinokio registry
+    try:
+        resp = requests.post(
+            f'{registry}/checkpoints',
+            headers={
+                'Authorization': f'Bearer {token}',
+                'Content-Type':  'application/json',
+            },
+            json={
+                'hash':       commit_hash,
+                'visibility': 'public',
+            },
+            timeout=15,
+        )
+    except requests.RequestException as e:
+        return jsonify({'ok': False, 'error': 'publish_failed', 'detail': str(e)}), 502
+
+    if not resp.ok:
+        try:
+            detail = resp.json()
+        except Exception:
+            detail = resp.text[:200]
+        return jsonify({'ok': False, 'error': 'publish_failed', 'detail': detail}), 502
+
+    try:
+        pub_data = resp.json()
+    except Exception:
+        pub_data = {}
+
+    return jsonify({
+        'ok':      True,
+        'created': created,
+        'publish': {'ok': True, 'hash': commit_hash, **pub_data},
+    })


### PR DESCRIPTION
## What

Fixes the Pinokio registry check-in flow so it actually completes instead of showing a static button.

## Changes

**`routes/registry.py`**
- `/registry/checkin`: now embeds JS that reads `#token` from URL hash (client-side only — Flask never sees it), auto-calls `/checkpoints/snapshot`, then redirects back to `beta.pinokio.co` with `?ok=1&hash=...`
- `/checkpoints/snapshot` (new route): gets current git hash (with fallbacks for Docker builds without git), POSTs to `api.pinokio.co/checkpoints` with the one-time token

**`app.py`**
- Adds `/registry/` and `/checkpoints/` to `_PUBLIC_PREFIXES` so Clerk auth doesn't block Pinokio from reaching these routes