### PR TITLE
fix: add version tag to desktop.html

### DIFF
--- a/default-pages/desktop.html
+++ b/default-pages/desktop.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- openvoiceui-version: 2026.3.29 -->
 <html lang="en">
 <head>
 <meta charset="UTF-8">


### PR DESCRIPTION
Without a version tag, server never re-seeds desktop.html on existing installs.