### PR TITLE
fix: docs baseUrl for GitHub Pages

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -11,8 +11,8 @@ const config: Config = {
     v4: true,
   },
 
-  url: 'https://docs.openvoiceui.com',
-  baseUrl: '/',
+  url: 'https://mcerqua.github.io',
+  baseUrl: '/OpenVoiceUI/',
 
   organizationName: 'MCERQUA',
   projectName: 'OpenVoiceUI',


### PR DESCRIPTION
Sets baseUrl to /OpenVoiceUI/ — required for GitHub Pages project sites.