### PR TITLE
docs: README overhaul — positioning, install blocks, plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@
 </p>
 
 <p align="center">
-  Talk to any LLM. Watch it build live web pages. Automate with 35+ skills.<br/>
-  Self-host with full privacy. MIT licensed, forever free.
+  Install, open <code>localhost:5001</code>, say <em>"build me a dashboard"</em>, and watch it render live.
 </p>
 
 ---
@@ -27,66 +26,91 @@
 
 ## Install
 
-Pick one:
+**Prerequisite: [Docker](https://docs.docker.com/get-docker/) must be installed and running for all install methods.**
+
+### Pinokio (one-click)
+
+Download [Pinokio](https://pinokio.co) if you don't have it, then search **"OpenVoiceUI"** in the app store and click **Install**.
+
+### npm
 
 ```bash
-# npm (quickest)
-npx openvoiceui setup
-npx openvoiceui start
+npx openvoiceui setup     # interactive wizard — walks you through API keys + builds Docker images
+npx openvoiceui start     # starts everything
+```
 
-# Docker
+### Docker
+
+```bash
 git clone https://github.com/MCERQUA/OpenVoiceUI.git
 cd OpenVoiceUI
 cp .env.example .env        # edit with your API keys
 docker compose up
-
-# Pinokio (one-click)
-# Search "OpenVoiceUI" in the Pinokio app store and click Install
 ```
 
-Open **localhost:5001**, say *"build me a dashboard"*, and watch it render live.
+Open **localhost:5001** and start talking.
 
 ---
 
 ## What is OpenVoiceUI?
 
-Most voice AI platforms sell you a voice API. OpenVoiceUI gives you an **entire AI workspace** — voice, canvas, skills, agents, media generation — open source and self-hosted.
+OpenVoiceUI is a hands-free, AI-controlled computer. You talk — it builds. Live web apps, dashboards, games, full websites — rendered in real time while you watch. No mouse, no keyboard, no typing prompts into a chat box.
 
-It's a voice-first AI assistant that doesn't just talk back — it builds live HTML pages mid-conversation, runs 35+ built-in skills, delegates work to parallel sub-agents, and remembers everything across sessions. Works with any LLM. Runs on your hardware. MIT licensed.
+It runs on [OpenClaw](https://openclaw.org) and works with any LLM. The AI agent can build and display apps mid-conversation, switch between projects with a voice command, generate music on the fly, delegate work to parallel sub-agents, and remember everything across sessions. It uses any [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [OpenClaw](https://openclaw.org) skill — and the community can build and share more through the plugin system.
+
+Self-hosted. Your hardware, your data. MIT licensed, forever free.
 
 ## Core Features
 
-- **Hands-Free Voice Control** — Wake word, push-to-talk, or continuous mode. Works with any LLM provider.
-- **Canvas UI** — AI builds live HTML pages mid-conversation: dashboards, reports, galleries, tools. Real web apps, not text responses.
-- **Skill System** — 35+ built-in skills for social media, SEO, email, business briefings, marketing. Build your own without touching core code.
-- **Sub-Agents** — Parallel AI workers. Delegate multiple tasks simultaneously and get results back.
+- **Hands-Free AI Computer** — Talk and watch it work. The AI builds apps, switches between projects, runs tasks, and displays results on a live visual canvas — all without touching a mouse or keyboard.
+- **Live Canvas** — AI renders real HTML pages mid-conversation: dashboards, tools, galleries, reports, full web apps. Not text responses — real interactive pages you can use.
+- **AI Music Generation** — Generate songs on the fly with your voice using Suno. Full music player with playlist management built in.
+- **Custom Animated Interface** — Choose from animated face modes (eye-face avatar, reactive halo-smoke orb) or install community-built faces through plugins. Build your own — the face system is fully extensible.
+- **Sub-Agents** — Delegate multiple tasks to parallel AI workers simultaneously and get results back.
 - **Long-Term Memory** — ByteRover context engine curates knowledge every turn. Persists across sessions in human-readable markdown.
-- **Admin Dashboard** — Mobile-responsive. Agent profiles, provider config, workspace file browser, plugin management, system health. Everything editable and saving.
-- **Plugin System** — Install face packs, gateway adapters, and extensions. Drop-in, no core changes.
-- **Self-Hosted** — Your hardware, your data. Docker, npm, or one-click Pinokio. No vendor lock-in, no monthly fees.
+- **Desktop OS Interface** — Themed desktop environment with window management (Windows XP, macOS, Ubuntu, Win95, Win 3.1).
+- **Admin Dashboard** — Mobile-responsive. Agent profiles, provider config, workspace file browser, plugin management, system health. Everything editable live.
+- **Self-Hosted** — Your hardware, your data. No vendor lock-in, no monthly fees.
 
 ## And More
 
-- Desktop OS interface with themes (Windows XP, macOS, Ubuntu, Win95, Win 3.1)
 - Image generation (FLUX.1, Stable Diffusion 3.5)
-- AI music generation and player (Suno)
 - Video creation (Remotion Studio)
 - Voice cloning (Qwen3-TTS via fal.ai)
 - Cron jobs for scheduled automation
 - File explorer with drag-and-drop
-- Animated face modes (eye-face avatar, halo smoke orb)
 - Agent profiles — switch personas, voices, and LLM providers from the admin panel
+
+---
+
+## Plugins
+
+OpenVoiceUI has a plugin system for community-built extensions. Plugins can include animated face packs, canvas pages, workflow dashboards, gateway adapters, or any combination of these.
+
+**Our first community plugin:**
+
+- [**BHB Animated Characters**](https://github.com/MCERQUA/openvoiceui-plugins) — Custom animated avatar faces by BHB
+
+**Build your own.** If you can build a canvas page, an animated face, or a workflow dashboard, you can package it as a plugin. See the [plugins repo](https://github.com/MCERQUA/openvoiceui-plugins) for submission guidelines and the BHB plugin as a reference.
 
 ---
 
 ## Install Details
 
-### Option 1: npm (recommended for local use)
+### Option 1: Pinokio (one-click)
 
-Requires **Node.js 20+** and **Python 3.10+**.
+1. Install [Pinokio](https://pinokio.co) if you don't have it
+2. Search **"OpenVoiceUI"** in the Pinokio app store
+3. Click **Install**, then **Start**
+
+Pinokio handles Docker, dependencies, and configuration automatically.
+
+### Option 2: npm
+
+Requires **Node.js 20+**, **Python 3.10+**, and **Docker**.
 
 ```bash
-npx openvoiceui setup     # interactive wizard — configures LLM, TTS, API keys
+npx openvoiceui setup     # interactive wizard — configures LLM, TTS, API keys, builds Docker images
 npx openvoiceui start     # starts OpenClaw gateway + Supertonic TTS + voice UI
 ```
 
@@ -98,7 +122,7 @@ npx openvoiceui status    # check what's running
 npx openvoiceui logs      # tail service logs
 ```
 
-### Option 2: Docker
+### Option 3: Docker
 
 Requires **Docker** and **Docker Compose**.
 
@@ -125,14 +149,6 @@ This starts three containers:
 Open **http://localhost:5001** to use the voice interface, or **http://localhost:5001/admin** for the admin dashboard.
 
 To stop: `docker compose down`
-
-### Option 3: Pinokio (one-click)
-
-1. Install [Pinokio](https://pinokio.computer) if you don't have it
-2. Search **"OpenVoiceUI"** in the Pinokio app store
-3. Click **Install**, then **Start**
-
-Pinokio handles Docker, dependencies, and configuration automatically.
 
 ### Option 4: VPS / Production
 
@@ -224,7 +240,7 @@ Access at **localhost:5001/admin**. Mobile-responsive.
 
 **Digital Agencies** — Deploy custom AI assistants per client. Multi-tenant ready. Each client gets their own voice-powered workspace.
 
-**Developers** — Fork it, extend it, deploy it anywhere. MIT licensed. Build custom skills, gateway plugins, and adapters on top of a voice-first platform.
+**Developers** — Fork it, extend it, deploy it anywhere. MIT licensed. Build custom plugins, gateway adapters, and canvas pages on top of a voice-first platform.
 
 ---
 
@@ -234,9 +250,11 @@ Access at **localhost:5001/admin**. Mobile-responsive.
 |---|---|---|
 | **Source** | Open source (MIT) | Closed source |
 | **Canvas UI** | Live HTML rendering | Text/audio only |
-| **Skills** | 35+ built-in, extensible | API endpoints |
+| **Skills** | Any Claude Code or OpenClaw skill | API endpoints |
+| **Music** | AI music generation (Suno) | None |
 | **Memory** | ByteRover long-term context | Session only |
 | **Admin** | Full dashboard, mobile-ready | Config files |
+| **Plugins** | Community face packs, pages, workflows | None |
 | **Hosting** | Self-hosted, your data | Vendor cloud only |
 | **Pricing** | Free forever | Per-minute billing |
 
@@ -244,10 +262,9 @@ Access at **localhost:5001/admin**. Mobile-responsive.
 
 ## Extend It
 
-- **Build a skill** — Add capabilities without touching core code. See [`docs/`](docs/)
+- **Build a plugin** — Face packs, canvas pages, workflow dashboards, or any combination. See the [plugins repo](https://github.com/MCERQUA/openvoiceui-plugins) for examples and submission guidelines.
 - **Build a gateway plugin** — Connect any LLM provider. See [`plugins/README.md`](plugins/README.md)
 - **Build an adapter** — Add new STT/TTS providers. See [`src/adapters/_template.js`](src/adapters/_template.js)
-- **Build a face plugin** — Custom animated avatars. See the [BHB Animated Characters](https://github.com/MCERQUA/openvoiceui-plugins) plugin as a reference.
 
 ---
 
@@ -278,7 +295,7 @@ Access at **localhost:5001/admin**. Mobile-responsive.
 
 ## Contributing
 
-We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. This project is MIT licensed — fork it, build on it, make it yours.
+We welcome contributions — especially plugins. Build a face pack, a canvas page, a workflow dashboard, or a full extension and submit it to the [plugins repo](https://github.com/MCERQUA/openvoiceui-plugins). See [CONTRIBUTING.md](CONTRIBUTING.md) for code contribution guidelines. This project is MIT licensed — fork it, build on it, make it yours.
 
 ## License
 
@@ -290,5 +307,6 @@ We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
   <a href="https://openvoiceui.com">Website</a> &nbsp;&middot;&nbsp;
   <a href="https://github.com/MCERQUA/OpenVoiceUI">GitHub</a> &nbsp;&middot;&nbsp;
   <a href="https://www.npmjs.com/package/openvoiceui">npm</a> &nbsp;&middot;&nbsp;
+  <a href="https://github.com/MCERQUA/openvoiceui-plugins">Plugins</a> &nbsp;&middot;&nbsp;
   <a href="mailto:hello@openvoiceui.com">hello@openvoiceui.com</a>
 </p>


### PR DESCRIPTION
## Summary
- One-liner header: install, open localhost:5001, say "build me a dashboard"
- Separate code blocks per install method (Pinokio first with pinokio.co link, then npm, then Docker)
- Docker listed as prerequisite for ALL install methods
- Rewrote "What is OpenVoiceUI?" — positioned as hands-free AI-controlled computer, not a voice API
- Highlighted music generation, custom animated faces, voice-controlled app switching
- New Plugins section with BHB as first community plugin + link to plugins repo
- Updated comparison table (skills → any Claude Code/OpenClaw skill, added Music + Plugins rows)
- Contributing section encourages plugin submissions
- Added Plugins link to footer