### PR TITLE
fix: lowercase repo URL in Pinokio registry POST body

### DIFF
--- a/routes/registry.py
+++ b/routes/registry.py
@@ -334,15 +334,20 @@ def checkpoints_snapshot():
     if not publish:
         return jsonify({'ok': True, 'created': created})
 
-    # Publish to Pinokio registry with the exact body format pinokiod uses
+    # Publish to Pinokio registry with the exact body format pinokiod uses.
+    # The checkpoint URLs must be lowercased to match the registry's canonicalRepoUrl().
     import platform as _platform
+    canon_url = repo_url.strip().rstrip('/')
+    if canon_url.lower().endswith('.git'):
+        canon_url = canon_url[:-4]
+    canon_url = canon_url.lower()
     post_body = {
         'hash':       checkpoint_hash,
         'visibility': 'public',
         'checkpoint': {
             'version': 1,
-            'root':    repo_url,
-            'repos':   [{'commit': git_sha, 'path': '.', 'repo': repo_url}],
+            'root':    canon_url,
+            'repos':   [{'commit': git_sha, 'path': '.', 'repo': canon_url}],
         },
         'system': {
             'platform': _platform.system().lower(),


### PR DESCRIPTION
## Summary
- The `checkpoint.root` and `checkpoint.repos[].repo` fields in the POST body to `api.pinokio.co` also need to use the canonical (lowercased) URL
- Previous fix only lowercased the URL for hash computation — the payload body was still sending mixed-case, causing the registry to reject the checkpoint

Completes the fix started in #174.