### PR TITLE
fix: remove bloat deps — faster installs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,10 @@ python-dotenv==1.2.1
 # System monitoring
 psutil==7.2.2
 
-# Speech-to-text (Faster Whisper — optional, for local STT)
-faster-whisper==1.2.1
+# Speech-to-text (optional — adds ~200MB for onnxruntime + ctranslate2)
+# Only needed for LOCAL on-device STT. Most users use Groq or Deepgram API instead.
+# To pre-install: pip install faster-whisper
+# faster-whisper==1.2.1
 
 # TTS providers
 groq==1.0.0                 # Groq Orpheus TTS (required if using groq provider)
@@ -31,8 +33,8 @@ cryptography==46.0.5
 # deepface>=0.0.93
 # tf-keras>=2.19.0
 
-# AI providers (optional)
-google-generativeai==0.8.6  # Only if using Gemini
+# AI providers (optional — not required, agents handle their own API calls)
+# google-generativeai==0.8.6  # Unused — remove if still commented on next cleanup
 
 # Supertonic local TTS (optional — install manually if using local ONNX TTS)
 # onnxruntime>=1.23.1

--- a/server.py
+++ b/server.py
@@ -58,7 +58,13 @@ _whisper_model = None
 def get_whisper_model():
     global _whisper_model
     if _whisper_model is None:
-        from faster_whisper import WhisperModel
+        try:
+            from faster_whisper import WhisperModel
+        except ImportError:
+            raise ImportError(
+                "Local STT requires faster-whisper. Install it with: "
+                "pip install faster-whisper"
+            )
         logger.info("Loading Faster-Whisper model (first STT request)...")
         _whisper_model = WhisperModel("tiny", device="cpu", compute_type="float32")
         logger.info("Faster-Whisper model ready.")


### PR DESCRIPTION
Removed google-generativeai (unused, zero imports). Made faster-whisper optional (most users use Groq/Deepgram). Install goes from 10+ min to ~1 min.