### PR TITLE
fix: device pairing on stock install + Deepgram optional

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -159,12 +159,12 @@ async function cmdSetup() {
   }
 
   const deepgramKey = await ask(
-    "  Deepgram API Key (console.deepgram.com) [REQUIRED]: "
+    "  Deepgram API Key (console.deepgram.com) [optional]: "
   );
   if (!deepgramKey) {
-    console.error("\n  ERROR: Deepgram API key is required for STT.\n");
-    rl.close();
-    process.exit(1);
+    console.log(
+      "  Skipped — browser speech recognition (WebSpeech) will be used for STT.\n"
+    );
   }
 
   console.log("\n  ── AI Provider Keys (pick at least one) ──────────────");
@@ -238,6 +238,13 @@ function cmdStart() {
     console.error("  ERROR: No .env file found. Run: openvoiceui setup\n");
     process.exit(1);
   }
+
+  // Pre-create devices directory before containers start. Without this,
+  // openclaw (running as root) creates it first via the bind mount, making
+  // it root-owned — then inject-device-identity.js can't write paired.json.
+  fs.mkdirSync(path.join(PROJECT_DIR, "openclaw-data", "devices"), {
+    recursive: true,
+  });
 
   console.log("  Starting OpenVoiceUI...\n");
   run(`${COMPOSE} up -d`);
@@ -355,7 +362,8 @@ function cmdHelp() {
 // Main
 // ---------------------------------------------------------------------------
 
-const command = process.argv[2] || "help";
+const rawCommand = process.argv[2] || "help";
+const command = (rawCommand === "--help" || rawCommand === "-h") ? "help" : rawCommand;
 
 if (commands[command]) {
   const result = commands[command].run();

--- a/inject-device-identity.js
+++ b/inject-device-identity.js
@@ -69,9 +69,34 @@ function writePairedJson(deviceId, publicKeyPem) {
     approvedAtMs: nowMs,
   };
 
-  fs.mkdirSync("openclaw-data/devices", { recursive: true });
-  fs.writeFileSync(PAIRED_FILE, JSON.stringify(paired, null, 2) + "\n");
-  fs.writeFileSync("openclaw-data/devices/pending.json", "{}\n");
+  var pairedContent = JSON.stringify(paired, null, 2) + "\n";
+
+  // Try direct write first (works when current user owns openclaw-data/devices/)
+  try {
+    fs.mkdirSync("openclaw-data/devices", { recursive: true });
+    fs.writeFileSync(PAIRED_FILE, pairedContent);
+    fs.writeFileSync("openclaw-data/devices/pending.json", "{}\n");
+    return;
+  } catch (e) {
+    if (e.code !== "EACCES") throw e;
+  }
+
+  // Fallback: openclaw container created devices/ as root via bind mount.
+  // Write via docker cp into the container — bind mount reflects it on host too.
+  console.log("  devices/ is root-owned — writing via docker cp");
+  var os = require("os");
+  var tmpPaired = path.join(os.tmpdir(), "ovu-paired.json");
+  var tmpPending = path.join(os.tmpdir(), "ovu-pending.json");
+  fs.writeFileSync(tmpPaired, pairedContent);
+  fs.writeFileSync(tmpPending, "{}\n");
+
+  var cid = exec(COMPOSE + " ps -q openclaw");
+  if (!cid) throw new Error("openclaw container not found for docker cp fallback");
+  exec("docker cp " + JSON.stringify(tmpPaired) + " " + cid + ":/root/.openclaw/devices/paired.json");
+  exec("docker cp " + JSON.stringify(tmpPending) + " " + cid + ":/root/.openclaw/devices/pending.json");
+
+  try { fs.unlinkSync(tmpPaired); } catch (e2) { /* ignore */ }
+  try { fs.unlinkSync(tmpPending); } catch (e2) { /* ignore */ }
 }
 
 // Step 1: Check if the container already has a device identity (from a previous run)


### PR DESCRIPTION
## Summary
- **Device pairing fix**: On stock installs, openclaw container (running as root) creates `devices/` directory via bind mount before `inject-device-identity.js` runs. The script then silently fails to write `paired.json` due to EACCES, leaving the install in permanent NOT_PAIRED state with no error message. Fixed with: pre-create the directory before compose up, and fall back to `docker cp` if direct write fails.
- **Deepgram now optional**: Setup wizard required a Deepgram API key but the runtime works fine without it — browser WebSpeech handles STT. Setup no longer blocks on a key the stack doesn't need.
- **`--help` flag**: `openvoiceui --help` now shows help instead of exiting as "Unknown command".