### PR TITLE
ci: fix npm publish on manual dispatch

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,6 +22,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Sync version from release tag
+        if: github.event_name == 'release'
         run: |
           # Strip leading 'v' if present (e.g. v2026.3.28 -> 2026.3.28)
           TAG="${GITHUB_REF_NAME#v}"


### PR DESCRIPTION
Version sync step now only runs on release events. Manual dispatch publishes whatever version is in package.json.