### PR TITLE
ci: add manual trigger to npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,7 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
Adds workflow_dispatch so npm publish can be triggered manually when needed (e.g. for releases created before the workflow existed).