### PR TITLE
fix: PTT unmute restores mic after deactivation

### DIFF
--- a/src/providers/WebSpeechSTT.js
+++ b/src/providers/WebSpeechSTT.js
@@ -356,7 +356,9 @@ class WebSpeechSTT {
         this.isProcessing = false;
         this.accumulatedText = '';
 
-        if (this.isListening && this.recognition) {
+        // Restore listening state — stop()/pttRelease() may have set isListening=false
+        this.isListening = true;
+        if (this.recognition) {
             try { this.recognition.start(); } catch (e) {}
         }
     }


### PR DESCRIPTION
pttUnmute() failed to restart recognition because isListening was false. One-line fix: restore the flag before calling start().