### PR TITLE
fix: add Pillow and PyYAML — crash on startup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,10 @@ python-dotenv==1.2.1
 # System monitoring
 psutil==7.2.2
 
+# Image processing (icon generation, uploads)
+Pillow>=10.0.0
+PyYAML>=6.0
+
 # Speech-to-text (optional — adds ~200MB for onnxruntime + ctranslate2)
 # Only needed for LOCAL on-device STT. Most users use Groq or Deepgram API instead.
 # To pre-install: pip install faster-whisper


### PR DESCRIPTION
These were transitive deps of deepface/tensorflow that icons.py and config loader depend on directly.