### PR TITLE
fix(suno): normalize action-tag whitespace + remove ghost-LLM completion flow

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -544,10 +544,32 @@ def _truncate_at_sentence(text: str, max_chars: int) -> str:
     return chunk.strip()
 
 
+def normalize_action_tags(text: str) -> str:
+    """Normalize whitespace inside action-tag brackets.
+
+    GLM sometimes emits `[ MUSIC_PLAY:Title ]` with stray whitespace after `[`
+    or around `:` / before `]`. Every downstream regex (TTS strip, frontend
+    tag extraction) requires a tight `[TAG:value]` form, so we collapse the
+    spaces here before any other processing runs.
+    """
+    if not text:
+        return text
+    text = re.sub(r'\[\s+', '[', text)
+    def _fix(m):
+        inner = m.group(1).strip()
+        inner = re.sub(r'\s*:\s*', ':', inner, count=1)
+        return f'[{inner}]'
+    text = re.sub(r'\[([A-Z][A-Z0-9_]*(?:\s*:[^\]]*)?)\]', _fix, text)
+    return text
+
+
 def clean_for_tts(text: str) -> str:
     """Remove markdown, reasoning tokens, and non-speech characters for TTS."""
     if not text:
         return ''
+
+    # Normalize sloppy tag whitespace FIRST so every strip regex below matches.
+    text = normalize_action_tags(text)
 
     # Strip GPT-OSS-120B reasoning tokens (but not if NO/YES is the full response)
     if text.strip().upper() not in ['NO', 'YES', 'NO.', 'YES.']:
@@ -1089,15 +1111,35 @@ def _conversation_inner():
                 'A new voice session has just started. Give a brief, friendly one-sentence greeting. '
                 'Do NOT address anyone by name — no face has been recognized and you do not know who is speaking.'
             )
-    elif user_message.startswith('__suno_complete__:'):
-        _song_title = user_message[len('__suno_complete__:'):].strip() or 'your track'
-        _gateway_message = (
-            f'The Suno song "{_song_title}" just finished generating and is now ready in the music player. '
-            f'Let the user know in one brief, friendly sentence and offer to play it for them.'
-        )
     else:
         _gateway_message = user_message
-    message_with_context = context_prefix + _gateway_message if context_prefix else _gateway_message
+
+    # Suno completion → inject as [SYSTEM] prefix on the NEXT real user turn so
+    # the agent sees the event in the same conversation turn as the user's reply.
+    # This replaces the old ghost-LLM `__suno_complete__` path that left the main
+    # session without context when the user said "yeah" to play the song.
+    _suno_prefix = ''
+    if user_message not in ('__session_start__',):
+        try:
+            from routes.suno import completed_songs_queue as _suno_q
+            if _suno_q:
+                _pending_titles = [s.get('title', 'Unknown Track') for s in list(_suno_q)]
+                if _pending_titles:
+                    _titles_str = ', '.join(f'"{t}"' for t in _pending_titles)
+                    _play_tag = _pending_titles[0]  # most recent — what "yeah/play it" refers to
+                    _suno_prefix = (
+                        f'[SYSTEM: Suno just finished generating {_titles_str} and they are now '
+                        f'loaded in the Generated playlist. If the user is asking to play the song '
+                        f'(e.g. "yeah", "play it", "let\'s hear it"), confirm briefly and emit '
+                        f'[MUSIC_PLAY:{_play_tag}] in your response.]\n\n'
+                    )
+                    # Pop so the note only fires on the turn immediately after completion.
+                    _suno_q.clear()
+        except Exception as _e:
+            logger.warning(f'Suno pending-note injection failed: {_e}')
+
+    _gateway_message_with_suno = _suno_prefix + _gateway_message if _suno_prefix else _gateway_message
+    message_with_context = context_prefix + _gateway_message_with_suno if context_prefix else _gateway_message_with_suno
     ai_response = None
     captured_actions = []
 
@@ -1470,6 +1512,8 @@ def _conversation_inner():
                                 evt['response'] = "One moment, still working on that."
                                 metrics['fallback_used'] = 1
                             full_response = evt.get('response')
+                            if full_response:
+                                full_response = normalize_action_tags(full_response)
                             if full_response and max_response_chars:
                                 full_response = _truncate_at_sentence(full_response, max_response_chars)
 
@@ -1843,6 +1887,8 @@ def _conversation_inner():
                     evt = event_queue.get_nowait()
                     if evt['type'] == 'text_done':
                         ai_response = evt.get('response')
+                        if ai_response:
+                            ai_response = normalize_action_tags(ai_response)
                     elif evt['type'] == 'handshake':
                         metrics['handshake_ms'] = evt['ms']
                 metrics['llm_inference_ms'] = int((time.time() - t_llm_start) * 1000)

--- a/src/app.js
+++ b/src/app.js
@@ -1581,42 +1581,29 @@ initUpdateChecker();
             },
 
             async _notifyAgent(title) {
+                // Plays a canned TTS announcement only — no ghost LLM call.
+                // The server-side `completed_songs_queue` already has the event; on the
+                // NEXT real user turn, conversation.py injects it as a [SYSTEM] prefix so
+                // the agent has full context when the user says "yeah" / "play it".
+                const line = `Your song "${title}" is ready. Just say play it to hear it.`;
+                TranscriptPanel?.addMessage('system', `🎵 ${line}`);
+                ActionConsole?.addEntry('system', `🎵 Song ready: "${title}"`);
                 try {
                     const provider = window.voiceAgent?.selectedProvider || 'groq';
                     const voice = window.voiceAgent?.currentVoice || 'autumn';
-                    const sessionId = window._activeSessionId || `suno-${Date.now()}`;
-
-                    const resp = await fetch(`${CONFIG.serverUrl}/api/conversation`, {
+                    const resp = await fetch(`${CONFIG.serverUrl}/api/tts/generate`, {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({
-                            message: `__suno_complete__:${title}`,
-                            tts_provider: provider,
-                            voice: voice,
-                            session_id: sessionId,
-                            ui_context: {},
-                        }),
+                        body: JSON.stringify({ text: line, provider, voice }),
                     });
-                    if (!resp.ok) throw new Error('notify failed');
-                    const data = await resp.json();
-
-                    if (data.response) {
-                        TranscriptPanel?.addMessage('assistant', data.response);
-                        ActionConsole?.addEntry('system', `🎵 Agent: ${data.response.substring(0, 80)}`);
-                    }
-                    if (data.audio) {
-                        const binary = atob(data.audio);
-                        const bytes = new Uint8Array(binary.length);
-                        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-                        const blob = new Blob([bytes], { type: 'audio/mpeg' });
-                        const url = URL.createObjectURL(blob);
-                        const audio = new Audio(url);
-                        audio.onended = () => URL.revokeObjectURL(url);
-                        audio.play().catch(() => {});
-                    }
+                    if (!resp.ok) throw new Error(`tts ${resp.status}`);
+                    const blob = await resp.blob();
+                    const url = URL.createObjectURL(blob);
+                    const audio = new Audio(url);
+                    audio.onended = () => URL.revokeObjectURL(url);
+                    audio.play().catch(() => {});
                 } catch (e) {
-                    console.warn('[Suno] Agent notify failed, falling back to TTS:', e);
-                    this._speakCompletion(title);
+                    console.warn('[Suno] announce TTS failed:', e);
                 }
             },
         };
@@ -3694,8 +3681,18 @@ initUpdateChecker();
                     const escapeHtml = (str) => str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 
                     // Helper: strip canvas and music tags from display text
-                    const stripCanvasTags = (text) => {
+                    // Normalize sloppy `[ TAG:val ]` → `[TAG:val]` before any tag regex runs.
+                    // GLM sometimes emits stray whitespace that defeats every downstream
+                    // match (display strip + MUSIC_PLAY extract + canvas open).
+                    const normalizeActionTags = (text) => {
+                        if (!text) return text;
                         return text
+                            .replace(/\[\s+/g, '[')
+                            .replace(/\[([A-Z][A-Z0-9_]*)\s*:\s*([^\]]*?)\s*\]/g, '[$1:$2]')
+                            .replace(/\[([A-Z][A-Z0-9_]*)\s*\]/g, '[$1]');
+                    };
+                    const stripCanvasTags = (text) => {
+                        return normalizeActionTags(text)
                             .replace(/```html[\s\S]*?```/gi, '')  // complete html fences
                             .replace(/```[\s\S]*?```/g, '')        // complete generic fences
                             .replace(/```html[\s\S]*/gi, '')       // unclosed html fence (streaming)
@@ -3718,6 +3715,7 @@ initUpdateChecker();
 
                     // Helper: check for canvas/music commands in accumulated text
                     const checkCanvasInStream = async (text) => {
+                        text = normalizeActionTags(text);
                         // Check for [CANVAS_MENU]
                         if (/\[CANVAS_MENU\]/i.test(text) && !canvasCommandsProcessed.has('CANVAS_MENU')) {
                             canvasCommandsProcessed.add('CANVAS_MENU');


### PR DESCRIPTION
## Summary
Two related bugs in the Suno song-generation flow, both universal (affect every instance with a Suno key, not JamBot-specific):

### 1. Ghost-LLM completion announcement broke context
When a Suno song finished, the frontend fired a **separate** \`/api/conversation\` call with the sentinel \`__suno_complete__:<title>\`. This produced an agent response that was isolated from the main voice session — when the user replied "yeah" / "play it", the agent had no memory of the song announcement and hung.

**Fix:** Pending-context pattern.
- \`conversation.py\` checks \`completed_songs_queue\` at the start of every real user turn and prepends a \`[SYSTEM: Suno just finished ...]\` prefix directly to the gateway message, then pops the queue so it only fires once.
- \`_notifyAgent()\` no longer hits \`/api/conversation\`. It plays a canned TTS announcement via \`/api/tts/generate\`.
- The song event and the user's reply now reach the agent in the same atomic turn.

### 2. Sloppy tag whitespace broke every downstream regex
GLM occasionally emits \`[ MUSIC_PLAY:Title ]\` with stray whitespace after \`[\` or around \`:\`. Every tag regex (TTS strip, display strip, MUSIC_PLAY extract, CANVAS open) required a tight \`[TAG:value]\` form — so the tag got spoken literally AND failed to trigger the music player.

**Fix:** New \`normalize_action_tags()\` (Python) + \`normalizeActionTags()\` (JS) that collapse \`[ TAG : value ]\` → \`[TAG:value]\`, running upstream of all tag processing:
- **Python:** start of \`clean_for_tts()\`, and on \`full_response\` / \`ai_response\` before returning to frontend.
- **JS:** start of \`stripCanvasTags()\` and \`checkCanvasInStream()\`.