### PR TITLE
chore: bump version to 2026.3.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openvoiceui",
-  "version": "2026.3.27",
+  "version": "2026.3.28",
   "description": "Voice-powered AI assistant platform — connect any LLM, any TTS, with a live web canvas, music generation, and agent orchestration",
   "bin": {
     "openvoiceui": "cli/index.js"


### PR DESCRIPTION
Sync package.json version with release.