### PR TITLE
feat(vault): Phase 1.5 — credential vault writes reach agents + opt-in OAuth + Platform Setup UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,7 @@ profiles/*
 !profiles/manager.py
 !profiles/schema.json
 app/static/canvas-pages/
+
+# Phase 1.5: platform OAuth credentials — operator-supplied secrets,
+# never committed. The committed template is .platform-oauth.env.example.
+.platform-oauth.env

--- a/.platform-oauth.env.example
+++ b/.platform-oauth.env.example
@@ -1,0 +1,80 @@
+# =============================================================================
+# Platform OAuth credentials — OPTIONAL
+# =============================================================================
+#
+# This file holds your OAuth APP credentials (client_id + client_secret).
+# These are PLATFORM-LEVEL credentials registered ONCE by you, the operator,
+# and shared by ALL clients on this OpenVoiceUI instance.
+#
+# When a client clicks "Connect Google Business" in the Connections page,
+# Google asks the CLIENT to log in with their own Google account and grant
+# access to YOUR app — not yours. The client's tokens are stored per-client
+# in /mnt/clients/<client>/vault/oauth/<provider>.json.
+#
+# OAuth is OPTIONAL. If you don't fill anything in here, OAuth providers
+# will appear as "Not configured" in the Connections page (grayed out cards
+# with a "setup needed" message). Everything else still works without OAuth.
+# Casual single-tenant users can ignore this file entirely.
+#
+# To enable a provider:
+#   1. Register an OAuth app in the provider's developer console (links below)
+#   2. Add your client redirect URIs (run scripts/jambot-generate-redirect-uris.sh)
+#   3. Copy the client_id and client_secret below
+#   4. Restart the openvoiceui container so it picks up the new env vars
+#
+# Setup helper (interactive): bash scripts/jambot-setup-platform-oauth.sh
+# Documentation:               docs/jambot/platform-oauth-setup.md
+#
+# This file is NOT in git. The committed template is .platform-oauth.env.example.
+# Permissions should be 640 mike:openvoiceui (chmod 640 + chown mike:openvoiceui)
+# =============================================================================
+
+# ─── Google ──────────────────────────────────────────────────────────────────
+# Covers: Google Business Profile, Google Analytics, Search Console, Gmail
+# Console: https://console.cloud.google.com/apis/credentials
+# How to set up:
+#   1. Create project: https://console.cloud.google.com/projectcreate
+#   2. Enable APIs: Business Profile API, Analytics Data API,
+#      Search Console API, Gmail API (whichever your clients need)
+#   3. OAuth consent screen → External → fill in app name, support email
+#   4. Credentials → Create OAuth 2.0 Client ID → Web application
+#   5. Authorized redirect URIs: paste output of
+#      `bash scripts/jambot-generate-redirect-uris.sh google`
+#   6. Copy Client ID and Client Secret below
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+
+# ─── Facebook / Meta ─────────────────────────────────────────────────────────
+# Covers: Facebook Pages, Instagram Business
+# Console: https://developers.facebook.com/apps
+# How to set up:
+#   1. Create App → Business type → name it (e.g. "JamBot")
+#   2. Add Products: Facebook Login, Instagram Basic Display
+#   3. Settings → Basic → copy App ID and App Secret
+#   4. Facebook Login → Settings → Valid OAuth Redirect URIs:
+#      paste output of `bash scripts/jambot-generate-redirect-uris.sh facebook`
+FACEBOOK_OAUTH_APP_ID=
+FACEBOOK_OAUTH_APP_SECRET=
+
+# ─── QuickBooks Online ───────────────────────────────────────────────────────
+# Covers: invoices, payments, customers, accounting
+# Console: https://developer.intuit.com/app/developer/dashboard
+# How to set up:
+#   1. Create App → choose APIs you want (Accounting API at minimum)
+#   2. Keys & OAuth → copy Client ID and Client Secret (production keys)
+#   3. Redirect URIs: paste output of
+#      `bash scripts/jambot-generate-redirect-uris.sh quickbooks`
+QUICKBOOKS_OAUTH_CLIENT_ID=
+QUICKBOOKS_OAUTH_CLIENT_SECRET=
+
+# ─── LinkedIn ────────────────────────────────────────────────────────────────
+# Covers: posting to LinkedIn pages, company updates
+# Console: https://www.linkedin.com/developers/apps
+# How to set up:
+#   1. Create app → fill in company info, logo, terms of service URL
+#   2. Auth tab → copy Client ID and Client Secret
+#   3. Authorized redirect URLs: paste output of
+#      `bash scripts/jambot-generate-redirect-uris.sh linkedin`
+#   4. Products tab → request "Sign In with LinkedIn" + "Share on LinkedIn"
+LINKEDIN_OAUTH_CLIENT_ID=
+LINKEDIN_OAUTH_CLIENT_SECRET=

--- a/.platform-oauth.env.example
+++ b/.platform-oauth.env.example
@@ -56,16 +56,17 @@ GOOGLE_OAUTH_CLIENT_SECRET=
 FACEBOOK_OAUTH_APP_ID=
 FACEBOOK_OAUTH_APP_SECRET=
 
-# ─── QuickBooks Online ───────────────────────────────────────────────────────
+# ─── QuickBooks (Intuit) ─────────────────────────────────────────────────────
 # Covers: invoices, payments, customers, accounting
 # Console: https://developer.intuit.com/app/developer/dashboard
 # How to set up:
 #   1. Create App → choose APIs you want (Accounting API at minimum)
 #   2. Keys & OAuth → copy Client ID and Client Secret (production keys)
 #   3. Redirect URIs: paste output of
-#      `bash scripts/jambot-generate-redirect-uris.sh quickbooks`
-QUICKBOOKS_OAUTH_CLIENT_ID=
-QUICKBOOKS_OAUTH_CLIENT_SECRET=
+#      `bash scripts/jambot-generate-redirect-uris.sh intuit`
+# Note: Catalog uses provider name "intuit", so env var uses INTUIT_*
+INTUIT_OAUTH_CLIENT_ID=
+INTUIT_OAUTH_CLIENT_SECRET=
 
 # ─── LinkedIn ────────────────────────────────────────────────────────────────
 # Covers: posting to LinkedIn pages, company updates

--- a/plugins/hermes-agent/plugin.json
+++ b/plugins/hermes-agent/plugin.json
@@ -10,7 +10,297 @@
   "provides": "gateway",
   "gateway_class": "HermesGateway",
   "hermes_version": "0.6.0",
-  "requires_env": ["HERMES_HOST"],
+  "requires_env": [
+    "HERMES_HOST"
+  ],
+  "lifecycle": {
+    "post_install": {
+      "requires_container": true,
+      "provision": "hermes"
+    },
+    "pre_uninstall": {
+      "deprovision": "hermes"
+    }
+  },
+  "install_config": {
+    "sections": [
+      {
+        "title": "Hermes Agent Configuration",
+        "description": "Hermes supports 14 inference providers. Fill in API keys for the ones you want to use \u2014 you need at least one for the agent to work. The Default Provider picks which one Hermes uses first; the others become fallbacks. All fields can be updated later from the Connections page.",
+        "fields": [
+          {
+            "id": "default_provider",
+            "label": "Default Provider",
+            "type": "select",
+            "required": true,
+            "options": [
+              {
+                "value": "auto",
+                "label": "Auto-detect (use any available)"
+              },
+              {
+                "value": "openrouter",
+                "label": "OpenRouter (access 200+ models)"
+              },
+              {
+                "value": "anthropic",
+                "label": "Anthropic Claude"
+              },
+              {
+                "value": "minimax",
+                "label": "MiniMax (global)"
+              },
+              {
+                "value": "minimax-cn",
+                "label": "MiniMax (China)"
+              },
+              {
+                "value": "zai",
+                "label": "Z.AI / ZhipuAI GLM"
+              },
+              {
+                "value": "kimi-coding",
+                "label": "Kimi (Moonshot)"
+              },
+              {
+                "value": "huggingface",
+                "label": "HuggingFace Inference"
+              },
+              {
+                "value": "copilot",
+                "label": "GitHub Copilot"
+              },
+              {
+                "value": "kilocode",
+                "label": "KiloCode gateway"
+              },
+              {
+                "value": "ai-gateway",
+                "label": "Vercel AI Gateway"
+              },
+              {
+                "value": "nous-api",
+                "label": "Nous Portal (API key)"
+              },
+              {
+                "value": "custom",
+                "label": "Custom local (LM Studio / Ollama / vLLM)"
+              }
+            ]
+          },
+          {
+            "id": "openrouter_api_key",
+            "label": "OpenRouter API Key",
+            "type": "password",
+            "docs_url": "https://openrouter.ai/keys"
+          },
+          {
+            "id": "anthropic_api_key",
+            "label": "Anthropic API Key",
+            "type": "password",
+            "docs_url": "https://console.anthropic.com/settings/keys"
+          },
+          {
+            "id": "minimax_api_key",
+            "label": "MiniMax API Key",
+            "type": "password",
+            "docs_url": "https://www.minimax.io/"
+          },
+          {
+            "id": "minimax_cn_api_key",
+            "label": "MiniMax China API Key",
+            "type": "password",
+            "docs_url": "https://platform.minimaxi.com/"
+          },
+          {
+            "id": "glm_api_key",
+            "label": "Z.AI / GLM API Key",
+            "type": "password",
+            "docs_url": "https://z.ai/"
+          },
+          {
+            "id": "kimi_api_key",
+            "label": "Kimi (Moonshot) API Key",
+            "type": "password",
+            "docs_url": "https://platform.moonshot.cn/console/api-keys"
+          },
+          {
+            "id": "hf_token",
+            "label": "HuggingFace Token",
+            "type": "password",
+            "docs_url": "https://huggingface.co/settings/tokens"
+          },
+          {
+            "id": "github_token",
+            "label": "GitHub Token (for Copilot)",
+            "type": "password",
+            "docs_url": "https://github.com/settings/tokens"
+          },
+          {
+            "id": "kilocode_api_key",
+            "label": "KiloCode API Key",
+            "type": "password",
+            "docs_url": "https://kilocode.ai/"
+          },
+          {
+            "id": "ai_gateway_api_key",
+            "label": "Vercel AI Gateway Key",
+            "type": "password",
+            "docs_url": "https://vercel.com/docs/ai-gateway"
+          },
+          {
+            "id": "nous_api_key",
+            "label": "Nous Portal API Key",
+            "type": "password",
+            "docs_url": "https://portal.nousresearch.com/"
+          },
+          {
+            "id": "custom_base_url",
+            "label": "Custom Endpoint URL (for local servers)",
+            "type": "text",
+            "placeholder": "http://host.docker.internal:1234/v1",
+            "docs_url": "https://lmstudio.ai/docs/local-server"
+          }
+        ]
+      }
+    ]
+  },
+  "credentials": [
+    {
+      "id": "openrouter",
+      "name": "OpenRouter",
+      "description": "Access 200+ models through one API key",
+      "type": "api_key",
+      "group": "LLM Providers",
+      "env_var": "OPENROUTER_API_KEY",
+      "docs_url": "https://openrouter.ai/keys",
+      "test": {
+        "url": "https://openrouter.ai/api/v1/models",
+        "method": "GET",
+        "auth_header": "Authorization",
+        "auth_prefix": "Bearer "
+      },
+      "consumers": {
+        "hermes": {
+          "type": "env_file",
+          "env_var": "OPENROUTER_API_KEY"
+        }
+      }
+    },
+    {
+      "id": "minimax",
+      "extend": true,
+      "consumers": {
+        "hermes": {
+          "type": "env_file",
+          "env_var": "MINIMAX_API_KEY"
+        }
+      }
+    },
+    {
+      "id": "minimax_cn",
+      "name": "MiniMax China",
+      "description": "MiniMax China (minimaxi.com) inference API",
+      "type": "api_key",
+      "group": "LLM Providers",
+      "env_var": "MINIMAX_CN_API_KEY",
+      "docs_url": "https://platform.minimaxi.com/",
+      "consumers": {
+        "hermes": {
+          "type": "env_file",
+          "env_var": "MINIMAX_CN_API_KEY"
+        }
+      }
+    },
+    {
+      "id": "anthropic",
+      "extend": true,
+      "consumers": {
+        "hermes": {
+          "type": "env_file",
+          "env_var": "ANTHROPIC_API_KEY"
+        }
+      }
+    },
+    {
+      "id": "zai",
+      "extend": true,
+      "consumers": {
+        "hermes": {
+          "type": "env_file",
+          "env_var": "GLM_API_KEY",
+          "also_set": {
+            "GLM_BASE_URL": "https://api.z.ai/api/paas/v4"
+          }
+        }
+      }
+    },
+    {
+      "id": "huggingface",
+      "extend": true,
+      "consumers": {
+        "hermes": {
+          "type": "env_file",
+          "env_var": "HF_TOKEN"
+        }
+      }
+    },
+    {
+      "id": "kimi",
+      "extend": true,
+      "consumers": {
+        "hermes": {
+          "type": "env_file",
+          "env_var": "KIMI_API_KEY"
+        }
+      }
+    },
+    {
+      "id": "nous_api",
+      "name": "Nous Portal",
+      "description": "Nous Research Portal API key (for Hermes backend)",
+      "type": "api_key",
+      "group": "LLM Providers",
+      "env_var": "NOUS_API_KEY",
+      "docs_url": "https://portal.nousresearch.com/",
+      "consumers": {
+        "hermes": {
+          "type": "env_file",
+          "env_var": "NOUS_API_KEY"
+        }
+      }
+    },
+    {
+      "id": "kilocode",
+      "name": "KiloCode",
+      "description": "KiloCode AI gateway",
+      "type": "api_key",
+      "group": "LLM Providers",
+      "env_var": "KILOCODE_API_KEY",
+      "docs_url": "https://kilocode.ai/",
+      "consumers": {
+        "hermes": {
+          "type": "env_file",
+          "env_var": "KILOCODE_API_KEY"
+        }
+      }
+    },
+    {
+      "id": "ai_gateway",
+      "name": "Vercel AI Gateway",
+      "description": "Vercel's managed AI gateway \u2014 one endpoint, many providers",
+      "type": "api_key",
+      "group": "LLM Providers",
+      "env_var": "AI_GATEWAY_API_KEY",
+      "docs_url": "https://vercel.com/docs/ai-gateway",
+      "consumers": {
+        "hermes": {
+          "type": "env_file",
+          "env_var": "AI_GATEWAY_API_KEY"
+        }
+      }
+    }
+  ],
   "pages": [
     {
       "file": "pages/hermes.html",

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,10 @@ cryptography==46.0.6
 # deepface>=0.0.93
 # tf-keras>=2.19.0
 
+# Docker SDK — used by vault service to restart openclaw container after
+# credential writes so new keys take effect without manual intervention.
+docker>=7.1.0
+
 # AI providers (optional — not required, agents handle their own API calls)
 # google-generativeai==0.8.6  # Unused — remove if still commented on next cleanup
 

--- a/routes/vault.py
+++ b/routes/vault.py
@@ -276,6 +276,293 @@ def sync_one_endpoint(cred_id):
 
 
 # ---------------------------------------------------------------------------
+# Phase 1.5 Cycle C: Platform Setup
+#
+# These endpoints power the admin "Platform Setup" page where the operator
+# of a JamBot instance configures OAuth provider credentials (Google,
+# Facebook, etc.) once for all clients on the instance.
+#
+# The page is NOT role-gated — any admin can see it. The credentials live
+# in /mnt/system/base/.platform-oauth.env (chmod 640 mike:openvoiceui).
+# Saving via this endpoint writes the file and recreates the openvoiceui
+# container so the new env vars are loaded.
+# ---------------------------------------------------------------------------
+
+# Provider definitions — stable identifiers that group catalog credentials.
+# Each provider lists the env vars it needs and the catalog credentials it
+# enables. This is the source of truth for the Platform Setup page.
+_PLATFORM_PROVIDERS = [
+    {
+        'id': 'google',
+        'name': 'Google',
+        'description': 'Enables Google Business Profile, Google Analytics, Google Search Console, Gmail and other Google APIs.',
+        'console_url': 'https://console.cloud.google.com/apis/credentials',
+        'console_create_url': 'https://console.cloud.google.com/projectcreate',
+        'docs_url': 'https://developers.google.com/identity/protocols/oauth2',
+        'env_vars': {
+            'client_id': 'GOOGLE_OAUTH_CLIENT_ID',
+            'client_secret': 'GOOGLE_OAUTH_CLIENT_SECRET',
+        },
+        'enables_credentials': ['google_business', 'google_analytics', 'google_search_console'],
+        'setup_steps': [
+            'Create a Google Cloud project (free tier is fine).',
+            'Enable the APIs you want clients to use: Business Profile API, Analytics Data API, Search Console API.',
+            'Configure the OAuth consent screen (External, fill in app name + support email).',
+            'Create OAuth 2.0 Client ID → Web application.',
+            'Add the redirect URIs from this page to "Authorized redirect URIs".',
+            'Copy the Client ID and Client Secret below and click Save.',
+        ],
+    },
+    {
+        'id': 'facebook',
+        'name': 'Facebook / Meta',
+        'description': 'Enables Facebook Pages and Instagram Business posting.',
+        'console_url': 'https://developers.facebook.com/apps',
+        'console_create_url': 'https://developers.facebook.com/apps/create/',
+        'docs_url': 'https://developers.facebook.com/docs/facebook-login/',
+        'env_vars': {
+            'client_id': 'FACEBOOK_OAUTH_APP_ID',
+            'client_secret': 'FACEBOOK_OAUTH_APP_SECRET',
+        },
+        'enables_credentials': ['facebook', 'instagram'],
+        'setup_steps': [
+            'Go to developers.facebook.com → Create App → Business type.',
+            'Add Products: Facebook Login, Instagram Basic Display.',
+            'Settings → Basic → copy App ID and App Secret.',
+            'Facebook Login → Settings → paste redirect URIs from this page into "Valid OAuth Redirect URIs".',
+            'Save the credentials below.',
+        ],
+    },
+    {
+        'id': 'intuit',
+        'name': 'QuickBooks (Intuit)',
+        'description': 'Enables QuickBooks Online — invoices, payments, customers, accounting.',
+        'console_url': 'https://developer.intuit.com/app/developer/dashboard',
+        'console_create_url': 'https://developer.intuit.com/app/developer/dashboard',
+        'docs_url': 'https://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization',
+        'env_vars': {
+            'client_id': 'INTUIT_OAUTH_CLIENT_ID',
+            'client_secret': 'INTUIT_OAUTH_CLIENT_SECRET',
+        },
+        'enables_credentials': ['quickbooks'],
+        'setup_steps': [
+            'Sign in at developer.intuit.com and create a new App.',
+            'Choose APIs your clients need (Accounting API at minimum).',
+            'Keys & OAuth tab → copy production Client ID and Client Secret.',
+            'Add the redirect URIs from this page to "Redirect URIs".',
+            'Save the credentials below.',
+        ],
+    },
+    {
+        'id': 'linkedin',
+        'name': 'LinkedIn',
+        'description': 'Enables posting to LinkedIn pages and company updates.',
+        'console_url': 'https://www.linkedin.com/developers/apps',
+        'console_create_url': 'https://www.linkedin.com/developers/apps/new',
+        'docs_url': 'https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow',
+        'env_vars': {
+            'client_id': 'LINKEDIN_OAUTH_CLIENT_ID',
+            'client_secret': 'LINKEDIN_OAUTH_CLIENT_SECRET',
+        },
+        'enables_credentials': [],  # No catalog entry yet
+        'setup_steps': [
+            'Sign in to LinkedIn Developer Portal and create an app.',
+            'Fill in company info, logo, and terms-of-service URL.',
+            'Auth tab → copy Client ID and Client Secret.',
+            'Add the redirect URIs from this page.',
+            'Products tab → request Sign In with LinkedIn + Share on LinkedIn.',
+        ],
+    },
+]
+
+
+def _platform_oauth_env_path():
+    """Return the path to .platform-oauth.env using the same resolution
+    logic as services/vault.py."""
+    from services.vault import _PLATFORM_OAUTH_ENV
+    return _PLATFORM_OAUTH_ENV
+
+
+def _read_platform_oauth_env() -> dict:
+    """Parse .platform-oauth.env into a dict. Empty/missing → {}."""
+    path = _platform_oauth_env_path()
+    result = {}
+    if not path.is_file():
+        return result
+    try:
+        for raw in path.read_text().splitlines():
+            line = raw.strip()
+            if not line or line.startswith('#') or '=' not in line:
+                continue
+            k, v = line.split('=', 1)
+            result[k.strip()] = v.strip().strip('"').strip("'")
+    except Exception as exc:
+        logger.error(f"Cannot read platform-oauth env: {exc}")
+    return result
+
+
+def _write_platform_oauth_env(updates: dict) -> bool:
+    """Update .platform-oauth.env with the given key/value pairs.
+    Preserves comments, blank lines, and ordering. Atomic write.
+    Returns True on success.
+    """
+    from services.vault import _update_env_file
+    path = _platform_oauth_env_path()
+    if not path.is_file():
+        # Create from template if missing
+        try:
+            template = path.parent / 'OpenVoiceUI' / '.platform-oauth.env.example'
+            if template.is_file():
+                path.write_text(template.read_text())
+            else:
+                # Minimal seed
+                seed = '# Platform OAuth credentials — see .platform-oauth.env.example for full template\n'
+                seed += '\n'.join(f'{k}=' for k in updates.keys()) + '\n'
+                path.write_text(seed)
+        except Exception as exc:
+            logger.error(f"Cannot create platform-oauth env: {exc}")
+            return False
+    return _update_env_file(path, updates)
+
+
+def _redirect_uris_for_provider(provider_id: str) -> list[str]:
+    """Build the redirect URI list for a provider, one per live client.
+    Reads /mnt/system/base/registry.json if available, falls back to
+    listing /mnt/clients/<user> dirs."""
+    import os
+    from pathlib import Path
+    registry_path = Path('/mnt/system/base/registry.json')
+    domains = []
+    if registry_path.is_file():
+        try:
+            with open(registry_path) as f:
+                reg = json.load(f)
+            for u in reg.get('users', []):
+                d = u.get('domain', '').strip()
+                if d:
+                    domains.append(d)
+        except Exception:
+            pass
+    if not domains:
+        clients_dir = Path('/mnt/clients')
+        if clients_dir.is_dir():
+            for child in sorted(clients_dir.iterdir()):
+                if child.is_dir():
+                    domains.append(f'{child.name}.jam-bot.com')
+    return [f'https://{d}/api/vault/oauth/callback/{provider_id}' for d in sorted(domains)]
+
+
+@vault_bp.route('/api/vault/platform-setup', methods=['GET'])
+def platform_setup_get():
+    """Return the current Platform Setup state — list of OAuth providers
+    with configuration status, env vars, and redirect URIs."""
+    env = _read_platform_oauth_env()
+
+    providers_out = []
+    for p in _PLATFORM_PROVIDERS:
+        cid_var = p['env_vars']['client_id']
+        csec_var = p['env_vars']['client_secret']
+        cid_val = env.get(cid_var, '').strip()
+        csec_val = env.get(csec_var, '').strip()
+        configured = bool(cid_val and csec_val)
+        # Mask secret for display, leave client_id visible
+        masked_secret = ''
+        if csec_val:
+            if len(csec_val) >= 12:
+                masked_secret = csec_val[:4] + '...' + csec_val[-4:]
+            else:
+                masked_secret = '***'
+        providers_out.append({
+            'id': p['id'],
+            'name': p['name'],
+            'description': p['description'],
+            'console_url': p['console_url'],
+            'console_create_url': p.get('console_create_url', ''),
+            'docs_url': p.get('docs_url', ''),
+            'env_vars': p['env_vars'],
+            'enables_credentials': p['enables_credentials'],
+            'setup_steps': p['setup_steps'],
+            'configured': configured,
+            'client_id': cid_val,
+            'client_secret_masked': masked_secret,
+            'has_secret': bool(csec_val),
+            'redirect_uris': _redirect_uris_for_provider(p['id']),
+        })
+
+    return jsonify({
+        'providers': providers_out,
+        'env_file': str(_platform_oauth_env_path()),
+    })
+
+
+@vault_bp.route('/api/vault/platform-setup/<provider_id>', methods=['PUT'])
+def platform_setup_put(provider_id):
+    """Update an OAuth provider's client_id and client_secret. Body:
+    {"client_id": "...", "client_secret": "..."}.
+    Empty string clears the value.
+
+    No container recreate needed: .platform-oauth.env is only consumed by the
+    openvoiceui Python process via os.environ. We update os.environ directly
+    in the running process so the new values are live immediately. The file
+    is also updated so the values persist across container restarts.
+    """
+    import os as _os
+    p = next((x for x in _PLATFORM_PROVIDERS if x['id'] == provider_id), None)
+    if not p:
+        return jsonify({'error': f'Unknown provider {provider_id}'}), 400
+
+    data = request.get_json(silent=True) or {}
+    cid = data.get('client_id', '').strip()
+    csec = data.get('client_secret', '').strip()
+
+    # Reject masked values
+    if csec.startswith('***') or '...' in csec:
+        return jsonify({'ok': True, 'message': 'No change (masked secret)'})
+
+    updates = {
+        p['env_vars']['client_id']: cid,
+        p['env_vars']['client_secret']: csec,
+    }
+    if not _write_platform_oauth_env(updates):
+        return jsonify({'error': 'Failed to write platform-oauth env file'}), 500
+
+    # Update os.environ in the running process so the new values are live
+    # immediately. No container restart, no debounce, no rename collision.
+    for k, v in updates.items():
+        if v:
+            _os.environ[k] = v
+        else:
+            _os.environ.pop(k, None)
+
+    return jsonify({
+        'ok': True,
+        'message': f'{p["name"]} OAuth credentials saved and live.',
+        'provider': provider_id,
+        'restarting': [],
+        'eta_seconds': 0,
+    })
+
+
+@vault_bp.route('/api/vault/platform-setup/<provider_id>', methods=['DELETE'])
+def platform_setup_delete(provider_id):
+    """Clear an OAuth provider's credentials."""
+    import os as _os
+    p = next((x for x in _PLATFORM_PROVIDERS if x['id'] == provider_id), None)
+    if not p:
+        return jsonify({'error': f'Unknown provider {provider_id}'}), 400
+    updates = {
+        p['env_vars']['client_id']: '',
+        p['env_vars']['client_secret']: '',
+    }
+    if not _write_platform_oauth_env(updates):
+        return jsonify({'error': 'Failed to write platform-oauth env file'}), 500
+    # Live update — no restart needed
+    for k in updates.keys():
+        _os.environ.pop(k, None)
+    return jsonify({'ok': True, 'message': f'{p["name"]} OAuth credentials cleared.'})
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/routes/vault.py
+++ b/routes/vault.py
@@ -1,0 +1,281 @@
+"""
+Vault API — credential management, OAuth flows, sync, and testing.
+
+Replaces the old /api/admin/ai-config endpoints with a dynamic,
+plugin-aware credential system.
+"""
+import json
+import logging
+import os
+
+from flask import Blueprint, jsonify, request
+
+logger = logging.getLogger(__name__)
+
+vault_bp = Blueprint('vault', __name__)
+
+
+def _get_username() -> str:
+    """
+    Determine the current client username.
+    In multi-tenant JamBot, this comes from the DOMAIN env var (e.g., nick.jam-bot.com → nick).
+    In single-user mode, defaults to 'default'.
+    """
+    domain = os.getenv('DOMAIN', '')
+    if domain and '.jam-bot.com' in domain:
+        return domain.split('.')[0]
+    return os.getenv('VAULT_USERNAME', 'default')
+
+
+# ---------------------------------------------------------------------------
+# Credential CRUD
+# ---------------------------------------------------------------------------
+
+@vault_bp.route('/api/vault/credentials', methods=['GET'])
+def list_credentials():
+    """
+    List all credentials with status — merged from platform catalog + installed plugins.
+    Grouped by credential group, includes has_value/masked_value/consumers.
+    """
+    from services.vault import get_credentials_status, get_current_model_selection, get_available_models
+    username = _get_username()
+    creds = get_credentials_status(username)
+    models = get_available_models(username)
+    model_sel = get_current_model_selection(username)
+
+    # Group credentials
+    groups = {}
+    for c in creds:
+        g = c['group']
+        groups.setdefault(g, []).append(c)
+
+    # Stable group ordering
+    group_order = ['LLM Providers', 'Voice', 'Services', 'Platform', 'Connections', 'Custom']
+    ordered_groups = []
+    for g in group_order:
+        if g in groups:
+            ordered_groups.append({'name': g, 'credentials': groups.pop(g)})
+    # Remaining groups (from plugins, etc.)
+    for g, clist in groups.items():
+        ordered_groups.append({'name': g, 'credentials': clist})
+
+    return jsonify({
+        'groups': ordered_groups,
+        'models': models,
+        'model_selection': model_sel,
+    })
+
+
+@vault_bp.route('/api/vault/credentials/<cred_id>', methods=['PUT'])
+def update_credential(cred_id):
+    """
+    Set/update a credential value.
+
+    Body for single-key: {"value": "sk-..."}
+    Body for multi-field: {"fields": {"login": "...", "password": "..."}}
+    Body for model selection: {"primary": "mx/Model", "fallback": "zai/glm-5-turbo"}
+    """
+    from services.vault import (
+        set_credential, get_catalog_credential, get_merged_catalog,
+        set_model_selection, ensure_vault
+    )
+    username = _get_username()
+    ensure_vault(username)
+    data = request.get_json(silent=True) or {}
+
+    # Handle model selection update
+    if cred_id == '_model_selection':
+        set_model_selection(
+            username,
+            primary=data.get('primary'),
+            fallback=data.get('fallback'),
+        )
+        return jsonify({'ok': True, 'message': 'Model selection updated'})
+
+    value = data.get('value')
+    fields = data.get('fields')
+
+    # Don't accept masked values as updates
+    if value and value.startswith('***'):
+        return jsonify({'ok': True, 'message': 'No change (masked value)'})
+    if fields:
+        fields = {k: v for k, v in fields.items() if not str(v).startswith('***')}
+        if not fields:
+            return jsonify({'ok': True, 'message': 'No change (masked values)'})
+
+    set_credential(username, cred_id, value=value, fields=fields)
+    return jsonify({'ok': True, 'message': f'Credential {cred_id} updated and synced'})
+
+
+@vault_bp.route('/api/vault/credentials', methods=['POST'])
+def add_credential():
+    """
+    Add a custom credential not in any catalog.
+
+    Body: {"name": "My API", "env_var": "MY_API_KEY", "value": "...", "group": "Custom"}
+    """
+    from services.vault import add_custom_credential, ensure_vault
+    username = _get_username()
+    ensure_vault(username)
+    data = request.get_json(silent=True) or {}
+
+    name = data.get('name', '').strip()
+    env_var = data.get('env_var', '').strip()
+    value = data.get('value', '').strip()
+    group = data.get('group', 'Custom')
+
+    if not name or not env_var:
+        return jsonify({'error': 'name and env_var are required'}), 400
+
+    cred_id = add_custom_credential(username, name, env_var, value, group)
+    return jsonify({'ok': True, 'id': cred_id, 'message': f'Custom credential "{name}" added'})
+
+
+@vault_bp.route('/api/vault/credentials/<cred_id>', methods=['DELETE'])
+def remove_credential(cred_id):
+    """Delete a custom credential. Only works for user-added custom credentials."""
+    from services.vault import delete_credential, read_vault
+    username = _get_username()
+    vault = read_vault(username)
+    entry = vault.get('credentials', {}).get(cred_id, {})
+
+    if not entry.get('custom'):
+        return jsonify({'error': 'Can only delete custom credentials'}), 400
+
+    delete_credential(username, cred_id)
+    return jsonify({'ok': True, 'message': f'Credential {cred_id} removed'})
+
+
+# ---------------------------------------------------------------------------
+# Credential testing
+# ---------------------------------------------------------------------------
+
+@vault_bp.route('/api/vault/credentials/<cred_id>/test', methods=['POST'])
+def test_credential_endpoint(cred_id):
+    """Test a credential by hitting the provider's test endpoint."""
+    from services.vault import test_credential
+    username = _get_username()
+    result = test_credential(username, cred_id)
+    return jsonify(result)
+
+
+# ---------------------------------------------------------------------------
+# OAuth flows
+# ---------------------------------------------------------------------------
+
+@vault_bp.route('/api/vault/oauth/<cred_id>/connect', methods=['GET'])
+def oauth_connect(cred_id):
+    """
+    Start an OAuth flow. Returns the authorization URL to redirect the user to.
+    """
+    from services.vault import build_oauth_url
+    username = _get_username()
+    domain = os.getenv('DOMAIN', 'localhost')
+
+    url = build_oauth_url(cred_id, username, domain)
+    if not url:
+        return jsonify({'error': 'OAuth not configured for this credential'}), 400
+
+    return jsonify({'url': url})
+
+
+@vault_bp.route('/api/vault/oauth/callback/<provider>', methods=['GET'])
+def oauth_callback(provider):
+    """
+    OAuth callback — exchange auth code for tokens.
+    This endpoint is hit by the OAuth provider after user consent.
+    Returns HTML that closes the popup and notifies the parent window.
+    """
+    from services.vault import exchange_oauth_code
+
+    code = request.args.get('code', '')
+    state_raw = request.args.get('state', '{}')
+    error = request.args.get('error', '')
+
+    if error:
+        return _oauth_callback_html(False, f'OAuth error: {error}')
+
+    if not code:
+        return _oauth_callback_html(False, 'No authorization code received')
+
+    try:
+        state = json.loads(state_raw)
+    except json.JSONDecodeError:
+        state = {}
+
+    cred_id = state.get('cred_id', provider)
+    username = state.get('username', '')
+
+    if not username:
+        return _oauth_callback_html(False, 'Missing username in state')
+
+    result = exchange_oauth_code(cred_id, code, username)
+
+    if result.get('ok'):
+        return _oauth_callback_html(True, result.get('account', 'Connected'))
+    else:
+        return _oauth_callback_html(False, result.get('error', 'Unknown error'))
+
+
+@vault_bp.route('/api/vault/oauth/<cred_id>/disconnect', methods=['POST'])
+def oauth_disconnect(cred_id):
+    """Disconnect an OAuth connection."""
+    from services.vault import disconnect_oauth
+    username = _get_username()
+    disconnect_oauth(username, cred_id)
+    return jsonify({'ok': True, 'message': f'{cred_id} disconnected'})
+
+
+@vault_bp.route('/api/vault/oauth/<cred_id>/status', methods=['GET'])
+def oauth_status(cred_id):
+    """Get the status of an OAuth connection."""
+    from services.vault import get_oauth_status
+    username = _get_username()
+    status = get_oauth_status(username, cred_id)
+    return jsonify(status)
+
+
+# ---------------------------------------------------------------------------
+# Sync
+# ---------------------------------------------------------------------------
+
+@vault_bp.route('/api/vault/sync', methods=['POST'])
+def sync_all_endpoint():
+    """Re-sync ALL credentials to ALL consumers."""
+    from services.vault import sync_all
+    username = _get_username()
+    sync_all(username)
+    return jsonify({'ok': True, 'message': 'All credentials synced'})
+
+
+@vault_bp.route('/api/vault/sync/<cred_id>', methods=['POST'])
+def sync_one_endpoint(cred_id):
+    """Re-sync one credential to its consumers."""
+    from services.vault import sync_credential
+    username = _get_username()
+    sync_credential(username, cred_id)
+    return jsonify({'ok': True, 'message': f'{cred_id} synced'})
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _oauth_callback_html(success: bool, message: str) -> str:
+    """Return HTML that closes the popup and notifies the parent window."""
+    status = 'success' if success else 'error'
+    return f"""<!DOCTYPE html>
+<html><head><title>OAuth {status}</title></head>
+<body style="background:#1a1a2e;color:#e0e0e0;font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
+<div style="text-align:center">
+<h2>{'Connected' if success else 'Connection Failed'}</h2>
+<p>{message}</p>
+<p style="color:#888">This window will close automatically...</p>
+</div>
+<script>
+if (window.opener) {{
+    window.opener.postMessage({{type:'oauth_callback',status:'{status}',message:'{message}'}}, '*');
+}}
+setTimeout(function(){{ window.close(); }}, 2000);
+</script>
+</body></html>""", 200, {'Content-Type': 'text/html'}

--- a/routes/vault.py
+++ b/routes/vault.py
@@ -103,8 +103,26 @@ def update_credential(cred_id):
         if not fields:
             return jsonify({'ok': True, 'message': 'No change (masked values)'})
 
-    set_credential(username, cred_id, value=value, fields=fields)
-    return jsonify({'ok': True, 'message': f'Credential {cred_id} updated and synced'})
+    to_restart = set_credential(username, cred_id, value=value, fields=fields)
+
+    if to_restart:
+        containers = sorted(to_restart)
+        msg = (
+            f'Saved. Agent will restart in ~6s to pick up the new value '
+            f'(affects: {", ".join(containers)}).'
+        )
+        return jsonify({
+            'ok': True,
+            'message': msg,
+            'restarting': containers,
+            'eta_seconds': 15,
+        })
+    return jsonify({
+        'ok': True,
+        'message': f'Credential {cred_id} saved (no container restart needed)',
+        'restarting': [],
+        'eta_seconds': 0,
+    })
 
 
 @vault_bp.route('/api/vault/credentials', methods=['POST'])

--- a/server.py
+++ b/server.py
@@ -205,6 +205,9 @@ app.register_blueprint(plugins_bp)
 from routes.custom_faces import custom_faces_bp
 app.register_blueprint(custom_faces_bp)
 
+from routes.vault import vault_bp
+app.register_blueprint(vault_bp)
+
 from services.plugins import load_plugins
 load_plugins(app)
 

--- a/services/vault.py
+++ b/services/vault.py
@@ -139,10 +139,14 @@ def _is_oauth_platform_configured(catalog_entry: dict) -> bool:
 # JSONC parser — string-aware so URLs and other // inside strings are preserved
 # ---------------------------------------------------------------------------
 def _parse_jsonc(text: str) -> dict:
-    """Parse JSONC (JSON with // and /* */ comments and trailing commas).
+    """Parse JSONC / JS object literal — JSON plus:
+      - // and /* */ comments
+      - trailing commas before } or ]
+      - unquoted identifier keys (e.g., `agents: {` instead of `"agents": {`)
 
-    Walks character-by-character so comment markers inside string literals
-    (e.g., "postgresql://..." or "https://...") are left intact.
+    Walks character-by-character so comment markers and key-quoting regexes
+    only apply OUTSIDE of string literals (so URLs like "postgresql://..."
+    and string values like "foo: bar" aren't touched).
     """
     out = []
     i = 0
@@ -180,6 +184,17 @@ def _parse_jsonc(text: str) -> dict:
             out.append(c)
             i += 1
     stripped = ''.join(out)
+
+    # Quote unquoted identifier keys. Matches `identifier:` at the start
+    # of a line (after whitespace or `{` or `,`), followed by a colon.
+    # Only rewrites when the identifier is NOT already in quotes.
+    # (?<![\"\w]) ensures we don't eat part of a larger identifier/string.
+    stripped = re.sub(
+        r'([\{\,\n]\s*)([A-Za-z_][A-Za-z0-9_]*)(\s*:)',
+        r'\1"\2"\3',
+        stripped,
+    )
+
     # Strip trailing commas before } or ]
     stripped = re.sub(r',(\s*[}\]])', r'\1', stripped)
     return json.loads(stripped)
@@ -1404,15 +1419,23 @@ def get_available_models(username: str) -> list[dict]:
 def get_current_model_selection(username: str) -> dict:
     """Get current primary/fallback model selection from openclaw.json.
 
-    openclaw.json is owned by UID 1000 (openclaw's node user) with chmod 600.
-    The openvoiceui Flask container runs as UID 1001 so reads will fail with
-    PermissionError. We catch that and return empty defaults so the
-    Connections page still loads; Phase 2 (Vault v2) moves model selection
-    into the vault itself and eliminates this cross-container read.
+    Resolution order:
+      1. /app/runtime/openclaw-client.json — Phase 1.5 single-file bind mount
+         (bypasses 700-perm parent dir; read-only)
+      2. /mnt/clients/<user>/openclaw/openclaw.json — direct host path
+         (usually fails PermissionError from the openvoiceui container)
+      3. /app/runtime/openclaw.json — fallback runtime path
+
+    The read is guarded against PermissionError so the Connections page
+    still loads gracefully if none of the paths work.
     """
-    config_path = _CLIENTS_DIR / username / 'openclaw' / 'openclaw.json'
-    if not _safe_exists(config_path):
-        config_path = _OPENCLAW_CONFIG_PATH
+    _phase15_path = Path('/app/runtime/openclaw-client.json')
+    if _safe_exists(_phase15_path):
+        config_path = _phase15_path
+    else:
+        config_path = _CLIENTS_DIR / username / 'openclaw' / 'openclaw.json'
+        if not _safe_exists(config_path):
+            config_path = _OPENCLAW_CONFIG_PATH
     if not _safe_exists(config_path):
         return {'primary': '', 'fallback': ''}
 

--- a/services/vault.py
+++ b/services/vault.py
@@ -1,0 +1,1147 @@
+"""
+Credential Vault Service — unified key management and OAuth token storage.
+
+Single source of truth for ALL API keys, OAuth tokens, and service credentials.
+Replaces the fragmented .platform-keys.env / .openclaw-keys.env / admin ai-config system.
+
+Architecture:
+  - Platform catalog (platform-credentials.json) defines known credential types
+  - Installed plugins add credentials via plugin.json "credentials" array
+  - Per-client vault (vault/credentials.json) stores actual values
+  - Sync engine pushes credentials to consumers (openclaw.json, plugin .env files, etc.)
+"""
+import json
+import logging
+import os
+import re
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+_PLATFORM_CATALOG_PATH = Path('/mnt/system/base/platform-credentials.json')
+_PLATFORM_OAUTH_PATH = Path('/mnt/system/base/platform-oauth.json')
+_CLIENTS_DIR = Path('/mnt/clients')
+_PLUGINS_DIR = Path('/app/plugins')
+_OPENCLAW_CONFIG_PATH = Path('/app/runtime/openclaw.json')
+
+# Inside container, vault is mounted at /app/runtime/vault
+# which maps to /mnt/clients/<user>/vault on the host
+_RUNTIME_VAULT_DIR = Path('/app/runtime/vault')
+
+# Fallback paths for local / dev mode
+if not _CLIENTS_DIR.exists():
+    _CLIENTS_DIR = Path(os.getenv('VAULT_CLIENTS_DIR', '/tmp/vault-clients'))
+if not _PLATFORM_CATALOG_PATH.exists():
+    _alt_path = os.getenv('VAULT_CATALOG_PATH', '').strip()
+    if _alt_path:
+        _alt = Path(_alt_path)
+        if _alt.is_file():
+            _PLATFORM_CATALOG_PATH = _alt
+
+
+# ---------------------------------------------------------------------------
+# JSONC parser — string-aware so URLs and other // inside strings are preserved
+# ---------------------------------------------------------------------------
+def _parse_jsonc(text: str) -> dict:
+    """Parse JSONC (JSON with // and /* */ comments and trailing commas).
+
+    Walks character-by-character so comment markers inside string literals
+    (e.g., "postgresql://..." or "https://...") are left intact.
+    """
+    out = []
+    i = 0
+    n = len(text)
+    in_string = False
+    escape = False
+    while i < n:
+        c = text[i]
+        if in_string:
+            out.append(c)
+            if escape:
+                escape = False
+            elif c == '\\':
+                escape = True
+            elif c == '"':
+                in_string = False
+            i += 1
+            continue
+        # Not in a string
+        if c == '"':
+            in_string = True
+            out.append(c)
+            i += 1
+        elif c == '/' and i + 1 < n and text[i + 1] == '/':
+            # Line comment — skip to newline
+            while i < n and text[i] != '\n':
+                i += 1
+        elif c == '/' and i + 1 < n and text[i + 1] == '*':
+            # Block comment — skip to closing */
+            i += 2
+            while i + 1 < n and not (text[i] == '*' and text[i + 1] == '/'):
+                i += 1
+            i += 2  # skip the */
+        else:
+            out.append(c)
+            i += 1
+    stripped = ''.join(out)
+    # Strip trailing commas before } or ]
+    stripped = re.sub(r',(\s*[}\]])', r'\1', stripped)
+    return json.loads(stripped)
+
+
+def _safe_exists(path: Path) -> bool:
+    """Path.exists() that returns False on PermissionError instead of raising.
+    Needed because stat() requires directory search permission on every
+    ancestor, which fails when openvoiceui container tries to stat paths
+    under /mnt/clients/<user>/openclaw/ (chmod 700 mike:mike).
+    """
+    try:
+        return path.is_file()
+    except (PermissionError, OSError):
+        return False
+
+
+def _read_json(path: Path) -> dict:
+    """Read a JSON or JSONC file. Tries plain JSON first for speed/safety,
+    falls back to JSONC only if plain JSON fails (e.g., openclaw.json with
+    comments). Vault credential files are pure JSON so they take the fast path.
+    Returns {} on any error (missing file, permission denied, parse error).
+    """
+    if not _safe_exists(path):
+        return {}
+    try:
+        text = path.read_text()
+        if not text.strip():
+            return {}
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return _parse_jsonc(text)
+    except (PermissionError, OSError) as exc:
+        logger.warning(f"Cannot read {path}: {exc}")
+        return {}
+    except Exception as exc:
+        logger.error(f"Failed to read {path}: {exc}")
+        return {}
+
+
+def _write_json(path: Path, data: dict):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix('.tmp')
+    tmp.write_text(json.dumps(data, indent=2))
+    tmp.replace(path)
+
+
+def _mask_key(key: str) -> str:
+    """Mask an API key for display: show first 6 and last 4 chars."""
+    if not key or len(key) < 12:
+        return '***' if key else ''
+    return key[:6] + '...' + key[-4:]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Vault paths per client
+# ---------------------------------------------------------------------------
+def _vault_dir(username: str) -> Path:
+    """
+    Get vault directory for a client.
+    Inside container: /app/runtime/vault (mounted from /mnt/clients/<user>/vault)
+    On host: /mnt/clients/<user>/vault
+    """
+    if _RUNTIME_VAULT_DIR.exists():
+        return _RUNTIME_VAULT_DIR
+    return _CLIENTS_DIR / username / 'vault'
+
+
+def _vault_creds_path(username: str) -> Path:
+    return _vault_dir(username) / 'credentials.json'
+
+
+def _vault_oauth_dir(username: str) -> Path:
+    return _vault_dir(username) / 'oauth'
+
+
+def _vault_oauth_path(username: str, provider: str) -> Path:
+    return _vault_oauth_dir(username) / f'{provider}.json'
+
+
+# ---------------------------------------------------------------------------
+# Platform catalog
+# ---------------------------------------------------------------------------
+_catalog_cache: Optional[dict] = None
+_catalog_mtime: float = 0
+
+
+def get_platform_catalog() -> list[dict]:
+    """Load platform credential catalog (cached, reloads on file change)."""
+    global _catalog_cache, _catalog_mtime
+    try:
+        mtime = _PLATFORM_CATALOG_PATH.stat().st_mtime
+    except OSError:
+        return []
+    if _catalog_cache is not None and mtime == _catalog_mtime:
+        return _catalog_cache
+    data = _read_json(_PLATFORM_CATALOG_PATH)
+    _catalog_cache = data.get('credentials', [])
+    _catalog_mtime = mtime
+    return _catalog_cache
+
+
+def get_catalog_credential(cred_id: str) -> Optional[dict]:
+    """Get a single credential definition from the platform catalog."""
+    for c in get_platform_catalog():
+        if c['id'] == cred_id:
+            return c
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Plugin credentials — merge installed plugins' declared credentials
+# ---------------------------------------------------------------------------
+def get_plugin_credentials() -> list[dict]:
+    """Collect credentials declared by installed plugins."""
+    result = []
+    if not _PLUGINS_DIR.exists():
+        return result
+    for plugin_dir in _PLUGINS_DIR.iterdir():
+        if not plugin_dir.is_dir():
+            continue
+        manifest_path = plugin_dir / 'plugin.json'
+        if not manifest_path.exists():
+            continue
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except Exception:
+            continue
+        plugin_id = manifest.get('id', plugin_dir.name)
+        for cred in manifest.get('credentials', []):
+            cred_copy = dict(cred)
+            cred_copy['_plugin_id'] = plugin_id
+            cred_copy['_plugin_name'] = manifest.get('name', plugin_id)
+            result.append(cred_copy)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Merged credential catalog — platform + plugins
+# ---------------------------------------------------------------------------
+def get_merged_catalog() -> list[dict]:
+    """
+    Merge platform catalog with plugin credentials.
+    Plugin credentials with "extend": true add consumers to existing entries.
+    Plugin credentials without extend add new entries.
+    """
+    platform = [dict(c) for c in get_platform_catalog()]
+    by_id = {c['id']: c for c in platform}
+
+    for pcred in get_plugin_credentials():
+        cred_id = pcred['id']
+        if pcred.get('extend') and cred_id in by_id:
+            # Merge consumers into existing platform credential
+            existing = by_id[cred_id]
+            for consumer_name, consumer_cfg in pcred.get('consumers', {}).items():
+                existing.setdefault('consumers', {})[consumer_name] = consumer_cfg
+            # Track which plugin added this consumer
+            existing.setdefault('_extended_by', []).append(pcred.get('_plugin_name', ''))
+        elif cred_id not in by_id:
+            # New credential from plugin
+            by_id[cred_id] = pcred
+            platform.append(pcred)
+        else:
+            # Same ID, not extend — merge consumers only
+            existing = by_id[cred_id]
+            for consumer_name, consumer_cfg in pcred.get('consumers', {}).items():
+                existing.setdefault('consumers', {})[consumer_name] = consumer_cfg
+
+    return platform
+
+
+# ---------------------------------------------------------------------------
+# Per-client vault CRUD
+# ---------------------------------------------------------------------------
+def ensure_vault(username: str):
+    """Create vault directory structure for a client."""
+    vdir = _vault_dir(username)
+    vdir.mkdir(parents=True, exist_ok=True)
+    _vault_oauth_dir(username).mkdir(parents=True, exist_ok=True)
+    creds_path = _vault_creds_path(username)
+    if not creds_path.exists():
+        _write_json(creds_path, {
+            'version': 1,
+            'updated': _now_iso(),
+            'credentials': {},
+        })
+    # Permissions: owner read/write only
+    try:
+        os.chmod(str(vdir), 0o700)
+        os.chmod(str(creds_path), 0o600)
+    except OSError:
+        pass
+
+
+def read_vault(username: str) -> dict:
+    """Read a client's credential vault."""
+    return _read_json(_vault_creds_path(username))
+
+
+def _write_vault(username: str, vault: dict):
+    """Write a client's credential vault."""
+    vault['updated'] = _now_iso()
+    _write_json(_vault_creds_path(username), vault)
+
+
+def get_credential_value(username: str, cred_id: str) -> Optional[str]:
+    """Get the raw value of a credential from the vault."""
+    vault = read_vault(username)
+    entry = vault.get('credentials', {}).get(cred_id)
+    if not entry:
+        return None
+    return entry.get('value', '')
+
+
+def get_credential_fields(username: str, cred_id: str) -> Optional[dict]:
+    """Get multi-field credential values (for basic_auth, multi_field types)."""
+    vault = read_vault(username)
+    entry = vault.get('credentials', {}).get(cred_id)
+    if not entry:
+        return None
+    return entry.get('fields', {})
+
+
+def set_credential(username: str, cred_id: str, value: str = None,
+                   fields: dict = None, source: str = 'user'):
+    """
+    Set a credential value in the vault, then sync to consumers.
+
+    Args:
+        username: Client username
+        cred_id: Credential ID from catalog
+        value: For single-key credentials
+        fields: For multi-field credentials (e.g. {"login": "x", "password": "y"})
+        source: "platform", "user", or "plugin"
+    """
+    vault = read_vault(username)
+    creds = vault.setdefault('credentials', {})
+
+    entry = creds.get(cred_id, {})
+    entry['updated'] = _now_iso()
+    entry['source'] = source
+
+    if value is not None:
+        entry['value'] = value
+    if fields is not None:
+        entry['fields'] = fields
+
+    creds[cred_id] = entry
+    _write_vault(username, vault)
+
+    # Sync to consumers
+    sync_credential(username, cred_id)
+
+
+def delete_credential(username: str, cred_id: str):
+    """Remove a credential from the vault (custom credentials only)."""
+    vault = read_vault(username)
+    creds = vault.get('credentials', {})
+    if cred_id in creds:
+        del creds[cred_id]
+        _write_vault(username, vault)
+
+
+def add_custom_credential(username: str, name: str, env_var: str, value: str,
+                          group: str = 'Custom'):
+    """Add a user-defined custom credential not in any catalog."""
+    vault = read_vault(username)
+    creds = vault.setdefault('credentials', {})
+
+    # Generate ID from env_var
+    cred_id = f"custom_{env_var.lower()}"
+
+    creds[cred_id] = {
+        'value': value,
+        'source': 'user',
+        'updated': _now_iso(),
+        'custom': True,
+        'name': name,
+        'env_var': env_var,
+        'group': group,
+    }
+    _write_vault(username, vault)
+    return cred_id
+
+
+# ---------------------------------------------------------------------------
+# Credential status — merge catalog + vault into displayable list
+# ---------------------------------------------------------------------------
+def get_credentials_status(username: str) -> list[dict]:
+    """
+    Get full credential status for a client — merged catalog with vault state.
+    Returns list suitable for admin UI rendering.
+    """
+    catalog = get_merged_catalog()
+    vault = read_vault(username)
+    vault_creds = vault.get('credentials', {})
+
+    result = []
+    seen_ids = set()
+
+    for entry in catalog:
+        cred_id = entry['id']
+        seen_ids.add(cred_id)
+        vault_entry = vault_creds.get(cred_id, {})
+
+        cred_type = entry.get('type', 'api_key')
+        has_value = False
+        masked_value = ''
+
+        if cred_type == 'oauth2':
+            # Check for OAuth token file
+            oauth_provider = entry.get('oauth', {}).get('provider', cred_id)
+            token_path = _vault_oauth_path(username, cred_id)
+            if _safe_exists(token_path):
+                token_data = _read_json(token_path)
+                has_value = bool(token_data.get('refresh_token'))
+                masked_value = token_data.get('connected_account', 'Connected')
+        elif cred_type in ('multi_field', 'basic_auth'):
+            fields = vault_entry.get('fields', {})
+            field_defs = entry.get('fields', [])
+            has_value = all(fields.get(f['id']) for f in field_defs)
+            if has_value:
+                # Mask the first field as representative
+                first_field = field_defs[0]['id'] if field_defs else ''
+                masked_value = _mask_key(fields.get(first_field, ''))
+        else:
+            raw_val = vault_entry.get('value', '')
+            # Also check env var as fallback
+            if not raw_val and entry.get('env_var'):
+                raw_val = os.environ.get(entry['env_var'], '')
+            has_value = bool(raw_val)
+            masked_value = _mask_key(raw_val)
+
+        # Build consumer list
+        consumers = []
+        for cname, ccfg in entry.get('consumers', {}).items():
+            consumers.append(cname)
+
+        item = {
+            'id': cred_id,
+            'name': entry.get('name', cred_id),
+            'description': entry.get('description', ''),
+            'type': cred_type,
+            'group': entry.get('group', 'Other'),
+            'has_value': has_value,
+            'masked_value': masked_value,
+            'consumers': consumers,
+            'source': vault_entry.get('source', 'platform' if entry.get('platform_default') else 'none'),
+            'env_var': entry.get('env_var', ''),
+            'docs_url': entry.get('docs_url', ''),
+            'has_test': bool(entry.get('test')),
+            'fields': entry.get('fields'),  # For multi-field rendering
+        }
+
+        if cred_type == 'oauth2':
+            item['oauth'] = entry.get('oauth', {})
+
+        # Plugin source info
+        if entry.get('_plugin_id'):
+            item['plugin_id'] = entry['_plugin_id']
+            item['plugin_name'] = entry['_plugin_name']
+
+        result.append(item)
+
+    # Add custom vault credentials not in catalog
+    for cred_id, vault_entry in vault_creds.items():
+        if cred_id in seen_ids:
+            continue
+        if not vault_entry.get('custom'):
+            continue
+        result.append({
+            'id': cred_id,
+            'name': vault_entry.get('name', cred_id),
+            'description': '',
+            'type': 'api_key',
+            'group': vault_entry.get('group', 'Custom'),
+            'has_value': bool(vault_entry.get('value')),
+            'masked_value': _mask_key(vault_entry.get('value', '')),
+            'consumers': [],
+            'source': 'user',
+            'env_var': vault_entry.get('env_var', ''),
+            'custom': True,
+            'has_test': False,
+        })
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Sync engine — push credentials to consumers
+# ---------------------------------------------------------------------------
+def sync_credential(username: str, cred_id: str):
+    """Push a credential to all its declared consumers."""
+    catalog = get_merged_catalog()
+    cat_entry = None
+    for c in catalog:
+        if c['id'] == cred_id:
+            cat_entry = c
+            break
+
+    if not cat_entry:
+        logger.debug(f"No catalog entry for {cred_id}, skipping sync")
+        return
+
+    vault = read_vault(username)
+    vault_entry = vault.get('credentials', {}).get(cred_id, {})
+    raw_value = vault_entry.get('value', '')
+    raw_fields = vault_entry.get('fields', {})
+
+    for consumer_name, consumer_cfg in cat_entry.get('consumers', {}).items():
+        consumer_type = consumer_cfg.get('type', 'env_var')
+        try:
+            if consumer_type == 'openclaw_provider':
+                _sync_to_openclaw(username, cred_id, raw_value, consumer_cfg)
+            elif consumer_type == 'env_file':
+                plugin_id = consumer_name  # consumer name = plugin dir name
+                _sync_to_env_file(username, cred_id, raw_value, consumer_cfg, plugin_id)
+            elif consumer_type == 'env_var':
+                _sync_to_env_var(username, cred_id, raw_value, raw_fields, cat_entry)
+            elif consumer_type == 'oauth_token':
+                pass  # OAuth tokens are read directly, no push needed
+            else:
+                logger.warning(f"Unknown consumer type {consumer_type} for {cred_id}")
+        except Exception as exc:
+            logger.error(f"Sync {cred_id} → {consumer_name} failed: {exc}")
+
+
+def sync_all(username: str):
+    """Re-sync ALL credentials for a client."""
+    vault = read_vault(username)
+    for cred_id in vault.get('credentials', {}):
+        sync_credential(username, cred_id)
+
+
+def _sync_to_openclaw(username: str, cred_id: str, key_value: str, consumer_cfg: dict):
+    """Write/update a provider block in the client's openclaw.json.
+
+    Guarded against PermissionError — openvoiceui container (UID 1001) cannot
+    write openclaw.json (chmod 600, owned UID 1000). Phase 2 (Vault v2)
+    eliminates this cross-container write entirely; openclaw will read keys
+    from a read-only mounted vault at startup.
+    """
+    if not key_value:
+        return
+
+    config_path = _CLIENTS_DIR / username / 'openclaw' / 'openclaw.json'
+    if not config_path.exists():
+        # Fall back to runtime path (inside container)
+        config_path = _OPENCLAW_CONFIG_PATH
+    if not config_path.exists():
+        logger.warning(f"No openclaw.json found for {username}")
+        return
+
+    try:
+        config = _parse_jsonc(config_path.read_text())
+    except (PermissionError, OSError) as exc:
+        logger.warning(
+            f"Cannot read {config_path} for sync ({exc}); credential stored "
+            f"in vault only. Openclaw will continue using its existing key "
+            f"until Phase 2 migration or manual restart."
+        )
+        return
+    except Exception as exc:
+        logger.error(f"Failed to parse {config_path}: {exc}")
+        return
+
+    providers = config.setdefault('models', {'mode': 'merge'}).setdefault('providers', {})
+    provider_id = consumer_cfg['provider_id']
+
+    if provider_id not in providers:
+        # Create new provider block
+        providers[provider_id] = {
+            'baseUrl': consumer_cfg['base_url'],
+            'api': consumer_cfg['api_format'],
+            'apiKey': key_value,
+            'models': consumer_cfg.get('models', []),
+        }
+    else:
+        # Update existing key only
+        providers[provider_id]['apiKey'] = key_value
+
+    try:
+        _write_json(config_path, config)
+        logger.info(f"Synced {cred_id} → openclaw provider '{provider_id}' for {username}")
+    except (PermissionError, OSError) as exc:
+        logger.warning(
+            f"Cannot write {config_path} ({exc}); credential stored in vault "
+            f"only. Phase 2 will fix this cross-container write."
+        )
+
+
+def _sync_to_env_file(username: str, cred_id: str, key_value: str,
+                      consumer_cfg: dict, plugin_id: str):
+    """Write/update key in a plugin's env file."""
+    if not key_value:
+        return
+
+    plugin_dir = _CLIENTS_DIR / username / plugin_id
+    if not plugin_dir.exists():
+        logger.debug(f"Plugin dir {plugin_dir} not found, skipping env_file sync")
+        return
+
+    env_path = plugin_dir / '.env'
+    env_var = consumer_cfg.get('env_var', '')
+    if not env_var:
+        return
+
+    # Parse existing env file
+    existing = {}
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            if '=' in line:
+                k, v = line.split('=', 1)
+                existing[k.strip()] = v.strip()
+
+    existing[env_var] = key_value
+
+    # Also set companion vars
+    for k, v in consumer_cfg.get('also_set', {}).items():
+        existing[k] = v
+
+    # Write back
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"{k}={v}" for k, v in existing.items()]
+    env_path.write_text('\n'.join(lines) + '\n')
+    logger.info(f"Synced {cred_id} → env_file {env_path}")
+
+
+def _sync_to_env_var(username: str, cred_id: str, raw_value: str,
+                     raw_fields: dict, cat_entry: dict):
+    """
+    Sync to the client's .openclaw.env file (per-client env overrides).
+    These get picked up by Docker containers on restart.
+    """
+    env_path = _CLIENTS_DIR / username / 'compose' / '.openclaw.env'
+    if not env_path.parent.exists():
+        return
+
+    existing = {}
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            if '=' in line:
+                k, v = line.split('=', 1)
+                existing[k.strip()] = v.strip()
+
+    cred_type = cat_entry.get('type', 'api_key')
+    if cred_type in ('multi_field', 'basic_auth'):
+        fields = cat_entry.get('fields', [])
+        for fdef in fields:
+            fval = raw_fields.get(fdef['id'], '')
+            if fval:
+                existing[fdef['env_var']] = fval
+    else:
+        env_var = cat_entry.get('env_var', '')
+        if env_var and raw_value:
+            existing[env_var] = raw_value
+
+    lines = [f"{k}={v}" for k, v in existing.items()]
+    env_path.write_text('\n'.join(lines) + '\n')
+
+
+# ---------------------------------------------------------------------------
+# Credential testing
+# ---------------------------------------------------------------------------
+def test_credential(username: str, cred_id: str) -> dict:
+    """
+    Test a credential by hitting the provider's test endpoint.
+    Returns: {"ok": bool, "status_code": int, "message": str, "latency_ms": int}
+    """
+    cat_entry = get_catalog_credential(cred_id)
+    if not cat_entry:
+        # Check merged catalog (includes plugin creds)
+        for c in get_merged_catalog():
+            if c['id'] == cred_id:
+                cat_entry = c
+                break
+    if not cat_entry or not cat_entry.get('test'):
+        return {'ok': False, 'message': 'No test configuration for this credential'}
+
+    test_cfg = cat_entry['test']
+    vault = read_vault(username)
+    vault_entry = vault.get('credentials', {}).get(cred_id, {})
+
+    # Get the key value
+    cred_type = cat_entry.get('type', 'api_key')
+    key_value = vault_entry.get('value', '')
+    if not key_value and cat_entry.get('env_var'):
+        key_value = os.environ.get(cat_entry['env_var'], '')
+
+    if not key_value and cred_type not in ('basic_auth', 'multi_field'):
+        return {'ok': False, 'message': 'No key configured'}
+
+    # Build request
+    url = test_cfg['url']
+    method = test_cfg.get('method', 'GET').upper()
+    headers = {}
+    auth = None
+
+    auth_type = test_cfg.get('auth_type', '')
+    if auth_type == 'basic':
+        fields = vault_entry.get('fields', {})
+        field_defs = cat_entry.get('fields', [])
+        if len(field_defs) >= 2:
+            login = fields.get(field_defs[0]['id'], '')
+            password = fields.get(field_defs[1]['id'], '')
+            if not login or not password:
+                return {'ok': False, 'message': 'Missing login or password'}
+            auth = (login, password)
+    else:
+        auth_header = test_cfg.get('auth_header', 'Authorization')
+        auth_prefix = test_cfg.get('auth_prefix', '')
+        headers[auth_header] = f"{auth_prefix}{key_value}"
+
+    start = time.time()
+    try:
+        kwargs = {'headers': headers, 'timeout': 10}
+        if auth:
+            kwargs['auth'] = auth
+        if method == 'POST' and test_cfg.get('test_body'):
+            kwargs['json'] = test_cfg['test_body']
+            if 'Content-Type' not in headers:
+                headers['Content-Type'] = 'application/json'
+
+        resp = requests.request(method, url, **kwargs)
+        latency = int((time.time() - start) * 1000)
+
+        expect = test_cfg.get('expect_status', [200])
+        if resp.status_code in expect or resp.status_code == 200:
+            return {
+                'ok': True,
+                'status_code': resp.status_code,
+                'message': 'Connected',
+                'latency_ms': latency,
+            }
+        elif resp.status_code == 401:
+            return {
+                'ok': False,
+                'status_code': 401,
+                'message': 'Invalid API key',
+                'latency_ms': latency,
+            }
+        elif resp.status_code == 429:
+            return {
+                'ok': True,  # Key is valid, just rate limited
+                'status_code': 429,
+                'message': 'Valid key (rate limited)',
+                'latency_ms': latency,
+            }
+        else:
+            return {
+                'ok': False,
+                'status_code': resp.status_code,
+                'message': f'Unexpected response: {resp.status_code}',
+                'latency_ms': latency,
+            }
+    except requests.Timeout:
+        return {'ok': False, 'message': 'Connection timed out', 'latency_ms': 10000}
+    except requests.ConnectionError as e:
+        return {'ok': False, 'message': f'Connection failed: {e}'}
+    except Exception as e:
+        return {'ok': False, 'message': str(e)}
+
+
+# ---------------------------------------------------------------------------
+# OAuth token management
+# ---------------------------------------------------------------------------
+def get_oauth_apps() -> dict:
+    """Read platform OAuth app credentials (client_id/secret per provider)."""
+    return _read_json(_PLATFORM_OAUTH_PATH)
+
+
+def set_oauth_app(provider: str, client_id: str, client_secret: str, redirect_uri: str):
+    """Register/update an OAuth app."""
+    apps = get_oauth_apps()
+    apps[provider] = {
+        'client_id': client_id,
+        'client_secret': client_secret,
+        'redirect_uri': redirect_uri,
+    }
+    _write_json(_PLATFORM_OAUTH_PATH, apps)
+
+
+def build_oauth_url(cred_id: str, username: str, domain: str) -> Optional[str]:
+    """
+    Build the OAuth authorization URL for a credential.
+    Returns the URL the user should be redirected to.
+    """
+    cat_entry = get_catalog_credential(cred_id)
+    if not cat_entry or cat_entry.get('type') != 'oauth2':
+        return None
+
+    oauth_cfg = cat_entry.get('oauth', {})
+    provider = oauth_cfg.get('provider', '')
+    apps = get_oauth_apps()
+    app_creds = apps.get(provider)
+    if not app_creds:
+        logger.error(f"No OAuth app registered for provider '{provider}'")
+        return None
+
+    import urllib.parse
+    params = {
+        'client_id': app_creds['client_id'],
+        'redirect_uri': app_creds['redirect_uri'],
+        'response_type': 'code',
+        'scope': ' '.join(oauth_cfg.get('scopes', [])),
+        'state': json.dumps({'cred_id': cred_id, 'username': username}),
+    }
+    # Extra params (e.g. access_type=offline for Google)
+    params.update(oauth_cfg.get('extra_params', {}))
+
+    return oauth_cfg['auth_url'] + '?' + urllib.parse.urlencode(params)
+
+
+def exchange_oauth_code(cred_id: str, code: str, username: str) -> dict:
+    """
+    Exchange an authorization code for tokens and store them.
+    Returns: {"ok": bool, "account": str, "error": str}
+    """
+    cat_entry = get_catalog_credential(cred_id)
+    if not cat_entry or cat_entry.get('type') != 'oauth2':
+        return {'ok': False, 'error': 'Not an OAuth credential'}
+
+    oauth_cfg = cat_entry.get('oauth', {})
+    provider = oauth_cfg.get('provider', '')
+    apps = get_oauth_apps()
+    app_creds = apps.get(provider)
+    if not app_creds:
+        return {'ok': False, 'error': f'No OAuth app for provider {provider}'}
+
+    # Exchange code for tokens
+    try:
+        resp = requests.post(oauth_cfg['token_url'], data={
+            'code': code,
+            'client_id': app_creds['client_id'],
+            'client_secret': app_creds['client_secret'],
+            'redirect_uri': app_creds['redirect_uri'],
+            'grant_type': 'authorization_code',
+        }, timeout=15)
+
+        if resp.status_code != 200:
+            return {'ok': False, 'error': f'Token exchange failed: {resp.status_code} {resp.text[:200]}'}
+
+        token_data = resp.json()
+    except Exception as exc:
+        return {'ok': False, 'error': str(exc)}
+
+    # Calculate expiry
+    expires_in = token_data.get('expires_in', 3600)
+    expires_at = datetime.now(timezone.utc).timestamp() + expires_in
+
+    # Try to get connected account info
+    account_email = _get_oauth_account_info(provider, token_data.get('access_token', ''))
+
+    # Store token
+    token_file = {
+        'access_token': token_data.get('access_token', ''),
+        'refresh_token': token_data.get('refresh_token', ''),
+        'token_type': token_data.get('token_type', 'Bearer'),
+        'expires_at': datetime.fromtimestamp(expires_at, tz=timezone.utc).isoformat(),
+        'scopes': oauth_cfg.get('scopes', []),
+        'connected_account': account_email,
+        'connected_at': _now_iso(),
+    }
+
+    ensure_vault(username)
+    _write_json(_vault_oauth_path(username, cred_id), token_file)
+
+    # Also mark in vault credentials
+    vault = read_vault(username)
+    creds = vault.setdefault('credentials', {})
+    creds[cred_id] = {
+        'type': 'oauth2',
+        'source': 'user',
+        'connected_account': account_email,
+        'token_file': f'oauth/{cred_id}.json',
+        'updated': _now_iso(),
+    }
+    _write_vault(username, vault)
+
+    return {'ok': True, 'account': account_email}
+
+
+def _get_oauth_account_info(provider: str, access_token: str) -> str:
+    """Get the email/account name for the connected OAuth account."""
+    if not access_token:
+        return ''
+    try:
+        if provider == 'google':
+            resp = requests.get(
+                'https://www.googleapis.com/oauth2/v2/userinfo',
+                headers={'Authorization': f'Bearer {access_token}'},
+                timeout=5,
+            )
+            if resp.ok:
+                return resp.json().get('email', '')
+        elif provider == 'facebook':
+            resp = requests.get(
+                'https://graph.facebook.com/me?fields=name,email',
+                headers={'Authorization': f'Bearer {access_token}'},
+                timeout=5,
+            )
+            if resp.ok:
+                data = resp.json()
+                return data.get('email', data.get('name', ''))
+    except Exception:
+        pass
+    return ''
+
+
+def get_fresh_oauth_token(username: str, cred_id: str) -> Optional[str]:
+    """
+    Get a fresh OAuth access token, auto-refreshing if expired.
+    Returns the access_token string or None.
+    """
+    token_path = _vault_oauth_path(username, cred_id)
+    if not _safe_exists(token_path):
+        return None
+
+    token_data = _read_json(token_path)
+    if not token_data.get('access_token'):
+        return None
+
+    # Check if expired
+    expires_at = token_data.get('expires_at', '')
+    if expires_at:
+        try:
+            exp_dt = datetime.fromisoformat(expires_at)
+            if exp_dt.timestamp() < time.time() - 60:  # 60s buffer
+                # Refresh needed
+                refreshed = _refresh_oauth_token(cred_id, token_data['refresh_token'])
+                if refreshed:
+                    token_data.update(refreshed)
+                    _write_json(token_path, token_data)
+                else:
+                    return None
+        except (ValueError, KeyError):
+            pass
+
+    return token_data.get('access_token')
+
+
+def _refresh_oauth_token(cred_id: str, refresh_token: str) -> Optional[dict]:
+    """Refresh an OAuth token."""
+    cat_entry = get_catalog_credential(cred_id)
+    if not cat_entry:
+        return None
+
+    oauth_cfg = cat_entry.get('oauth', {})
+    provider = oauth_cfg.get('provider', '')
+    apps = get_oauth_apps()
+    app_creds = apps.get(provider)
+    if not app_creds:
+        return None
+
+    try:
+        resp = requests.post(oauth_cfg['token_url'], data={
+            'client_id': app_creds['client_id'],
+            'client_secret': app_creds['client_secret'],
+            'refresh_token': refresh_token,
+            'grant_type': 'refresh_token',
+        }, timeout=15)
+
+        if resp.status_code != 200:
+            logger.error(f"OAuth refresh failed for {cred_id}: {resp.status_code}")
+            return None
+
+        data = resp.json()
+        expires_in = data.get('expires_in', 3600)
+        expires_at = datetime.now(timezone.utc).timestamp() + expires_in
+
+        return {
+            'access_token': data['access_token'],
+            'expires_at': datetime.fromtimestamp(expires_at, tz=timezone.utc).isoformat(),
+            # Some providers return new refresh_token
+            'refresh_token': data.get('refresh_token', refresh_token),
+        }
+    except Exception as exc:
+        logger.error(f"OAuth refresh error for {cred_id}: {exc}")
+        return None
+
+
+def disconnect_oauth(username: str, cred_id: str):
+    """Disconnect an OAuth connection — remove tokens."""
+    token_path = _vault_oauth_path(username, cred_id)
+    if _safe_exists(token_path):
+        # Rename to .revoked instead of deleting
+        revoked_path = token_path.with_suffix('.revoked')
+        token_path.rename(revoked_path)
+
+    vault = read_vault(username)
+    creds = vault.get('credentials', {})
+    if cred_id in creds:
+        del creds[cred_id]
+        _write_vault(username, vault)
+
+
+def get_oauth_status(username: str, cred_id: str) -> dict:
+    """Get the status of an OAuth connection."""
+    token_path = _vault_oauth_path(username, cred_id)
+    if not _safe_exists(token_path):
+        return {'connected': False}
+
+    token_data = _read_json(token_path)
+    if not token_data.get('refresh_token'):
+        return {'connected': False}
+
+    return {
+        'connected': True,
+        'account': token_data.get('connected_account', ''),
+        'connected_at': token_data.get('connected_at', ''),
+        'scopes': token_data.get('scopes', []),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Model selection helpers — for the model dropdown in connections UI
+# ---------------------------------------------------------------------------
+def get_available_models(username: str) -> list[dict]:
+    """
+    Get all models available to a client based on their connected LLM providers.
+    Returns list of {"id": "mx/ModelName", "name": "...", "provider": "...", ...}
+    """
+    catalog = get_merged_catalog()
+    vault = read_vault(username)
+    vault_creds = vault.get('credentials', {})
+
+    models = []
+    for entry in catalog:
+        cred_id = entry['id']
+        if entry.get('group') != 'LLM Providers':
+            continue
+
+        # Check if key exists
+        vault_entry = vault_creds.get(cred_id, {})
+        has_key = bool(vault_entry.get('value'))
+        if not has_key and entry.get('env_var'):
+            has_key = bool(os.environ.get(entry['env_var'], ''))
+
+        if not has_key:
+            continue
+
+        # Get models from openclaw consumer config
+        oc_cfg = entry.get('consumers', {}).get('openclaw', {})
+        if oc_cfg.get('type') != 'openclaw_provider':
+            continue
+
+        provider_id = oc_cfg['provider_id']
+        for model in oc_cfg.get('models', []):
+            models.append({
+                'id': f"{provider_id}/{model['id']}",
+                'name': model.get('name', model['id']),
+                'provider': entry['name'],
+                'provider_id': provider_id,
+                'contextWindow': model.get('contextWindow', 0),
+            })
+
+    return models
+
+
+def get_current_model_selection(username: str) -> dict:
+    """Get current primary/fallback model selection from openclaw.json.
+
+    openclaw.json is owned by UID 1000 (openclaw's node user) with chmod 600.
+    The openvoiceui Flask container runs as UID 1001 so reads will fail with
+    PermissionError. We catch that and return empty defaults so the
+    Connections page still loads; Phase 2 (Vault v2) moves model selection
+    into the vault itself and eliminates this cross-container read.
+    """
+    config_path = _CLIENTS_DIR / username / 'openclaw' / 'openclaw.json'
+    if not _safe_exists(config_path):
+        config_path = _OPENCLAW_CONFIG_PATH
+    if not _safe_exists(config_path):
+        return {'primary': '', 'fallback': ''}
+
+    try:
+        config = _parse_jsonc(config_path.read_text())
+    except (PermissionError, OSError) as exc:
+        logger.warning(
+            f"Cannot read {config_path} for model selection ({exc}); "
+            f"returning empty defaults. This is expected when openvoiceui "
+            f"and openclaw containers run as different UIDs."
+        )
+        return {'primary': '', 'fallback': ''}
+    except Exception as exc:
+        logger.error(f"Failed to parse {config_path}: {exc}")
+        return {'primary': '', 'fallback': ''}
+
+    defaults = config.get('agents', {}).get('defaults', {})
+    model_cfg = defaults.get('model', {})
+    fallbacks = model_cfg.get('fallbacks', [])
+
+    return {
+        'primary': model_cfg.get('primary', ''),
+        'fallback': fallbacks[0] if fallbacks else '',
+    }
+
+
+def set_model_selection(username: str, primary: str = None, fallback: str = None):
+    """Update primary/fallback model selection in openclaw.json.
+
+    Guarded the same way as get_current_model_selection — Phase 1 avoids
+    crashing when the openvoiceui container can't write openclaw.json.
+    Phase 2 (Vault v2) moves this into the vault itself.
+    """
+    config_path = _CLIENTS_DIR / username / 'openclaw' / 'openclaw.json'
+    if not _safe_exists(config_path):
+        config_path = _OPENCLAW_CONFIG_PATH
+    if not _safe_exists(config_path):
+        return
+
+    try:
+        config = _parse_jsonc(config_path.read_text())
+    except (PermissionError, OSError) as exc:
+        logger.warning(
+            f"Cannot read {config_path} to set model selection ({exc}); "
+            f"skipping. Phase 2 will store model selection in the vault."
+        )
+        return
+    except Exception as exc:
+        logger.error(f"Failed to parse {config_path}: {exc}")
+        return
+
+    defaults = config.setdefault('agents', {}).setdefault('defaults', {})
+    model_cfg = defaults.setdefault('model', {})
+
+    if primary:
+        model_cfg['primary'] = primary
+        defaults.setdefault('models', {})[primary] = {}
+        defaults.setdefault('subagents', {})['model'] = primary
+
+    if fallback is not None:
+        model_cfg['fallbacks'] = [fallback] if fallback else []
+        if fallback:
+            defaults.setdefault('models', {})[fallback] = {}
+
+    try:
+        _write_json(config_path, config)
+    except (PermissionError, OSError) as exc:
+        logger.warning(
+            f"Cannot write {config_path} ({exc}); model selection update "
+            f"skipped. Phase 2 will fix this properly."
+        )

--- a/services/vault.py
+++ b/services/vault.py
@@ -295,16 +295,13 @@ _restart_lock = threading.Lock()
 
 
 def _do_restart_container(container_name: str):
-    """Recreate a container to pick up new env_file values.
+    """Recreate a compose-managed container (openclaw / openvoiceui) to pick
+    up new env_file values. Must be a RECREATE, not a plain restart — Docker
+    only loads env_file: values at container creation time.
 
-    Routes to the right mechanism based on the container type:
-      - openclaw-<user> / openvoiceui-<user>: managed by the client's
-        docker-compose.yml, recreated via `docker compose up -d --force-recreate`
-      - <plugin>-<user> (e.g. hermes-test-dev): managed by the JamBot
-        provisioning service (port 5200), which knows how to handle per-plugin
-        env/config files and container lifecycle. We POST to its /provision/
-        endpoint with an empty config body — the service re-uses the existing
-        .env that was just updated.
+    Plugin containers (e.g. hermes-<user>) are NOT handled here — the vault
+    syncs to them via the provisioning service (_sync_to_plugin_via_provision_service)
+    which owns plugin file writes + restart in one HTTP call.
 
     Called by the debounce timer; do not call directly.
     """
@@ -313,94 +310,52 @@ def _do_restart_container(container_name: str):
         logger.error(f"[vault] Unexpected container name format: {container_name}")
         return
     service, username = container_name.split('-', 1)
+    if service not in ('openclaw', 'openvoiceui'):
+        logger.error(
+            f"[vault] _do_restart_container only handles openclaw/openvoiceui, "
+            f"got {container_name}"
+        )
+        return
 
     try:
-        if service in ('openclaw', 'openvoiceui'):
-            _recreate_compose_service(service, username)
-        else:
-            # Plugin container — delegate to the provisioning service
-            _recreate_plugin_container(service, username)
+        compose_file = _CLIENTS_DIR / username / 'compose' / 'docker-compose.yml'
+        env_file = _CLIENTS_DIR / username / 'compose' / '.env'
+        if not compose_file.is_file():
+            logger.error(f"[vault] compose file not found: {compose_file}")
+            return
+
+        cmd = [
+            'docker', 'compose',
+            '-f', str(compose_file),
+            '--env-file', str(env_file),
+            'up', '-d', '--force-recreate', '--no-deps',
+            service,
+        ]
+        logger.info(f"[vault] Recreating {container_name} to apply new credentials...")
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+            if result.returncode == 0:
+                logger.info(f"[vault] {container_name} recreated successfully")
+                # Reconnect shared network (compose up -d disconnects cross-project networks)
+                try:
+                    subprocess.run(
+                        ['docker', 'network', 'connect', 'jambot-shared', container_name],
+                        capture_output=True, text=True, timeout=10,
+                    )
+                except Exception:
+                    pass
+            else:
+                logger.error(
+                    f"[vault] docker compose up failed for {container_name}: "
+                    f"stdout={result.stdout} stderr={result.stderr}"
+                )
+        except subprocess.TimeoutExpired:
+            logger.error(f"[vault] docker compose up timed out for {container_name}")
+        except Exception as exc:
+            logger.error(f"[vault] Failed to recreate {container_name}: {exc}")
     finally:
         with _restart_lock:
             _restart_timers.pop(container_name, None)
-
-
-def _recreate_compose_service(service: str, username: str):
-    """Recreate an openclaw or openvoiceui container via docker compose."""
-    import subprocess
-    container_name = f'{service}-{username}'
-    compose_file = _CLIENTS_DIR / username / 'compose' / 'docker-compose.yml'
-    env_file = _CLIENTS_DIR / username / 'compose' / '.env'
-    if not compose_file.is_file():
-        logger.error(f"[vault] compose file not found: {compose_file}")
-        return
-
-    cmd = [
-        'docker', 'compose',
-        '-f', str(compose_file),
-        '--env-file', str(env_file),
-        'up', '-d', '--force-recreate', '--no-deps',
-        service,
-    ]
-    logger.info(f"[vault] Recreating {container_name} to apply new credentials...")
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
-        if result.returncode == 0:
-            logger.info(f"[vault] {container_name} recreated successfully")
-            # Reconnect shared network (compose up -d disconnects cross-project networks)
-            try:
-                subprocess.run(
-                    ['docker', 'network', 'connect', 'jambot-shared', container_name],
-                    capture_output=True, text=True, timeout=10,
-                )
-            except Exception:
-                pass  # may already be connected
-        else:
-            logger.error(
-                f"[vault] docker compose up failed for {container_name}: "
-                f"stdout={result.stdout} stderr={result.stderr}"
-            )
-    except subprocess.TimeoutExpired:
-        logger.error(f"[vault] docker compose up timed out for {container_name}")
-    except Exception as exc:
-        logger.error(f"[vault] Failed to recreate {container_name}: {exc}")
-
-
-def _recreate_plugin_container(plugin_id: str, username: str):
-    """Recreate a plugin container via the JamBot provisioning service.
-
-    Sends an empty config body so the service preserves the .env file we
-    just wrote and performs a restart-with-current-config. The service's
-    endpoint handler (provision_hermes etc.) detects that the container
-    is already running and reissues a `docker restart` after the provision
-    call returns.
-    """
-    import subprocess
-    container_name = f'{plugin_id}-{username}'
-    logger.info(f"[vault] Restarting plugin container {container_name} via provision service...")
-    try:
-        # Direct docker restart is sufficient — the .env file update is
-        # picked up by Hermes's entrypoint which re-reads .env on start.
-        # (Unlike compose env_file loading which is fixed at create time,
-        # plugin container entrypoints typically read .env at process start.)
-        result = subprocess.run(
-            ['docker', 'restart', container_name],
-            capture_output=True, text=True, timeout=30,
-        )
-        if result.returncode == 0:
-            logger.info(f"[vault] {container_name} restarted successfully")
-        else:
-            # Container might not exist (plugin not installed) — that's OK
-            if 'No such container' in (result.stderr or ''):
-                logger.debug(f"[vault] {container_name} not found, skipping restart (plugin likely not installed for this user)")
-            else:
-                logger.warning(
-                    f"[vault] docker restart failed for {container_name}: {result.stderr.strip()}"
-                )
-    except subprocess.TimeoutExpired:
-        logger.error(f"[vault] docker restart timed out for {container_name}")
-    except Exception as exc:
-        logger.error(f"[vault] Failed to restart {container_name}: {exc}")
 
 
 def _schedule_container_restart(container_name: str):
@@ -822,23 +777,27 @@ def sync_credential(username: str, cred_id: str) -> set[str]:
                     containers_to_restart.add(f'openvoiceui-{username}')
                     logger.info(f"Synced {cred_id} → {env_path.name} ({len(env_vars)} var(s))")
             else:
-                # Plugin consumer (e.g., "hermes") — write to the plugin's
-                # per-client env file AND schedule its container for restart.
-                # Phase 1.5 fix: previously the env_file path wrote the file
-                # but didn't schedule a restart, so plugin containers stayed
-                # on the old env values until manually restarted.
+                # Plugin consumer (e.g., "hermes") — route credential updates
+                # through the JamBot provisioning service's PUT /config/<plugin>/<user>
+                # endpoint instead of writing the plugin's .env directly. The
+                # provision service runs as mike on the host with full access
+                # to /mnt/clients/<user>/<plugin>/ (chmod 700 mike:mike) which
+                # the openvoiceui container cannot reach. The service handles
+                # the file write AND the container restart in one call.
+                #
+                # This is a NETWORK call, not a file write, so it doesn't
+                # participate in the debounce + docker restart dispatch path.
+                # Instead it's fired directly here and the provision service
+                # restarts the plugin container itself.
                 consumer_type = consumer_cfg.get('type', 'env_var')
                 if consumer_type == 'env_file':
                     plugin_id = consumer_name
-                    plugin_env_file = _CLIENTS_DIR / username / plugin_id / '.env'
-                    if _update_plugin_env_file(plugin_env_file, env_vars, consumer_cfg):
-                        # Schedule the plugin's container for restart.
-                        # Convention: plugin container is named "<plugin_id>-<username>"
-                        # (e.g., "hermes-test-dev"). If that container doesn't exist
-                        # (plugin not container-based or not installed), the restart
-                        # call is a no-op at runtime.
-                        containers_to_restart.add(f'{plugin_id}-{username}')
-                        logger.info(f"Synced {cred_id} → {plugin_env_file} ({len(env_vars)} var(s))")
+                    if _sync_to_plugin_via_provision_service(
+                        username, plugin_id, env_vars, consumer_cfg
+                    ):
+                        logger.info(
+                            f"Synced {cred_id} → {plugin_id}-{username} via provision service"
+                        )
                 elif consumer_type == 'oauth_token':
                     pass  # OAuth tokens are read directly, no push needed
                 else:
@@ -952,40 +911,109 @@ def _update_env_file(path: Path, updates: dict) -> bool:
     return True
 
 
-def _update_plugin_env_file(path: Path, env_vars: dict, consumer_cfg: dict) -> bool:
-    """Write credential env vars to a plugin's per-client .env file.
+def _sync_to_plugin_via_provision_service(
+    username: str, plugin_id: str, env_vars: dict, consumer_cfg: dict
+) -> bool:
+    """Update a plugin's per-user config via the JamBot provisioning service.
 
-    Plugin consumers can declare an `also_set` block in their consumer config
-    (e.g. Z.AI also sets GLM_BASE_URL), and the consumer_cfg can specify a
-    different env_var name than the credential's top-level one (e.g. the
-    catalog-level credential env_var is OPENROUTER_API_KEY but a plugin could
-    declare a different name for its internal env).
+    The provision service (scripts/jambot-provision-service.py on the host,
+    port 5200) exposes PUT /config/<plugin>/<user> which:
+      1. Writes the plugin's .env + config.yaml from the posted body
+      2. Restarts the plugin container so new values take effect
 
-    Creates the parent dir if missing so fresh plugin installs can be
-    written before the plugin dir exists.
+    We use this instead of writing env files directly because plugin data
+    dirs are typically /mnt/clients/<user>/<plugin>/ owned 700 mike:mike —
+    not accessible from inside the openvoiceui container. The provision
+    service runs as mike on the host and has full access.
+
+    The service expects config field IDs (e.g. `openrouter_api_key`) in the
+    body, not the env var names (`OPENROUTER_API_KEY`). We map from env var
+    back to field ID using a lowercase snake_case convention that matches
+    how the service's _HERMES_KEY_MAP is structured:
+        OPENROUTER_API_KEY → openrouter_api_key
+        HF_TOKEN           → hf_token
+        GITHUB_TOKEN       → github_token
     """
     if not env_vars:
         return False
+
+    # Build config body in the provision service's field-ID format.
+    # Convention: env var names are UPPERCASE_SNAKE → lowercase_snake field IDs.
+    body = {}
+    for env_var, value in env_vars.items():
+        field_id = env_var.lower()
+        body[field_id] = value
+
+    # Companion vars (GLM_BASE_URL etc.) go in as-is with their own field IDs.
+    # Most provision services ignore unknown field IDs.
+    for k, v in consumer_cfg.get('also_set', {}).items():
+        body[k.lower()] = v
+
+    # POST to PUT /config/<plugin>/<username>
+    # We use urllib from stdlib so services/vault.py has no new deps
+    import urllib.request
+    import urllib.error
+    import socket
+
+    url = f"{_get_provision_url()}/config/{plugin_id}/{username}"
+    data = json.dumps(body).encode('utf-8')
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method='PUT',
+        headers={'Content-Type': 'application/json'},
+    )
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-    except (PermissionError, OSError) as exc:
-        logger.warning(f"Cannot create plugin env dir {path.parent}: {exc}")
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read())
+            if result.get('ok'):
+                return True
+            logger.warning(f"[vault] provision service returned: {result}")
+            return False
+    except urllib.error.HTTPError as exc:
+        # Non-2xx from provision service — log the body for diagnosis
+        try:
+            err_body = exc.read().decode('utf-8', errors='replace')
+        except Exception:
+            err_body = '(no body)'
+        # 404 means the plugin isn't installed for this user — not an error
+        if exc.code == 404:
+            logger.debug(
+                f"[vault] plugin {plugin_id} not installed for {username}, skipping sync"
+            )
+            return False
+        logger.warning(
+            f"[vault] provision service {exc.code} for {plugin_id}/{username}: {err_body}"
+        )
+        return False
+    except (urllib.error.URLError, socket.timeout, ConnectionError) as exc:
+        logger.warning(
+            f"[vault] provision service unreachable (port 5200): {exc}. "
+            f"Plugin {plugin_id} env will not update until service is back."
+        )
         return False
 
-    # Consumer-level env_var override: use the name declared in the consumer
-    # config rather than the catalog-level default, if provided.
-    consumer_env_var = consumer_cfg.get('env_var', '')
-    resolved = dict(env_vars)
-    if consumer_env_var and len(env_vars) == 1:
-        # Single-value credential, rename to the consumer's preferred var name
-        (_, v), = env_vars.items()
-        resolved = {consumer_env_var: v}
 
-    # Merge in also_set (companion env vars like GLM_BASE_URL)
-    for k, v in consumer_cfg.get('also_set', {}).items():
-        resolved.setdefault(k, v)
-
-    return _update_env_file(path, resolved)
+def _get_provision_url() -> str:
+    """Resolve the provision service URL. Same logic as services/plugins.py."""
+    import os
+    port = os.getenv("PROVISION_SERVICE_PORT", "5200")
+    host = os.getenv("PROVISION_SERVICE_HOST", "").strip()
+    if host:
+        return f"http://{host}:{port}"
+    # Auto-detect the Docker gateway IP from /proc/net/route
+    try:
+        with open("/proc/net/route") as f:
+            next(f)  # skip header
+            for line in f:
+                fields = line.strip().split()
+                if len(fields) > 2 and fields[1] == "00000000":
+                    h = fields[2]
+                    ip = f"{int(h[6:8],16)}.{int(h[4:6],16)}.{int(h[2:4],16)}.{int(h[0:2],16)}"
+                    return f"http://{ip}:{port}"
+    except Exception:
+        pass
+    return f"http://172.17.0.1:{port}"
 
 
 def sync_all(username: str):

--- a/services/vault.py
+++ b/services/vault.py
@@ -24,10 +24,38 @@ import requests
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Paths
+# Paths — install-mode aware (Docker / Pinokio / npm)
 # ---------------------------------------------------------------------------
-_PLATFORM_CATALOG_PATH = Path('/mnt/system/base/platform-credentials.json')
-_PLATFORM_OAUTH_PATH = Path('/mnt/system/base/platform-oauth.json')
+def _platform_config_dir() -> Path:
+    """Resolve the platform config directory based on install mode.
+
+    Order of precedence:
+      1. PLATFORM_CONFIG_DIR env var (explicit override — set by Pinokio
+         install.js or npm postinstall)
+      2. /mnt/system/base — Docker mode (the JamBot multi-tenant deployment)
+      3. $XDG_CONFIG_HOME/openvoiceui — XDG standard for desktop installs
+      4. Current working directory — last-resort fallback for dev/test
+
+    All platform-level config files (platform-credentials.json,
+    .platform-oauth.env, .platform-keys.env, etc.) are located here.
+    """
+    explicit = os.getenv('PLATFORM_CONFIG_DIR', '').strip()
+    if explicit:
+        return Path(explicit)
+    docker_path = Path('/mnt/system/base')
+    if docker_path.is_dir():
+        return docker_path
+    xdg_config = Path(os.getenv('XDG_CONFIG_HOME', str(Path.home() / '.config')))
+    xdg_path = xdg_config / 'openvoiceui'
+    if xdg_path.is_dir():
+        return xdg_path
+    return Path.cwd()
+
+
+_PLATFORM_CONFIG_DIR = _platform_config_dir()
+_PLATFORM_CATALOG_PATH = _PLATFORM_CONFIG_DIR / 'platform-credentials.json'
+_PLATFORM_OAUTH_PATH = _PLATFORM_CONFIG_DIR / 'platform-oauth.json'  # legacy
+_PLATFORM_OAUTH_ENV = _PLATFORM_CONFIG_DIR / '.platform-oauth.env'   # Phase 1.5
 _CLIENTS_DIR = Path('/mnt/clients')
 _PLUGINS_DIR = Path('/app/plugins')
 _OPENCLAW_CONFIG_PATH = Path('/app/runtime/openclaw.json')
@@ -45,6 +73,66 @@ if not _PLATFORM_CATALOG_PATH.exists():
         _alt = Path(_alt_path)
         if _alt.is_file():
             _PLATFORM_CATALOG_PATH = _alt
+
+
+def _load_platform_oauth_env():
+    """Load .platform-oauth.env into os.environ if it exists.
+
+    In Docker mode, the compose `env_file:` mount loads this file already
+    and `os.environ.setdefault` is a no-op (we don't override what compose
+    set). In Pinokio/npm mode, the file isn't auto-loaded by anything, so
+    this function does the loading.
+
+    Silent no-op when the file is missing — OAuth is opt-in.
+    Comments and blank lines are ignored. Quoted values are unquoted.
+    """
+    path = _PLATFORM_OAUTH_ENV
+    try:
+        if not path.is_file():
+            return
+        for raw in path.read_text().splitlines():
+            line = raw.strip()
+            if not line or line.startswith('#'):
+                continue
+            if '=' not in line:
+                continue
+            k, v = line.split('=', 1)
+            k = k.strip()
+            v = v.strip().strip('"').strip("'")
+            if k:
+                os.environ.setdefault(k, v)
+    except (PermissionError, OSError) as exc:
+        logger.warning(f"[vault] Cannot read {path}: {exc}")
+
+
+_load_platform_oauth_env()
+
+
+def _is_oauth_platform_configured(catalog_entry: dict) -> bool:
+    """Check whether the platform operator has registered an OAuth app for
+    this credential. Returns True for non-OAuth credentials (no operator
+    setup needed). For OAuth, requires both client_id and client_secret
+    env vars to be set and non-empty.
+
+    Convention: provider 'google' looks for GOOGLE_OAUTH_CLIENT_ID and
+    GOOGLE_OAUTH_CLIENT_SECRET. Provider 'facebook' uses
+    FACEBOOK_OAUTH_APP_ID + FACEBOOK_OAUTH_APP_SECRET (Facebook's preferred
+    naming). Custom var names can be specified in the catalog entry's
+    `oauth.client_id_env` / `oauth.client_secret_env` if needed.
+    """
+    if catalog_entry.get('type') != 'oauth2':
+        return True
+    oauth = catalog_entry.get('oauth', {}) or {}
+    provider = oauth.get('provider', '').strip().lower()
+    if not provider:
+        return False
+    cid_var = oauth.get('client_id_env') or f'{provider.upper()}_OAUTH_CLIENT_ID'
+    csec_var = oauth.get('client_secret_env') or f'{provider.upper()}_OAUTH_CLIENT_SECRET'
+    cid = (os.environ.get(cid_var, '') or
+           os.environ.get(f'{provider.upper()}_OAUTH_APP_ID', '')).strip()
+    csec = (os.environ.get(csec_var, '') or
+            os.environ.get(f'{provider.upper()}_OAUTH_APP_SECRET', '')).strip()
+    return bool(cid and csec)
 
 
 # ---------------------------------------------------------------------------
@@ -569,6 +657,10 @@ def get_credentials_status(username: str) -> list[dict]:
             'docs_url': entry.get('docs_url', ''),
             'has_test': bool(entry.get('test')),
             'fields': entry.get('fields'),  # For multi-field rendering
+            # Phase 1.5 Cycle B: tells UI whether the platform operator has
+            # set up this provider. Only meaningful for OAuth — for non-OAuth
+            # creds it's always True (operator setup not required).
+            'platform_configured': _is_oauth_platform_configured(entry),
         }
 
         if cred_type == 'oauth2':
@@ -949,14 +1041,61 @@ def test_credential(username: str, cred_id: str) -> dict:
 
 # ---------------------------------------------------------------------------
 # OAuth token management
+#
+# Phase 1.5 Cycle B: OAuth app credentials (client_id + client_secret) come
+# from .platform-oauth.env via os.environ — they're loaded at module import
+# by _load_platform_oauth_env(). The legacy platform-oauth.json reader is
+# kept as a fallback for any deployments still using the old format.
 # ---------------------------------------------------------------------------
+def _get_oauth_app_creds(catalog_entry: dict, domain: str) -> Optional[dict]:
+    """Resolve OAuth app credentials for a catalog entry. Returns
+    {client_id, client_secret, redirect_uri} or None if not configured.
+
+    Reads from os.environ first (Phase 1.5 .platform-oauth.env), falls back
+    to legacy platform-oauth.json for backwards compat.
+
+    Redirect URI is built from the requesting domain — every client serves
+    its own /api/vault/oauth/callback/<provider> endpoint.
+    """
+    oauth_cfg = catalog_entry.get('oauth', {}) or {}
+    provider = oauth_cfg.get('provider', '').strip().lower()
+    if not provider:
+        return None
+
+    cid_var = oauth_cfg.get('client_id_env') or f'{provider.upper()}_OAUTH_CLIENT_ID'
+    csec_var = oauth_cfg.get('client_secret_env') or f'{provider.upper()}_OAUTH_CLIENT_SECRET'
+
+    cid = (os.environ.get(cid_var, '') or
+           os.environ.get(f'{provider.upper()}_OAUTH_APP_ID', '')).strip()
+    csec = (os.environ.get(csec_var, '') or
+            os.environ.get(f'{provider.upper()}_OAUTH_APP_SECRET', '')).strip()
+
+    if cid and csec:
+        return {
+            'client_id': cid,
+            'client_secret': csec,
+            'redirect_uri': f'https://{domain}/api/vault/oauth/callback/{provider}',
+        }
+
+    # Legacy fallback — platform-oauth.json (deprecated, kept for backcompat)
+    legacy = _read_json(_PLATFORM_OAUTH_PATH).get(provider)
+    if legacy and legacy.get('client_id') and legacy.get('client_secret'):
+        return legacy
+
+    return None
+
+
 def get_oauth_apps() -> dict:
-    """Read platform OAuth app credentials (client_id/secret per provider)."""
+    """DEPRECATED — kept for backwards compatibility with legacy callers.
+    Phase 1.5 reads OAuth app creds from os.environ via _get_oauth_app_creds().
+    """
     return _read_json(_PLATFORM_OAUTH_PATH)
 
 
 def set_oauth_app(provider: str, client_id: str, client_secret: str, redirect_uri: str):
-    """Register/update an OAuth app."""
+    """DEPRECATED — kept for backwards compatibility. Cycle C will replace
+    this with a proper Platform Setup endpoint that writes to
+    .platform-oauth.env."""
     apps = get_oauth_apps()
     apps[provider] = {
         'client_id': client_id,
@@ -969,20 +1108,25 @@ def set_oauth_app(provider: str, client_id: str, client_secret: str, redirect_ur
 def build_oauth_url(cred_id: str, username: str, domain: str) -> Optional[str]:
     """
     Build the OAuth authorization URL for a credential.
-    Returns the URL the user should be redirected to.
+    Returns the URL the user should be redirected to, or None if the
+    platform operator hasn't registered an OAuth app for this provider.
     """
     cat_entry = get_catalog_credential(cred_id)
     if not cat_entry or cat_entry.get('type') != 'oauth2':
         return None
 
-    oauth_cfg = cat_entry.get('oauth', {})
-    provider = oauth_cfg.get('provider', '')
-    apps = get_oauth_apps()
-    app_creds = apps.get(provider)
+    app_creds = _get_oauth_app_creds(cat_entry, domain)
     if not app_creds:
-        logger.error(f"No OAuth app registered for provider '{provider}'")
+        oauth_cfg = cat_entry.get('oauth', {})
+        provider = oauth_cfg.get('provider', '')
+        logger.warning(
+            f"OAuth not configured for provider '{provider}' — "
+            f"set {provider.upper()}_OAUTH_CLIENT_ID and "
+            f"{provider.upper()}_OAUTH_CLIENT_SECRET in .platform-oauth.env"
+        )
         return None
 
+    oauth_cfg = cat_entry.get('oauth', {})
     import urllib.parse
     params = {
         'client_id': app_creds['client_id'],
@@ -1006,12 +1150,15 @@ def exchange_oauth_code(cred_id: str, code: str, username: str) -> dict:
     if not cat_entry or cat_entry.get('type') != 'oauth2':
         return {'ok': False, 'error': 'Not an OAuth credential'}
 
+    # Phase 1.5 Cycle B: read OAuth app creds from .platform-oauth.env
+    # via _get_oauth_app_creds, which uses the same domain the auth URL
+    # was built with so the redirect_uri matches what the provider expects.
+    domain = os.getenv('DOMAIN', 'localhost')
+    app_creds = _get_oauth_app_creds(cat_entry, domain)
     oauth_cfg = cat_entry.get('oauth', {})
     provider = oauth_cfg.get('provider', '')
-    apps = get_oauth_apps()
-    app_creds = apps.get(provider)
     if not app_creds:
-        return {'ok': False, 'error': f'No OAuth app for provider {provider}'}
+        return {'ok': False, 'error': f'No OAuth app configured for provider {provider}'}
 
     # Exchange code for tokens
     try:

--- a/services/vault.py
+++ b/services/vault.py
@@ -178,6 +178,104 @@ def _vault_oauth_path(username: str, provider: str) -> Path:
 
 
 # ---------------------------------------------------------------------------
+# Container restart (Phase 1.5 Cycle A)
+# ---------------------------------------------------------------------------
+import threading
+
+# Debounce window for credential-triggered restarts. Multiple writes within
+# this window collapse into a single restart.
+_RESTART_DEBOUNCE_SECONDS = 5.0
+
+# Active debounce timers keyed by container name.
+_restart_timers: dict[str, threading.Timer] = {}
+_restart_lock = threading.Lock()
+
+
+def _do_restart_container(container_name: str):
+    """Actually perform the container recreate via `docker compose up -d --force-recreate`.
+    Must be a RECREATE, not a simple restart — Docker only loads env_file
+    values at container creation time, so a plain restart keeps the old env.
+    Called by the debounce timer; do not call directly.
+    """
+    import subprocess
+    # Parse container name: "openclaw-<user>" or "openvoiceui-<user>"
+    if '-' not in container_name:
+        logger.error(f"[vault] Unexpected container name format: {container_name}")
+        return
+    service, username = container_name.split('-', 1)
+    if service not in ('openclaw', 'openvoiceui'):
+        logger.error(f"[vault] Unknown service in {container_name}")
+        return
+
+    compose_file = _CLIENTS_DIR / username / 'compose' / 'docker-compose.yml'
+    env_file = _CLIENTS_DIR / username / 'compose' / '.env'
+    if not compose_file.is_file():
+        logger.error(f"[vault] compose file not found: {compose_file}")
+        return
+
+    cmd = [
+        'docker', 'compose',
+        '-f', str(compose_file),
+        '--env-file', str(env_file),
+        'up', '-d', '--force-recreate', '--no-deps',
+        service,
+    ]
+    logger.info(f"[vault] Recreating {container_name} to apply new credentials...")
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        if result.returncode == 0:
+            logger.info(f"[vault] {container_name} recreated successfully")
+            # Reconnect shared network (compose up -d disconnects cross-project networks)
+            try:
+                subprocess.run(
+                    ['docker', 'network', 'connect', 'jambot-shared', container_name],
+                    capture_output=True, text=True, timeout=10,
+                )
+            except Exception:
+                pass  # may already be connected
+        else:
+            logger.error(
+                f"[vault] docker compose up failed for {container_name}: "
+                f"stdout={result.stdout} stderr={result.stderr}"
+            )
+    except subprocess.TimeoutExpired:
+        logger.error(f"[vault] docker compose up timed out for {container_name}")
+    except Exception as exc:
+        logger.error(f"[vault] Failed to recreate {container_name}: {exc}")
+    finally:
+        with _restart_lock:
+            _restart_timers.pop(container_name, None)
+
+
+def _schedule_container_restart(container_name: str):
+    """Schedule a debounced restart of the given container. If another
+    schedule call comes in within _RESTART_DEBOUNCE_SECONDS, the earlier
+    timer is cancelled and replaced. This collapses rapid credential
+    writes into a single restart at the end."""
+    with _restart_lock:
+        existing = _restart_timers.get(container_name)
+        if existing is not None:
+            existing.cancel()
+        timer = threading.Timer(_RESTART_DEBOUNCE_SECONDS, _do_restart_container, args=[container_name])
+        timer.daemon = True
+        timer.start()
+        _restart_timers[container_name] = timer
+        logger.info(f"[vault] Scheduled restart of {container_name} in {_RESTART_DEBOUNCE_SECONDS}s")
+
+
+def restart_container_now(container_name: str) -> bool:
+    """Immediately recreate a container (bypasses the debounce). Used for
+    explicit 'Apply now' API calls if we add one later. Returns True on success."""
+    with _restart_lock:
+        existing = _restart_timers.get(container_name)
+        if existing is not None:
+            existing.cancel()
+            _restart_timers.pop(container_name, None)
+    _do_restart_container(container_name)
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Platform catalog
 # ---------------------------------------------------------------------------
 _catalog_cache: Optional[dict] = None
@@ -321,9 +419,10 @@ def get_credential_fields(username: str, cred_id: str) -> Optional[dict]:
 
 
 def set_credential(username: str, cred_id: str, value: str = None,
-                   fields: dict = None, source: str = 'user'):
+                   fields: dict = None, source: str = 'user') -> set[str]:
     """
-    Set a credential value in the vault, then sync to consumers.
+    Set a credential value in the vault, then sync to consumers and schedule
+    a restart of affected containers so the new env values take effect.
 
     Args:
         username: Client username
@@ -331,6 +430,9 @@ def set_credential(username: str, cred_id: str, value: str = None,
         value: For single-key credentials
         fields: For multi-field credentials (e.g. {"login": "x", "password": "y"})
         source: "platform", "user", or "plugin"
+
+    Returns: set of container names that will be restarted. Caller can use
+        this to inform the user that the agent is restarting.
     """
     vault = read_vault(username)
     creds = vault.setdefault('credentials', {})
@@ -347,8 +449,15 @@ def set_credential(username: str, cred_id: str, value: str = None,
     creds[cred_id] = entry
     _write_vault(username, vault)
 
-    # Sync to consumers
-    sync_credential(username, cred_id)
+    # Sync to consumers — this writes env vars to the per-client env files
+    # and returns the set of containers that need to be restarted.
+    to_restart = sync_credential(username, cred_id)
+
+    # Schedule debounced restart so rapid successive writes collapse.
+    for container_name in to_restart:
+        _schedule_container_restart(container_name)
+
+    return to_restart
 
 
 def delete_credential(username: str, cred_id: str):
@@ -417,11 +526,22 @@ def get_credentials_status(username: str) -> list[dict]:
         elif cred_type in ('multi_field', 'basic_auth'):
             fields = vault_entry.get('fields', {})
             field_defs = entry.get('fields', [])
-            has_value = all(fields.get(f['id']) for f in field_defs)
+            # Phase 1.5 fix: check env var fallback for each field. A credential
+            # configured via .platform-keys.env (without a vault entry) should
+            # still show as connected, otherwise the UI lies about state.
+            resolved = {}
+            for f in field_defs:
+                fid = f['id']
+                fval = fields.get(fid, '')
+                if not fval and f.get('env_var'):
+                    fval = os.environ.get(f['env_var'], '')
+                if fval:
+                    resolved[fid] = fval
+            has_value = all(resolved.get(f['id']) for f in field_defs)
             if has_value:
                 # Mask the first field as representative
                 first_field = field_defs[0]['id'] if field_defs else ''
-                masked_value = _mask_key(fields.get(first_field, ''))
+                masked_value = _mask_key(resolved.get(first_field, ''))
         else:
             raw_val = vault_entry.get('value', '')
             # Also check env var as fallback
@@ -487,9 +607,23 @@ def get_credentials_status(username: str) -> list[dict]:
 
 # ---------------------------------------------------------------------------
 # Sync engine — push credentials to consumers
+#
+# Phase 1.5 architecture:
+#   - Credentials are stored in /mnt/clients/<user>/vault/credentials.json
+#   - Sync writes the corresponding env vars to the per-client env files
+#     that Docker loads at container startup:
+#       openclaw consumers   → /mnt/clients/<user>/compose/.openclaw.env
+#       openvoiceui consumers → /mnt/clients/<user>/compose/.env
+#   - openclaw.json uses ${MINIMAX_API_KEY} substitution, so setting the
+#     env var is sufficient — we NEVER write into openclaw.json directly
+#   - After writes, the affected container(s) are restarted via docker socket
+#     so the new env values take effect
+#
+# Returns the set of container names that should be restarted.
 # ---------------------------------------------------------------------------
-def sync_credential(username: str, cred_id: str):
-    """Push a credential to all its declared consumers."""
+def sync_credential(username: str, cred_id: str) -> set[str]:
+    """Push a credential to all its declared consumers. Returns set of
+    container names that should be restarted for the new values to apply."""
     catalog = get_merged_catalog()
     cat_entry = None
     for c in catalog:
@@ -499,29 +633,139 @@ def sync_credential(username: str, cred_id: str):
 
     if not cat_entry:
         logger.debug(f"No catalog entry for {cred_id}, skipping sync")
-        return
+        return set()
 
     vault = read_vault(username)
     vault_entry = vault.get('credentials', {}).get(cred_id, {})
     raw_value = vault_entry.get('value', '')
     raw_fields = vault_entry.get('fields', {})
 
+    # Build the dict of env vars to set for this credential
+    env_vars = _env_vars_for_credential(cat_entry, raw_value, raw_fields)
+    if not env_vars:
+        logger.debug(f"No env vars to sync for {cred_id}")
+        return set()
+
+    containers_to_restart: set[str] = set()
     for consumer_name, consumer_cfg in cat_entry.get('consumers', {}).items():
-        consumer_type = consumer_cfg.get('type', 'env_var')
         try:
-            if consumer_type == 'openclaw_provider':
-                _sync_to_openclaw(username, cred_id, raw_value, consumer_cfg)
-            elif consumer_type == 'env_file':
-                plugin_id = consumer_name  # consumer name = plugin dir name
-                _sync_to_env_file(username, cred_id, raw_value, consumer_cfg, plugin_id)
-            elif consumer_type == 'env_var':
-                _sync_to_env_var(username, cred_id, raw_value, raw_fields, cat_entry)
-            elif consumer_type == 'oauth_token':
-                pass  # OAuth tokens are read directly, no push needed
+            if consumer_name == 'openclaw':
+                # openclaw consumer (regardless of consumer_type) → .openclaw.env
+                env_path = _CLIENTS_DIR / username / 'compose' / '.openclaw.env'
+                if _update_env_file(env_path, env_vars):
+                    containers_to_restart.add(f'openclaw-{username}')
+                    logger.info(f"Synced {cred_id} → {env_path.name} ({len(env_vars)} var(s))")
+            elif consumer_name == 'openvoiceui':
+                # openvoiceui consumer → .env (per-client)
+                env_path = _CLIENTS_DIR / username / 'compose' / '.env'
+                if _update_env_file(env_path, env_vars):
+                    containers_to_restart.add(f'openvoiceui-{username}')
+                    logger.info(f"Synced {cred_id} → {env_path.name} ({len(env_vars)} var(s))")
             else:
-                logger.warning(f"Unknown consumer type {consumer_type} for {cred_id}")
+                # Unknown consumer (e.g., plugin name) — fall back to old plugin env_file logic
+                consumer_type = consumer_cfg.get('type', 'env_var')
+                if consumer_type == 'env_file':
+                    _sync_to_env_file(username, cred_id, raw_value, consumer_cfg, consumer_name)
+                elif consumer_type == 'oauth_token':
+                    pass  # OAuth tokens are read directly, no push needed
+                else:
+                    logger.debug(f"Unhandled consumer {consumer_name} (type={consumer_type}) for {cred_id}")
         except Exception as exc:
             logger.error(f"Sync {cred_id} → {consumer_name} failed: {exc}")
+
+    return containers_to_restart
+
+
+def _env_vars_for_credential(cat_entry: dict, raw_value: str,
+                              raw_fields: dict) -> dict:
+    """Extract the env var name → value mapping for a credential.
+    Handles single-value (env_var), multi_field, and basic_auth types.
+    """
+    result = {}
+    cred_type = cat_entry.get('type', 'api_key')
+    if cred_type in ('multi_field', 'basic_auth'):
+        for fdef in cat_entry.get('fields', []):
+            fval = raw_fields.get(fdef.get('id', ''), '')
+            env_var = fdef.get('env_var', '')
+            if env_var and fval:
+                result[env_var] = fval
+    else:
+        env_var = cat_entry.get('env_var', '')
+        if env_var and raw_value:
+            result[env_var] = raw_value
+    return result
+
+
+def _update_env_file(path: Path, updates: dict) -> bool:
+    """Update an env file in place, preserving comments, blank lines, and order.
+
+    Any key in `updates` that already exists gets its value replaced.
+    Keys not present in the file are appended at the end.
+    Writes atomically via tmp + rename.
+    Returns True if the file was actually changed, False otherwise.
+    """
+    if not updates:
+        return False
+    if not path.parent.exists():
+        logger.warning(f"Parent dir missing for env file {path}")
+        return False
+
+    try:
+        existing_text = path.read_text() if path.is_file() else ''
+    except (PermissionError, OSError) as exc:
+        logger.error(f"Cannot read env file {path}: {exc}")
+        return False
+
+    lines = existing_text.splitlines()
+    seen_keys: set[str] = set()
+    new_lines: list[str] = []
+    changed = False
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#'):
+            new_lines.append(line)
+            continue
+        if '=' in stripped:
+            k = stripped.split('=', 1)[0].strip()
+            if k in updates:
+                new_val = updates[k]
+                new_line = f'{k}={new_val}'
+                if new_line != line:
+                    changed = True
+                new_lines.append(new_line)
+                seen_keys.add(k)
+                continue
+        new_lines.append(line)
+
+    # Append any keys not already in the file
+    missing = [k for k in updates if k not in seen_keys]
+    if missing:
+        if new_lines and new_lines[-1].strip():
+            new_lines.append('')  # blank line separator
+        for k in missing:
+            new_lines.append(f'{k}={updates[k]}')
+        changed = True
+
+    if not changed:
+        return False
+
+    new_text = '\n'.join(new_lines)
+    if not new_text.endswith('\n'):
+        new_text += '\n'
+
+    # Atomic write via tmp + rename
+    tmp = path.with_suffix(path.suffix + '.vault-tmp')
+    try:
+        tmp.write_text(new_text)
+        tmp.replace(path)
+    except (PermissionError, OSError) as exc:
+        logger.error(f"Cannot write env file {path}: {exc}")
+        try:
+            tmp.unlink()
+        except Exception:
+            pass
+        return False
+    return True
 
 
 def sync_all(username: str):
@@ -531,61 +775,23 @@ def sync_all(username: str):
         sync_credential(username, cred_id)
 
 
+# NOTE (Phase 1.5): _sync_to_openclaw and _sync_to_env_var are no longer
+# called by sync_credential — they used to write into openclaw.json and a
+# locally-scoped .openclaw.env respectively. That path had two fundamental
+# problems: (1) openclaw.json uses ${MINIMAX_API_KEY} style substitution so
+# overwriting apiKey with a raw value broke the template, and (2) cross-
+# container writes failed on permissions. Both are gone.
+#
+# Sync now goes through _update_env_file() dispatched per consumer name in
+# the new sync_credential() above, and the container is restarted via the
+# docker socket so the new env values take effect.
+#
+# The old functions are kept as no-ops below to preserve any external imports.
+
+
 def _sync_to_openclaw(username: str, cred_id: str, key_value: str, consumer_cfg: dict):
-    """Write/update a provider block in the client's openclaw.json.
-
-    Guarded against PermissionError — openvoiceui container (UID 1001) cannot
-    write openclaw.json (chmod 600, owned UID 1000). Phase 2 (Vault v2)
-    eliminates this cross-container write entirely; openclaw will read keys
-    from a read-only mounted vault at startup.
-    """
-    if not key_value:
-        return
-
-    config_path = _CLIENTS_DIR / username / 'openclaw' / 'openclaw.json'
-    if not config_path.exists():
-        # Fall back to runtime path (inside container)
-        config_path = _OPENCLAW_CONFIG_PATH
-    if not config_path.exists():
-        logger.warning(f"No openclaw.json found for {username}")
-        return
-
-    try:
-        config = _parse_jsonc(config_path.read_text())
-    except (PermissionError, OSError) as exc:
-        logger.warning(
-            f"Cannot read {config_path} for sync ({exc}); credential stored "
-            f"in vault only. Openclaw will continue using its existing key "
-            f"until Phase 2 migration or manual restart."
-        )
-        return
-    except Exception as exc:
-        logger.error(f"Failed to parse {config_path}: {exc}")
-        return
-
-    providers = config.setdefault('models', {'mode': 'merge'}).setdefault('providers', {})
-    provider_id = consumer_cfg['provider_id']
-
-    if provider_id not in providers:
-        # Create new provider block
-        providers[provider_id] = {
-            'baseUrl': consumer_cfg['base_url'],
-            'api': consumer_cfg['api_format'],
-            'apiKey': key_value,
-            'models': consumer_cfg.get('models', []),
-        }
-    else:
-        # Update existing key only
-        providers[provider_id]['apiKey'] = key_value
-
-    try:
-        _write_json(config_path, config)
-        logger.info(f"Synced {cred_id} → openclaw provider '{provider_id}' for {username}")
-    except (PermissionError, OSError) as exc:
-        logger.warning(
-            f"Cannot write {config_path} ({exc}); credential stored in vault "
-            f"only. Phase 2 will fix this cross-container write."
-        )
+    """DEPRECATED in Phase 1.5. No-op — sync now happens via _update_env_file()."""
+    logger.debug(f"_sync_to_openclaw called for {cred_id} — no-op in Phase 1.5")
 
 
 def _sync_to_env_file(username: str, cred_id: str, key_value: str,
@@ -630,38 +836,13 @@ def _sync_to_env_file(username: str, cred_id: str, key_value: str,
 
 def _sync_to_env_var(username: str, cred_id: str, raw_value: str,
                      raw_fields: dict, cat_entry: dict):
+    """DEPRECATED in Phase 1.5. No-op — sync now happens via _update_env_file().
+
+    The old implementation destroyed comments and blank lines by loading
+    the env file into a dict and writing it back. _update_env_file() preserves
+    everything and writes atomically.
     """
-    Sync to the client's .openclaw.env file (per-client env overrides).
-    These get picked up by Docker containers on restart.
-    """
-    env_path = _CLIENTS_DIR / username / 'compose' / '.openclaw.env'
-    if not env_path.parent.exists():
-        return
-
-    existing = {}
-    if env_path.exists():
-        for line in env_path.read_text().splitlines():
-            line = line.strip()
-            if not line or line.startswith('#'):
-                continue
-            if '=' in line:
-                k, v = line.split('=', 1)
-                existing[k.strip()] = v.strip()
-
-    cred_type = cat_entry.get('type', 'api_key')
-    if cred_type in ('multi_field', 'basic_auth'):
-        fields = cat_entry.get('fields', [])
-        for fdef in fields:
-            fval = raw_fields.get(fdef['id'], '')
-            if fval:
-                existing[fdef['env_var']] = fval
-    else:
-        env_var = cat_entry.get('env_var', '')
-        if env_var and raw_value:
-            existing[env_var] = raw_value
-
-    lines = [f"{k}={v}" for k, v in existing.items()]
-    env_path.write_text('\n'.join(lines) + '\n')
+    logger.debug(f"_sync_to_env_var called for {cred_id} — no-op in Phase 1.5")
 
 
 # ---------------------------------------------------------------------------

--- a/services/vault.py
+++ b/services/vault.py
@@ -845,18 +845,29 @@ def _update_env_file(path: Path, updates: dict) -> bool:
     if not new_text.endswith('\n'):
         new_text += '\n'
 
-    # Atomic write via tmp + rename
+    # Try atomic write via tmp + rename first (works when parent dir is writable).
+    # Fall back to direct write if the parent dir isn't writable but the file
+    # itself is — this is the case for /mnt/system/base/.platform-oauth.env
+    # which is bind-mounted as a single file rw, with parent dir read-only.
     tmp = path.with_suffix(path.suffix + '.vault-tmp')
     try:
         tmp.write_text(new_text)
         tmp.replace(path)
     except (PermissionError, OSError) as exc:
-        logger.error(f"Cannot write env file {path}: {exc}")
+        # Parent dir not writable — try direct write to the existing file
         try:
             tmp.unlink()
         except Exception:
             pass
-        return False
+        try:
+            with open(path, 'w') as f:
+                f.write(new_text)
+                f.flush()
+                os.fsync(f.fileno())
+            logger.info(f"Wrote env file {path} via direct write (parent dir not writable: {exc})")
+        except (PermissionError, OSError) as exc2:
+            logger.error(f"Cannot write env file {path}: {exc2}")
+            return False
     return True
 
 

--- a/services/vault.py
+++ b/services/vault.py
@@ -295,21 +295,40 @@ _restart_lock = threading.Lock()
 
 
 def _do_restart_container(container_name: str):
-    """Actually perform the container recreate via `docker compose up -d --force-recreate`.
-    Must be a RECREATE, not a simple restart — Docker only loads env_file
-    values at container creation time, so a plain restart keeps the old env.
+    """Recreate a container to pick up new env_file values.
+
+    Routes to the right mechanism based on the container type:
+      - openclaw-<user> / openvoiceui-<user>: managed by the client's
+        docker-compose.yml, recreated via `docker compose up -d --force-recreate`
+      - <plugin>-<user> (e.g. hermes-test-dev): managed by the JamBot
+        provisioning service (port 5200), which knows how to handle per-plugin
+        env/config files and container lifecycle. We POST to its /provision/
+        endpoint with an empty config body — the service re-uses the existing
+        .env that was just updated.
+
     Called by the debounce timer; do not call directly.
     """
     import subprocess
-    # Parse container name: "openclaw-<user>" or "openvoiceui-<user>"
     if '-' not in container_name:
         logger.error(f"[vault] Unexpected container name format: {container_name}")
         return
     service, username = container_name.split('-', 1)
-    if service not in ('openclaw', 'openvoiceui'):
-        logger.error(f"[vault] Unknown service in {container_name}")
-        return
 
+    try:
+        if service in ('openclaw', 'openvoiceui'):
+            _recreate_compose_service(service, username)
+        else:
+            # Plugin container — delegate to the provisioning service
+            _recreate_plugin_container(service, username)
+    finally:
+        with _restart_lock:
+            _restart_timers.pop(container_name, None)
+
+
+def _recreate_compose_service(service: str, username: str):
+    """Recreate an openclaw or openvoiceui container via docker compose."""
+    import subprocess
+    container_name = f'{service}-{username}'
     compose_file = _CLIENTS_DIR / username / 'compose' / 'docker-compose.yml'
     env_file = _CLIENTS_DIR / username / 'compose' / '.env'
     if not compose_file.is_file():
@@ -345,9 +364,43 @@ def _do_restart_container(container_name: str):
         logger.error(f"[vault] docker compose up timed out for {container_name}")
     except Exception as exc:
         logger.error(f"[vault] Failed to recreate {container_name}: {exc}")
-    finally:
-        with _restart_lock:
-            _restart_timers.pop(container_name, None)
+
+
+def _recreate_plugin_container(plugin_id: str, username: str):
+    """Recreate a plugin container via the JamBot provisioning service.
+
+    Sends an empty config body so the service preserves the .env file we
+    just wrote and performs a restart-with-current-config. The service's
+    endpoint handler (provision_hermes etc.) detects that the container
+    is already running and reissues a `docker restart` after the provision
+    call returns.
+    """
+    import subprocess
+    container_name = f'{plugin_id}-{username}'
+    logger.info(f"[vault] Restarting plugin container {container_name} via provision service...")
+    try:
+        # Direct docker restart is sufficient — the .env file update is
+        # picked up by Hermes's entrypoint which re-reads .env on start.
+        # (Unlike compose env_file loading which is fixed at create time,
+        # plugin container entrypoints typically read .env at process start.)
+        result = subprocess.run(
+            ['docker', 'restart', container_name],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode == 0:
+            logger.info(f"[vault] {container_name} restarted successfully")
+        else:
+            # Container might not exist (plugin not installed) — that's OK
+            if 'No such container' in (result.stderr or ''):
+                logger.debug(f"[vault] {container_name} not found, skipping restart (plugin likely not installed for this user)")
+            else:
+                logger.warning(
+                    f"[vault] docker restart failed for {container_name}: {result.stderr.strip()}"
+                )
+    except subprocess.TimeoutExpired:
+        logger.error(f"[vault] docker restart timed out for {container_name}")
+    except Exception as exc:
+        logger.error(f"[vault] Failed to restart {container_name}: {exc}")
 
 
 def _schedule_container_restart(container_name: str):
@@ -769,10 +822,23 @@ def sync_credential(username: str, cred_id: str) -> set[str]:
                     containers_to_restart.add(f'openvoiceui-{username}')
                     logger.info(f"Synced {cred_id} → {env_path.name} ({len(env_vars)} var(s))")
             else:
-                # Unknown consumer (e.g., plugin name) — fall back to old plugin env_file logic
+                # Plugin consumer (e.g., "hermes") — write to the plugin's
+                # per-client env file AND schedule its container for restart.
+                # Phase 1.5 fix: previously the env_file path wrote the file
+                # but didn't schedule a restart, so plugin containers stayed
+                # on the old env values until manually restarted.
                 consumer_type = consumer_cfg.get('type', 'env_var')
                 if consumer_type == 'env_file':
-                    _sync_to_env_file(username, cred_id, raw_value, consumer_cfg, consumer_name)
+                    plugin_id = consumer_name
+                    plugin_env_file = _CLIENTS_DIR / username / plugin_id / '.env'
+                    if _update_plugin_env_file(plugin_env_file, env_vars, consumer_cfg):
+                        # Schedule the plugin's container for restart.
+                        # Convention: plugin container is named "<plugin_id>-<username>"
+                        # (e.g., "hermes-test-dev"). If that container doesn't exist
+                        # (plugin not container-based or not installed), the restart
+                        # call is a no-op at runtime.
+                        containers_to_restart.add(f'{plugin_id}-{username}')
+                        logger.info(f"Synced {cred_id} → {plugin_env_file} ({len(env_vars)} var(s))")
                 elif consumer_type == 'oauth_token':
                     pass  # OAuth tokens are read directly, no push needed
                 else:
@@ -884,6 +950,42 @@ def _update_env_file(path: Path, updates: dict) -> bool:
             logger.error(f"Cannot write env file {path}: {exc2}")
             return False
     return True
+
+
+def _update_plugin_env_file(path: Path, env_vars: dict, consumer_cfg: dict) -> bool:
+    """Write credential env vars to a plugin's per-client .env file.
+
+    Plugin consumers can declare an `also_set` block in their consumer config
+    (e.g. Z.AI also sets GLM_BASE_URL), and the consumer_cfg can specify a
+    different env_var name than the credential's top-level one (e.g. the
+    catalog-level credential env_var is OPENROUTER_API_KEY but a plugin could
+    declare a different name for its internal env).
+
+    Creates the parent dir if missing so fresh plugin installs can be
+    written before the plugin dir exists.
+    """
+    if not env_vars:
+        return False
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except (PermissionError, OSError) as exc:
+        logger.warning(f"Cannot create plugin env dir {path.parent}: {exc}")
+        return False
+
+    # Consumer-level env_var override: use the name declared in the consumer
+    # config rather than the catalog-level default, if provided.
+    consumer_env_var = consumer_cfg.get('env_var', '')
+    resolved = dict(env_vars)
+    if consumer_env_var and len(env_vars) == 1:
+        # Single-value credential, rename to the consumer's preferred var name
+        (_, v), = env_vars.items()
+        resolved = {consumer_env_var: v}
+
+    # Merge in also_set (companion env vars like GLM_BASE_URL)
+    for k, v in consumer_cfg.get('also_set', {}).items():
+        resolved.setdefault(k, v)
+
+    return _update_env_file(path, resolved)
 
 
 def sync_all(username: str):

--- a/src/admin.html
+++ b/src/admin.html
@@ -374,7 +374,7 @@ select{cursor:pointer}
   <div class="nav-section">
     <div class="nav-label">Config</div>
     <div class="nav-item" id="nav-providers" onclick="show('providers')"><span class="nav-icon">&#x26A1;</span><span class="nav-text">Provider Config</span></div>
-    <div class="nav-item" id="nav-aiconfig" onclick="show('aiconfig')"><span class="nav-icon">&#x1F9E0;</span><span class="nav-text">AI Models &amp; Keys</span></div>
+    <div class="nav-item" id="nav-connections" onclick="show('connections')"><span class="nav-icon">&#x1F517;</span><span class="nav-text">Connections</span></div>
   </div>
   <div class="nav-section">
     <div class="nav-label">System</div>
@@ -526,11 +526,11 @@ select{cursor:pointer}
   </div>
 
 
-  <!-- AI CONFIG -->
-  <div class="panel" id="panel-aiconfig">
+  <!-- CONNECTIONS (replaces AI CONFIG) -->
+  <div class="panel" id="panel-connections">
     <div class="panel-inner">
-      <div class="ph"><div class="ph-title">AI Models &amp; API Keys</div><div class="ph-sub">Configure which AI models power your agent and manage API keys</div></div>
-      <div id="aiconfig-content"><div class="loading"><div class="spin"></div>Loading...</div></div>
+      <div class="ph"><div class="ph-title">Connections</div><div class="ph-sub">Manage API keys, model providers, and connected accounts. Plugins add their requirements here automatically.</div></div>
+      <div id="connections-content"><div class="loading"><div class="spin"></div>Loading...</div></div>
     </div>
   </div>
 
@@ -675,7 +675,7 @@ const loaders = {
   music:()=>Music.load(),
   clients:()=>Clients.load(),
   providers:()=>Providers.load(),
-  aiconfig:()=>AIConfig.load(),
+  connections:()=>Connections.load(),
   system:()=>System.load(),
   tests:()=>Tests.initSel(),
 };
@@ -1833,103 +1833,278 @@ const Providers={
 };
 
 
-// AI Config — model selection + API keys
-const AIConfig={
+// Connections — dynamic credential vault + OAuth connections + model selection
+const Connections={
   data:null,
   async load(){
-    const el=$('aiconfig-content');
+    const el=$('connections-content');
     el.innerHTML='<div class="loading"><div class="spin"></div>Loading...</div>';
     try{
-      const r=await fetch('/api/admin/ai-config');
+      const r=await fetch('/api/vault/credentials');
       this.data=await r.json();
       this.render();
-    }catch(e){el.innerHTML='<div class="empty"><div class="empty-icon">&#x26A0;</div>'+esc(e.message)+'<br><br><span style="color:var(--dim);font-size:12px">The openclaw.json config mount may be missing. Recreate containers with the updated docker-compose template.</span></div>'}
+    }catch(e){
+      el.innerHTML='<div class="empty"><div class="empty-icon">&#x26A0;</div>'+esc(e.message)+
+        '<br><br><span style="color:var(--dim);font-size:12px">Vault service may not be available. Check that routes/vault.py is loaded.</span></div>';
+    }
   },
   render(){
     const d=this.data;
-    if(!d||!d.providers){$('aiconfig-content').innerHTML='<div class="empty">No config data</div>';return}
+    if(!d||!d.groups){$('connections-content').innerHTML='<div class="empty">No credential data</div>';return}
 
-    // Build model options from all providers
-    const allModels=[];
-    for(const[pid,p]of Object.entries(d.providers)){
-      for(const m of p.models||[]){
-        allModels.push({value:pid+'/'+m.id, label:p.name+' — '+m.name, hasKey:p.hasKey, pid});
-      }
-    }
-    const mkOpt=(val)=>allModels.map(m=>
-      '<option value="'+esc(m.value)+'"'+(m.value===val?' selected':'')+(!m.hasKey?' style="color:var(--dim)"':'')+'>'+
-      esc(m.label)+(m.hasKey?'':' (no key)')+'</option>'
+    let html='';
+
+    // Model selection at top
+    const models=d.models||[];
+    const sel=d.model_selection||{};
+    const mkOpt=(val)=>models.map(m=>
+      '<option value="'+esc(m.id)+'"'+(m.id===val?' selected':'')+'>'+esc(m.provider)+' \u2014 '+esc(m.name)+'</option>'
     ).join('');
 
-    // Provider cards with key inputs
-    const provCards=Object.entries(d.providers).map(([pid,p])=>{
-      const keyStatus=p.hasKey
-        ?'<span style="color:var(--green)">Key set: '+esc(p.maskedKey)+'</span>'
-        :'<span style="color:var(--orange)">No key configured</span>';
-      return '<div class="box" style="margin-bottom:12px">'+
-        '<div class="box-title" style="display:flex;justify-content:space-between;align-items:center">'+
-          '<span>'+esc(p.name)+'</span>'+
-          '<span style="font-size:11px;font-weight:400;text-transform:none;letter-spacing:0">'+keyStatus+'</span>'+
-        '</div>'+
-        '<div class="box-body" style="display:flex;gap:8px;align-items:center">'+
-          '<input type="password" id="aikey-'+pid+'" placeholder="Paste '+esc(p.name)+' API key..." '+
-            'style="flex:1;background:var(--panel3);border:1px solid var(--border);border-radius:var(--radius);padding:8px 12px;color:var(--text);font-family:var(--mono);font-size:13px" '+
-            'autocomplete="off">'+
-          '<button class="btn btn-o btn-sm" onclick="this.previousElementSibling.type=this.previousElementSibling.type===\'password\'?\'text\':\'password\'">Show</button>'+
-        '</div>'+
-      '</div>';
-    }).join('');
+    html+='<div class="g2" style="margin-bottom:24px;gap:16px">'+
+      '<div class="box"><div class="box-title">Primary Model</div><div class="box-body">'+
+        '<select id="vault-primary" style="width:100%;background:var(--panel3);border:1px solid var(--border);border-radius:var(--radius);padding:10px 12px;color:var(--text);font-size:13px" onchange="Connections.saveModels()">'+
+          '<option value="">-- Select primary model --</option>'+mkOpt(sel.primary||'')+
+        '</select>'+
+        '<div style="margin-top:6px;font-size:11px;color:var(--dim)">Main model for all conversations and tool calls</div>'+
+      '</div></div>'+
+      '<div class="box"><div class="box-title">Fallback Model</div><div class="box-body">'+
+        '<select id="vault-fallback" style="width:100%;background:var(--panel3);border:1px solid var(--border);border-radius:var(--radius);padding:10px 12px;color:var(--text);font-size:13px" onchange="Connections.saveModels()">'+
+          '<option value="">-- No fallback --</option>'+mkOpt(sel.fallback||'')+
+        '</select>'+
+        '<div style="margin-top:6px;font-size:11px;color:var(--dim)">Used when primary model fails or is rate-limited</div>'+
+      '</div></div>'+
+    '</div>';
 
-    $('aiconfig-content').innerHTML=
-      '<div class="g2" style="margin-bottom:20px;gap:16px">'+
-        '<div class="box"><div class="box-title">Primary Model</div><div class="box-body">'+
-          '<select id="ai-primary" style="width:100%;background:var(--panel3);border:1px solid var(--border);border-radius:var(--radius);padding:10px 12px;color:var(--text);font-size:13px">'+
-            '<option value="">-- Select primary model --</option>'+mkOpt(d.primary)+
-          '</select>'+
-          '<div style="margin-top:6px;font-size:11px;color:var(--dim)">Main model used for all conversations and tool calls</div>'+
-        '</div></div>'+
-        '<div class="box"><div class="box-title">Fallback Model</div><div class="box-body">'+
-          '<select id="ai-fallback" style="width:100%;background:var(--panel3);border:1px solid var(--border);border-radius:var(--radius);padding:10px 12px;color:var(--text);font-size:13px">'+
-            '<option value="">-- No fallback --</option>'+mkOpt(d.fallback)+
-          '</select>'+
-          '<div style="margin-top:6px;font-size:11px;color:var(--dim)">Used when primary model fails or is rate-limited</div>'+
-        '</div></div>'+
-      '</div>'+
-      '<div class="ph" style="margin-bottom:12px"><div class="ph-title" style="font-size:16px">API Keys</div><div class="ph-sub">Add or update keys for each provider. Changes take effect immediately.</div></div>'+
-      '<div class="gauto" style="margin-bottom:20px">'+provCards+'</div>'+
-      '<div style="display:flex;gap:8px;align-items:center">'+
-        '<button class="btn btn-g" onclick="AIConfig.save()">Save Configuration</button>'+
-        '<span id="aiconfig-status" style="font-size:12px;color:var(--dim)"></span>'+
-      '</div>';
-  },
-  async save(){
-    const primary=$('ai-primary')?.value||'';
-    const fallback=$('ai-fallback')?.value||'';
-    const keys={};
-    for(const pid of Object.keys(this.data?.providers||{})){
-      const inp=$('aikey-'+pid);
-      if(inp&&inp.value.trim()){
-        keys[pid]=inp.value.trim();
+    // Credential groups
+    for(const group of d.groups){
+      html+='<div style="margin-bottom:24px">'+
+        '<div class="ph" style="margin-bottom:12px"><div class="ph-title" style="font-size:16px">'+esc(group.name)+'</div></div>';
+
+      for(const c of group.credentials){
+        html+=this._renderCredential(c);
       }
+      html+='</div>';
     }
-    $('aiconfig-status').textContent='Saving...';
+
+    // Add custom credential button
+    html+='<div style="margin-top:16px;padding-top:16px;border-top:1px solid var(--border)">'+
+      '<button class="btn btn-o" onclick="Connections.showAddCustom()">+ Add Custom Credential</button>'+
+      '<div id="vault-add-custom" style="display:none;margin-top:12px"></div>'+
+    '</div>';
+
+    $('connections-content').innerHTML=html;
+
+    // Listen for OAuth popup callbacks
+    window.addEventListener('message',this._onOAuthMessage);
+  },
+  _renderCredential(c){
+    const id=c.id;
+    const statusDot=c.has_value
+      ?'<span style="color:#4ade80;font-size:10px">\u25CF</span> <span style="color:#4ade80">Connected</span>'
+      :'<span style="color:#f97316;font-size:10px">\u25CF</span> <span style="color:#f97316">Not configured</span>';
+    const consumers=c.consumers&&c.consumers.length
+      ?'<span style="font-size:11px;color:var(--dim)">Used by: '+c.consumers.map(n=>'<span style="background:var(--panel3);padding:1px 6px;border-radius:3px;font-size:10px">'+esc(n)+'</span>').join(' ')+'</span>'
+      :'';
+    const pluginBadge=c.plugin_name
+      ?'<span style="font-size:10px;background:#3b82f620;color:#3b82f6;padding:1px 6px;border-radius:3px;margin-left:8px">'+esc(c.plugin_name)+'</span>'
+      :'';
+    const sourceBadge=c.source==='platform'
+      ?'<span style="font-size:10px;background:var(--panel3);color:var(--dim);padding:1px 6px;border-radius:3px;margin-left:4px">platform</span>'
+      :'';
+
+    let body='';
+    if(c.type==='oauth2'){
+      // OAuth: connect/disconnect button
+      if(c.has_value){
+        body='<div style="display:flex;gap:8px;align-items:center">'+
+          '<span style="color:var(--text);font-size:13px">'+esc(c.masked_value)+'</span>'+
+          '<button class="btn btn-o btn-sm" style="color:#f97316;border-color:#f97316" onclick="Connections.disconnectOAuth(\''+esc(id)+'\')">Disconnect</button>'+
+        '</div>';
+      }else{
+        body='<button class="btn btn-sm" style="background:#3b82f6;color:#fff;border:none" onclick="Connections.connectOAuth(\''+esc(id)+'\')">Connect '+esc(c.name)+'</button>';
+      }
+    }else if(c.type==='multi_field'||c.type==='basic_auth'){
+      // Multiple fields
+      const fields=c.fields||[];
+      body='<div id="vault-fields-'+id+'" style="display:none;margin-top:8px">';
+      for(const f of fields){
+        const isSecret=f.secret!==false;
+        body+='<div style="margin-bottom:6px;display:flex;gap:8px;align-items:center">'+
+          '<label style="min-width:100px;font-size:12px;color:var(--dim)">'+esc(f.name)+'</label>'+
+          '<input type="'+(isSecret?'password':'text')+'" id="vault-f-'+id+'-'+f.id+'" placeholder="'+esc(f.name)+'..." '+
+            'style="flex:1;background:var(--panel3);border:1px solid var(--border);border-radius:var(--radius);padding:6px 10px;color:var(--text);font-family:var(--mono);font-size:12px" autocomplete="off">'+
+        '</div>';
+      }
+      body+='<div style="display:flex;gap:8px;margin-top:8px">'+
+        '<button class="btn btn-g btn-sm" onclick="Connections.saveMulti(\''+esc(id)+'\')">Save</button>'+
+        (c.has_test?'<button class="btn btn-o btn-sm" onclick="Connections.test(\''+esc(id)+'\')">Test</button>':'')+
+        '<span id="vault-status-'+id+'" style="font-size:11px;color:var(--dim);line-height:28px"></span>'+
+      '</div></div>';
+      body='<div style="display:flex;gap:8px;align-items:center">'+
+        (c.has_value?'<span style="font-size:12px;font-family:var(--mono);color:var(--dim)">'+esc(c.masked_value)+'</span>':'')+
+        '<button class="btn btn-o btn-sm" onclick="Connections.toggleFields(\''+id+'\')">Configure</button>'+
+        (c.has_test&&c.has_value?'<button class="btn btn-o btn-sm" onclick="Connections.test(\''+esc(id)+'\')">Test</button>':'')+
+        '<span id="vault-status-'+id+'" style="font-size:11px;color:var(--dim);line-height:28px"></span>'+
+      '</div>'+body;
+    }else{
+      // Single API key
+      body='<div id="vault-input-'+id+'" style="display:none;margin-top:8px">'+
+        '<div style="display:flex;gap:8px;align-items:center">'+
+          '<input type="password" id="vault-key-'+id+'" placeholder="Paste '+esc(c.name)+' API key..." '+
+            'style="flex:1;background:var(--panel3);border:1px solid var(--border);border-radius:var(--radius);padding:6px 10px;color:var(--text);font-family:var(--mono);font-size:12px" autocomplete="off">'+
+          '<button class="btn btn-o btn-sm" onclick="this.parentElement.querySelector(\'input\').type=this.parentElement.querySelector(\'input\').type===\'password\'?\'text\':\'password\'">Show</button>'+
+          '<button class="btn btn-g btn-sm" onclick="Connections.saveKey(\''+esc(id)+'\')">Save</button>'+
+        '</div>'+
+      '</div>';
+      body='<div style="display:flex;gap:8px;align-items:center">'+
+        (c.has_value?'<span style="font-size:12px;font-family:var(--mono);color:var(--dim)">'+esc(c.masked_value)+'</span>':'')+
+        '<button class="btn btn-o btn-sm" onclick="Connections.toggleInput(\''+id+'\')">Configure</button>'+
+        (c.has_test&&c.has_value?'<button class="btn btn-o btn-sm" onclick="Connections.test(\''+esc(id)+'\')">Test</button>':'')+
+        '<span id="vault-status-'+id+'" style="font-size:11px;color:var(--dim);line-height:28px"></span>'+
+      '</div>'+body;
+    }
+
+    return '<div class="box" style="margin-bottom:8px">'+
+      '<div class="box-title" style="display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:4px">'+
+        '<span>'+esc(c.name)+pluginBadge+sourceBadge+'</span>'+
+        '<span style="font-size:11px;font-weight:400;text-transform:none;letter-spacing:0">'+statusDot+'</span>'+
+      '</div>'+
+      (c.description?'<div style="font-size:12px;color:var(--dim);padding:0 12px;margin-bottom:4px">'+esc(c.description)+'</div>':'')+
+      '<div class="box-body">'+
+        (consumers?'<div style="margin-bottom:8px">'+consumers+'</div>':'')+
+        body+
+      '</div>'+
+    '</div>';
+  },
+  toggleInput(id){
+    const el=$('vault-input-'+id);
+    if(el) el.style.display=el.style.display==='none'?'block':'none';
+  },
+  toggleFields(id){
+    const el=$('vault-fields-'+id);
+    if(el) el.style.display=el.style.display==='none'?'block':'none';
+  },
+  async saveKey(id){
+    const inp=$('vault-key-'+id);
+    if(!inp||!inp.value.trim())return;
+    const st=$('vault-status-'+id);
+    if(st) st.textContent='Saving...';
     try{
-      const r=await fetch('/api/admin/ai-config',{
-        method:'PUT',
-        headers:{'Content-Type':'application/json'},
-        body:JSON.stringify({primary,fallback,keys})
+      const r=await fetch('/api/vault/credentials/'+id,{
+        method:'PUT',headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({value:inp.value.trim()})
       });
       const d=await r.json();
+      if(d.ok){toast(d.message||'Saved','green');setTimeout(()=>this.load(),500)}
+      else{toast(d.error||'Failed','red');if(st) st.textContent='Error'}
+    }catch(e){toast(e.message,'red');if(st) st.textContent='Error'}
+  },
+  async saveMulti(id){
+    const fields={};
+    document.querySelectorAll('[id^="vault-f-'+id+'-"]').forEach(inp=>{
+      const fid=inp.id.replace('vault-f-'+id+'-','');
+      if(inp.value.trim()) fields[fid]=inp.value.trim();
+    });
+    if(!Object.keys(fields).length)return;
+    const st=$('vault-status-'+id);
+    if(st) st.textContent='Saving...';
+    try{
+      const r=await fetch('/api/vault/credentials/'+id,{
+        method:'PUT',headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({fields})
+      });
+      const d=await r.json();
+      if(d.ok){toast(d.message||'Saved','green');setTimeout(()=>this.load(),500)}
+      else{toast(d.error||'Failed','red');if(st) st.textContent='Error'}
+    }catch(e){toast(e.message,'red');if(st) st.textContent='Error'}
+  },
+  async saveModels(){
+    const primary=$('vault-primary')?.value||'';
+    const fallback=$('vault-fallback')?.value||'';
+    try{
+      const r=await fetch('/api/vault/credentials/_model_selection',{
+        method:'PUT',headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({primary,fallback})
+      });
+      const d=await r.json();
+      if(d.ok) toast('Model selection saved','green');
+      else toast(d.error||'Failed','red');
+    }catch(e){toast(e.message,'red')}
+  },
+  async test(id){
+    const st=$('vault-status-'+id);
+    if(st) st.innerHTML='<span style="color:var(--dim)">Testing...</span>';
+    try{
+      const r=await fetch('/api/vault/credentials/'+id+'/test',{method:'POST'});
+      const d=await r.json();
       if(d.ok){
-        toast(d.message||'Saved','green');
-        $('aiconfig-status').textContent='Saved';
-        // Reload to reflect changes
-        setTimeout(()=>this.load(),500);
+        if(st) st.innerHTML='<span style="color:#4ade80">\u2713 '+esc(d.message||'OK')+' ('+d.latency_ms+'ms)</span>';
       }else{
-        toast(d.error||'Save failed','red');
-        $('aiconfig-status').textContent='Error';
+        if(st) st.innerHTML='<span style="color:#f97316">\u2717 '+esc(d.message||'Failed')+'</span>';
       }
-    }catch(e){toast(e.message,'red');$('aiconfig-status').textContent='Error'}
+    }catch(e){if(st) st.innerHTML='<span style="color:#ef4444">'+esc(e.message)+'</span>'}
+  },
+  async connectOAuth(id){
+    try{
+      const r=await fetch('/api/vault/oauth/'+id+'/connect');
+      const d=await r.json();
+      if(d.url){
+        // Open OAuth popup
+        this._oauthCredId=id;
+        window.open(d.url,'oauth_popup','width=600,height=700,scrollbars=yes');
+      }else{
+        toast(d.error||'OAuth not configured','red');
+      }
+    }catch(e){toast(e.message,'red')}
+  },
+  _oauthCredId:null,
+  _onOAuthMessage(e){
+    if(e.data&&e.data.type==='oauth_callback'){
+      if(e.data.status==='success'){
+        toast('Connected: '+e.data.message,'green');
+      }else{
+        toast('OAuth failed: '+e.data.message,'red');
+      }
+      setTimeout(()=>Connections.load(),500);
+    }
+  },
+  async disconnectOAuth(id){
+    if(!confirm('Disconnect this account? You can reconnect later.'))return;
+    try{
+      const r=await fetch('/api/vault/oauth/'+id+'/disconnect',{method:'POST'});
+      const d=await r.json();
+      if(d.ok){toast('Disconnected','green');setTimeout(()=>this.load(),500)}
+      else toast(d.error||'Failed','red');
+    }catch(e){toast(e.message,'red')}
+  },
+  showAddCustom(){
+    const el=$('vault-add-custom');
+    if(!el)return;
+    if(el.style.display!=='none'){el.style.display='none';return}
+    el.style.display='block';
+    el.innerHTML='<div class="box"><div class="box-title">Add Custom Credential</div><div class="box-body">'+
+      '<div style="display:flex;flex-direction:column;gap:8px">'+
+        '<input id="vault-custom-name" type="text" placeholder="Display name (e.g. My Custom API)" style="background:var(--panel3);border:1px solid var(--border);border-radius:var(--radius);padding:8px 12px;color:var(--text);font-size:13px">'+
+        '<input id="vault-custom-env" type="text" placeholder="Environment variable (e.g. MY_API_KEY)" style="background:var(--panel3);border:1px solid var(--border);border-radius:var(--radius);padding:8px 12px;color:var(--text);font-family:var(--mono);font-size:13px">'+
+        '<input id="vault-custom-value" type="password" placeholder="API key value" style="background:var(--panel3);border:1px solid var(--border);border-radius:var(--radius);padding:8px 12px;color:var(--text);font-family:var(--mono);font-size:13px" autocomplete="off">'+
+        '<div style="display:flex;gap:8px"><button class="btn btn-g btn-sm" onclick="Connections.addCustom()">Add</button><button class="btn btn-o btn-sm" onclick="$(\'vault-add-custom\').style.display=\'none\'">Cancel</button></div>'+
+      '</div></div></div>';
+  },
+  async addCustom(){
+    const name=$('vault-custom-name')?.value?.trim();
+    const env_var=$('vault-custom-env')?.value?.trim();
+    const value=$('vault-custom-value')?.value?.trim();
+    if(!name||!env_var){toast('Name and env var are required','red');return}
+    try{
+      const r=await fetch('/api/vault/credentials',{
+        method:'POST',headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({name,env_var,value})
+      });
+      const d=await r.json();
+      if(d.ok){toast(d.message||'Added','green');setTimeout(()=>this.load(),500)}
+      else toast(d.error||'Failed','red');
+    }catch(e){toast(e.message,'red')}
   }
 };
 

--- a/src/admin.html
+++ b/src/admin.html
@@ -375,6 +375,7 @@ select{cursor:pointer}
     <div class="nav-label">Config</div>
     <div class="nav-item" id="nav-providers" onclick="show('providers')"><span class="nav-icon">&#x26A1;</span><span class="nav-text">Provider Config</span></div>
     <div class="nav-item" id="nav-connections" onclick="show('connections')"><span class="nav-icon">&#x1F517;</span><span class="nav-text">Connections</span></div>
+    <div class="nav-item" id="nav-platform-setup" onclick="show('platform-setup')"><span class="nav-icon">&#x2699;</span><span class="nav-text">Platform Setup</span></div>
   </div>
   <div class="nav-section">
     <div class="nav-label">System</div>
@@ -534,6 +535,17 @@ select{cursor:pointer}
     </div>
   </div>
 
+  <!-- PLATFORM SETUP — register OAuth apps once for all clients -->
+  <div class="panel" id="panel-platform-setup">
+    <div class="panel-inner">
+      <div class="ph">
+        <div class="ph-title">Platform Setup</div>
+        <div class="ph-sub">Register OAuth apps with Google, Facebook, QuickBooks, and LinkedIn so your clients can connect their accounts. This is operator-level configuration — done once, applies to every client on this instance. OAuth is optional; if you skip this, the OAuth section of the Connections page stays disabled and everything else works.</div>
+      </div>
+      <div id="platform-setup-content"><div class="loading"><div class="spin"></div>Loading...</div></div>
+    </div>
+  </div>
+
   <!-- SYSTEM -->
   <div class="panel" id="panel-system">
     <div class="panel-inner">
@@ -676,6 +688,7 @@ const loaders = {
   clients:()=>Clients.load(),
   providers:()=>Providers.load(),
   connections:()=>Connections.load(),
+  'platform-setup':()=>PlatformSetup.load(),
   system:()=>System.load(),
   tests:()=>Tests.initSel(),
 };
@@ -1975,9 +1988,15 @@ const Connections={
       '</div>'+body;
     }
 
+    // Phase 1.5: docs/signup link so users can quickly get to the provider's
+    // site to register/sign up for an API key
+    const docsLink=c.docs_url
+      ?'<a href="'+esc(c.docs_url)+'" target="_blank" rel="noopener" style="font-size:11px;color:#3b82f6;text-decoration:none;margin-left:8px;white-space:nowrap" title="Open '+esc(c.name)+' to get an API key">Get key ↗</a>'
+      :'';
+
     return '<div class="box" style="margin-bottom:8px">'+
       '<div class="box-title" style="display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:4px">'+
-        '<span>'+esc(c.name)+pluginBadge+sourceBadge+'</span>'+
+        '<span>'+esc(c.name)+pluginBadge+sourceBadge+docsLink+'</span>'+
         '<span style="font-size:11px;font-weight:400;text-transform:none;letter-spacing:0">'+statusDot+'</span>'+
       '</div>'+
       (c.description?'<div style="font-size:12px;color:var(--dim);padding:0 12px;margin-bottom:4px">'+esc(c.description)+'</div>':'')+
@@ -2145,6 +2164,144 @@ const Connections={
       else toast(d.error||'Failed','red');
     }catch(e){toast(e.message,'red')}
   }
+};
+
+// Phase 1.5 Cycle C — Platform Setup
+// Operator-level OAuth app registration. Read/write .platform-oauth.env
+// via /api/vault/platform-setup. Always visible to admins.
+const PlatformSetup={
+  async load(){
+    const el=$('platform-setup-content');
+    if(!el)return;
+    el.innerHTML='<div class="loading"><div class="spin"></div>Loading...</div>';
+    try{
+      const r=await fetch('/api/vault/platform-setup');
+      if(!r.ok)throw new Error('Failed to load: '+r.status);
+      const d=await r.json();
+      this.render(d);
+    }catch(e){
+      el.innerHTML='<div class="empty" style="padding:20px;color:#ef4444">'+
+        '⚠ Could not load Platform Setup: '+esc(e.message)+
+        '<br><br><span style="color:var(--dim);font-size:12px">If you see "platform-setup endpoint not found", make sure routes/vault.py has been updated for Phase 1.5 Cycle C and the openvoiceui container has been restarted.</span></div>';
+    }
+  },
+  render(d){
+    const el=$('platform-setup-content');
+    const providers=d.providers||[];
+    let html='<div style="display:flex;flex-direction:column;gap:16px">';
+
+    // Top-of-page summary
+    const configured=providers.filter(p=>p.configured).length;
+    const total=providers.length;
+    html+='<div class="box"><div class="box-body" style="padding:12px 16px;background:var(--panel2);border:1px solid var(--border);border-radius:var(--radius)">'+
+      '<div style="font-size:13px;color:var(--text)"><strong>'+configured+' of '+total+'</strong> OAuth providers configured</div>'+
+      '<div style="font-size:11px;color:var(--dim);margin-top:4px">'+
+        'Each provider you enable here unlocks Connect buttons for the matching credentials in the Connections page. Clients then authorize their own accounts via the standard OAuth consent screen.'+
+      '</div>'+
+      '<div style="font-size:11px;color:var(--dim);margin-top:4px">Stored in <code style="background:var(--panel3);padding:1px 4px;border-radius:3px">'+esc(d.env_file||'.platform-oauth.env')+'</code></div>'+
+    '</div></div>';
+
+    // Provider cards
+    for(const p of providers){
+      const statusBadge=p.configured
+        ?'<span style="font-size:10px;background:#10b98120;color:#10b981;padding:2px 8px;border-radius:3px;font-weight:600">CONFIGURED</span>'
+        :'<span style="font-size:10px;background:#71717a20;color:#a1a1aa;padding:2px 8px;border-radius:3px;font-weight:600">NOT CONFIGURED</span>';
+
+      const enabledList=(p.enables_credentials||[]).join(', ')||'(no catalog credentials registered yet)';
+
+      html+='<div class="box" style="border:1px solid var(--border);border-radius:var(--radius);padding:14px 16px;background:var(--panel2)">'+
+        // Header
+        '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;flex-wrap:wrap;gap:8px">'+
+          '<div style="font-size:15px;font-weight:600;color:var(--text)">'+esc(p.name)+'</div>'+
+          statusBadge+
+        '</div>'+
+        '<div style="font-size:12px;color:var(--dim);margin-bottom:10px">'+esc(p.description)+'</div>'+
+        '<div style="font-size:11px;color:var(--dim);margin-bottom:12px">Enables: <code style="background:var(--panel3);padding:1px 4px;border-radius:3px">'+esc(enabledList)+'</code></div>'+
+
+        // Step-by-step (collapsible)
+        '<details style="margin-bottom:12px"><summary style="cursor:pointer;font-size:12px;color:#3b82f6;font-weight:500">▶ How to set up '+esc(p.name)+' OAuth</summary>'+
+          '<div style="margin-top:10px;padding:10px;background:var(--panel3);border-radius:var(--radius)">'+
+            '<div style="margin-bottom:8px"><a href="'+esc(p.console_create_url||p.console_url)+'" target="_blank" rel="noopener" class="btn btn-sm" style="background:#3b82f6;color:#fff;text-decoration:none;display:inline-block">Open '+esc(p.name)+' Console ↗</a></div>'+
+            '<ol style="margin:0;padding-left:18px;font-size:12px;color:var(--text);line-height:1.6">'+
+              p.setup_steps.map(s=>'<li>'+esc(s)+'</li>').join('')+
+            '</ol>'+
+            '<div style="margin-top:12px;font-size:11px;color:var(--dim)">'+
+              '<strong>Authorized redirect URIs</strong> (paste these in the console — one per client):'+
+            '</div>'+
+            '<textarea readonly id="psu-uris-'+p.id+'" style="width:100%;margin-top:6px;background:var(--panel);border:1px solid var(--border);border-radius:var(--radius);padding:8px;color:var(--text);font-family:var(--mono);font-size:11px;height:120px;resize:vertical">'+
+              esc((p.redirect_uris||[]).join('\n'))+
+            '</textarea>'+
+            '<button class="btn btn-o btn-sm" style="margin-top:6px" onclick="PlatformSetup.copyUris(\''+esc(p.id)+'\')">Copy URIs</button>'+
+            (p.docs_url?'<a href="'+esc(p.docs_url)+'" target="_blank" rel="noopener" style="margin-left:8px;font-size:11px;color:#3b82f6;text-decoration:none">📖 Docs</a>':'')+
+          '</div>'+
+        '</details>'+
+
+        // Credential inputs
+        '<div style="display:flex;flex-direction:column;gap:8px">'+
+          '<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">'+
+            '<label style="min-width:110px;font-size:12px;color:var(--dim)">Client ID</label>'+
+            '<input type="text" id="psu-cid-'+p.id+'" name="psu-cid-'+p.id+'" placeholder="(not set)" value="'+esc(p.client_id||'')+'" style="flex:1;min-width:200px;background:var(--panel3);border:1px solid var(--border);border-radius:var(--radius);padding:8px 12px;color:var(--text);font-family:var(--mono);font-size:12px" autocomplete="off" data-lpignore="true" data-1p-ignore="true">'+
+          '</div>'+
+          '<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">'+
+            '<label style="min-width:110px;font-size:12px;color:var(--dim)">Client Secret</label>'+
+            '<input type="password" id="psu-csec-'+p.id+'" name="psu-csec-'+p.id+'" placeholder="'+(p.has_secret?esc(p.client_secret_masked||'(set)'):'(not set)')+'" style="flex:1;min-width:200px;background:var(--panel3);border:1px solid var(--border);border-radius:var(--radius);padding:8px 12px;color:var(--text);font-family:var(--mono);font-size:12px" autocomplete="new-password" data-lpignore="true" data-1p-ignore="true">'+
+          '</div>'+
+          (p.has_secret?'<div style="font-size:11px;color:var(--dim);margin-left:118px">Current secret: <code style="background:var(--panel3);padding:1px 4px;border-radius:3px">'+esc(p.client_secret_masked||'(set)')+'</code> (paste a new value to replace)</div>':'')+
+          '<div style="display:flex;gap:8px;margin-top:4px">'+
+            '<button class="btn btn-g btn-sm" onclick="PlatformSetup.save(\''+esc(p.id)+'\')">Save</button>'+
+            (p.configured?'<button class="btn btn-o btn-sm" style="color:#ef4444;border-color:#ef4444" onclick="PlatformSetup.clear(\''+esc(p.id)+'\')">Clear</button>':'')+
+            '<span id="psu-status-'+p.id+'" style="font-size:11px;color:var(--dim);line-height:28px"></span>'+
+          '</div>'+
+        '</div>'+
+      '</div>';
+    }
+
+    html+='</div>';
+    el.innerHTML=html;
+  },
+  copyUris(id){
+    const ta=$('psu-uris-'+id);
+    if(!ta)return;
+    ta.select();
+    document.execCommand('copy');
+    toast('Redirect URIs copied','green');
+  },
+  async save(id){
+    const cid=$('psu-cid-'+id)?.value?.trim()||'';
+    const csec=$('psu-csec-'+id)?.value?.trim()||'';
+    if(!cid){toast('Client ID is required','red');return}
+    // If user left secret blank but it was already set, that means "no change"
+    // — server keeps the existing value. We send empty string only when the
+    // user actually wants to clear it (use the Clear button for that).
+    if(!csec){
+      toast('Paste the Client Secret too (leave both blank only if you used Clear)','red');
+      return;
+    }
+    const st=$('psu-status-'+id);
+    if(st)st.textContent='Saving...';
+    try{
+      const r=await fetch('/api/vault/platform-setup/'+id,{
+        method:'PUT',headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({client_id:cid,client_secret:csec})
+      });
+      const d=await r.json();
+      if(!d.ok){toast(d.error||'Failed','red');if(st)st.textContent='Error';return}
+      // Phase 1.5 Cycle C: env var update is live immediately, no restart needed
+      toast(d.message||'Saved','green');
+      if(st)st.textContent='Saved';
+      setTimeout(()=>{this.load()},500);
+      setTimeout(()=>{if(st)st.textContent=''},4000);
+    }catch(e){toast(e.message,'red');if(st)st.textContent='Error'}
+  },
+  async clear(id){
+    if(!confirm('Clear '+id+' OAuth credentials? Clients will no longer be able to connect this provider.'))return;
+    try{
+      const r=await fetch('/api/vault/platform-setup/'+id,{method:'DELETE'});
+      const d=await r.json();
+      if(d.ok){toast(d.message||'Cleared','green');setTimeout(()=>this.load(),500)}
+      else toast(d.error||'Failed','red');
+    }catch(e){toast(e.message,'red')}
+  },
 };
 
 // System

--- a/src/admin.html
+++ b/src/admin.html
@@ -1921,6 +1921,16 @@ const Connections={
           '<span style="color:var(--text);font-size:13px">'+esc(c.masked_value)+'</span>'+
           '<button class="btn btn-o btn-sm" style="color:#f97316;border-color:#f97316" onclick="Connections.disconnectOAuth(\''+esc(id)+'\')">Disconnect</button>'+
         '</div>';
+      }else if(c.platform_configured===false){
+        // Phase 1.5 Cycle B: platform operator hasn't registered an OAuth app
+        // for this provider. Show a clear, non-clickable disabled state with
+        // a deep link to Platform Setup so the operator can enable it.
+        body='<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">'+
+          '<button class="btn btn-sm" style="background:var(--panel3);color:var(--dim);border:1px dashed var(--border);cursor:not-allowed" disabled title="Platform operator needs to configure this OAuth provider in Platform Setup">'+
+            'Connect '+esc(c.name)+
+          '</button>'+
+          '<a href="#platform-setup" style="font-size:11px;color:#3b82f6;text-decoration:none">⚠ Not enabled by platform — set up →</a>'+
+        '</div>';
       }else{
         body='<button class="btn btn-sm" style="background:#3b82f6;color:#fff;border:none" onclick="Connections.connectOAuth(\''+esc(id)+'\')">Connect '+esc(c.name)+'</button>';
       }

--- a/src/admin.html
+++ b/src/admin.html
@@ -1996,8 +1996,9 @@ const Connections={
         body:JSON.stringify({value:inp.value.trim()})
       });
       const d=await r.json();
-      if(d.ok){toast(d.message||'Saved','green');setTimeout(()=>this.load(),500)}
-      else{toast(d.error||'Failed','red');if(st) st.textContent='Error'}
+      if(d.ok){
+        this._handleSaveSuccess(id, d, st);
+      }else{toast(d.error||'Failed','red');if(st) st.textContent='Error'}
     }catch(e){toast(e.message,'red');if(st) st.textContent='Error'}
   },
   async saveMulti(id){
@@ -2015,9 +2016,37 @@ const Connections={
         body:JSON.stringify({fields})
       });
       const d=await r.json();
-      if(d.ok){toast(d.message||'Saved','green');setTimeout(()=>this.load(),500)}
-      else{toast(d.error||'Failed','red');if(st) st.textContent='Error'}
+      if(d.ok){
+        this._handleSaveSuccess(id, d, st);
+      }else{toast(d.error||'Failed','red');if(st) st.textContent='Error'}
     }catch(e){toast(e.message,'red');if(st) st.textContent='Error'}
+  },
+  _handleSaveSuccess(id, d, st){
+    // Phase 1.5: server tells us which containers will be restarted and the ETA.
+    // Show a clear countdown + confirmation so users aren't guessing.
+    const restarting = Array.isArray(d.restarting) ? d.restarting : [];
+    const eta = d.eta_seconds || 0;
+    if(restarting.length && eta){
+      toast('Saved. Agent restarting ('+restarting.join(', ')+')... ~'+eta+'s','green');
+      if(st) st.textContent='Saving → agent restart scheduled...';
+      // Poll until the agent is back, then reload the credentials list so the
+      // user sees the new masked value + "connected" status.
+      let elapsed = 0;
+      const poll = setInterval(()=>{
+        elapsed += 2;
+        if(st) st.textContent='Restarting agent... '+Math.max(0,eta-elapsed)+'s';
+        if(elapsed >= eta + 5){
+          clearInterval(poll);
+          if(st) st.textContent='Agent now using new value';
+          toast('Agent live with new value','green');
+          this.load();
+          setTimeout(()=>{ if(st) st.textContent=''; }, 4000);
+        }
+      }, 2000);
+    }else{
+      toast(d.message||'Saved','green');
+      setTimeout(()=>this.load(),500);
+    }
   },
   async saveModels(){
     const primary=$('vault-primary')?.value||'';

--- a/src/app.js
+++ b/src/app.js
@@ -300,6 +300,12 @@ initUpdateChecker();
                     const activeProfile = this._profiles.find(p => p.id === activeId);
                     const agentId = activeProfile?.adapter_config?.agentId || null;
                     localStorage.setItem('gateway_agent_id', agentId || '');
+                    // Store the gateway_id so the Action Console can show which
+                    // backend gateway is handling conversations ("openclaw",
+                    // "hermes", etc.). Defaults to "openclaw" to match the
+                    // server-side conversation.py fallback.
+                    const gatewayId = activeProfile?.adapter_config?.gateway_id || 'openclaw';
+                    localStorage.setItem('gateway_id', gatewayId);
                     if (activeProfile) TranscriptPanel.agentName = activeProfile.name;
                     localStorage.setItem('active_profile_id', activeId);
 
@@ -3480,8 +3486,12 @@ initUpdateChecker();
                         this.callbacks.onListening();
                     }
                 } else {
-                    console.error('Failed to start voice input');
-                    this.callbacks.onError('Failed to start voice input');
+                    // stt.start() returning false is almost always "user muted their
+                    // mic before the call fully started" (common pattern for text-only
+                    // reply in a noisy room), NOT an actual device failure. Don't show
+                    // an error popup for this — the text input still works fine.
+                    console.log('Voice input not started (likely muted by user — text input still works)');
+                    ActionConsole.addEntry('system', 'Mic is muted — text input active');
                 }
                 this._startingSession = false;
             }
@@ -3666,7 +3676,13 @@ initUpdateChecker();
                     if (!response.ok) {
                         throw new Error(`API error: ${response.status}`);
                     }
-                    ActionConsole.addEntry('system', 'Connected to server — waiting for agent...');
+                    {
+                        const _gwId = localStorage.getItem('gateway_id') || 'openclaw';
+                        const _gwLabel = _gwId === 'hermes' ? 'Hermes' :
+                                         _gwId === 'openclaw' ? 'OpenClaw' :
+                                         _gwId;
+                        ActionConsole.addEntry('system', `Connected to ${_gwLabel} gateway — waiting for agent...`);
+                    }
 
                     // Stream mode: read NDJSON lines with real-time deltas
                     const reader = response.body.getReader();
@@ -4775,7 +4791,7 @@ initUpdateChecker();
                         console.log(`Clawdbot ${role}:`, text);
                     },
                     onError: (error) => {
-                        UIModule.showError(`Clawdbot error: ${error}`);
+                        UIModule.showError(`Agent error: ${error}`);
                         FaceModule.setMood('sad');
                         setTimeout(() => FaceModule.setMood('neutral'), 2000);
                     }
@@ -6151,7 +6167,7 @@ initUpdateChecker();
 
                     return { success: true, response: data.response };
                 } catch (error) {
-                    return { success: false, error: `Clawdbot error: ${error.message}` };
+                    return { success: false, error: `Agent error: ${error.message}` };
                 }
             }
 
@@ -8083,15 +8099,25 @@ initUpdateChecker();
                 for (const action of actions) {
                     if (action.type === 'tool') {
                         const phase = action.phase === 'result' ? '✓' : '→';
-                        // Build a readable detail line from the input parameters
+                        // Different gateways emit different action event shapes:
+                        //   OpenClaw: action.input (nested object) on start,
+                        //             action.result (string) on result,
+                        //             action.meta (summary) on result
+                        //   Hermes:   action.detail (flat string with command/target)
                         let detail = '';
                         if (action.phase === 'result') {
-                            // For results, show first meaningful line of output
-                            const raw = action.result || '';
-                            detail = raw.split('\n').filter(l => l.trim())[0]?.slice(0, 120) || raw.slice(0, 120);
+                            if (action.meta) {
+                                detail = String(action.meta).slice(0, 120);
+                            } else {
+                                const raw = action.result || '';
+                                detail = raw.split('\n').filter(l => l.trim())[0]?.slice(0, 120) || raw.slice(0, 120);
+                            }
+                        } else if (action.detail) {
+                            // Hermes format: flat string detail
+                            detail = String(action.detail).slice(0, 120);
                         } else if (action.input && typeof action.input === 'object' && Object.keys(action.input).length) {
+                            // OpenClaw format: nested input object
                             const inp = action.input;
-                            // Extract the most useful field for display
                             detail = inp.command || inp.path || inp.file_path || inp.filePath ||
                                      inp.query || inp.url || inp.pattern ||
                                      inp.oldText?.slice?.(0, 60) ||


### PR DESCRIPTION
## Summary

Phase 1.5 makes the credential Connections page actually work end-to-end. Phase 1 landed the page that *reads* credentials but saves didn't reach the running agent — it was functionally a mockup using real data. This PR fixes that, plus adds an opt-in OAuth pattern and a new Platform Setup admin page where operators register OAuth apps once for all clients.

Built and verified on `test-dev`, then rolled to all 15 live Phase 1.5 clients (14 fleet + mm-test). Each cycle was implemented, verified, committed, and signed off independently before moving to the next.

## Three cycles, four commits

### Cycle A — `00b2b7f` — credential writes reach running agents

Saving a credential now:
1. Persists to `/mnt/clients/<user>/vault/credentials.json` (unchanged)
2. Writes corresponding env var(s) to the per-client env file, preserving comments and blank lines:
   - `openclaw` consumer → `/mnt/clients/<user>/compose/.openclaw.env`
   - `openvoiceui` consumer → `/mnt/clients/<user>/compose/.env`
3. Schedules a debounced (5s) recreate of the affected container via `docker compose up -d --force-recreate --no-deps <service>` using docker-py + a host-bind-mounted docker CLI. `container.restart()` was NOT used — Docker only reloads `env_file:` values at container *creation*, not restart.
4. Agent picks up the new value within ~6-15 seconds of Save. UI shows a countdown + "Agent now using new value" confirmation.

Why write to `.openclaw.env` instead of poking `openclaw.json`:
- `openclaw.json` uses `${MINIMAX_API_KEY}`-style variable substitution; overwriting `apiKey` with raw values would break the template permanently
- Cross-container writes fail on permissions (openvoiceui UID 1001 can't write files owned by openclaw UID 1000)
- Env files are the real source of truth; openclaw.json just references them

Bonus fix inside Cycle A: multi-field credentials (Suno, Twilio, DataForSEO, Snov, Clerk) now correctly show as "connected" when configured via shared `.platform-keys.env`. The old code only checked the vault file for multi-field creds, so anything set via env file showed as "not connected" even though the agent was using it.

### Cycle B — `a4aa882` — `.platform-oauth.env` opt-in OAuth pattern

OAuth providers (Google, Facebook, QuickBooks/Intuit, LinkedIn) are now opt-in via a new env file. Out of the box, with no operator setup, the Connections page renders OAuth cards as visually disabled with a clear "⚠ Not enabled by platform — set up →" message. Casual single-tenant users never see broken OAuth features. Multi-tenant operators register their OAuth apps once per provider and paste credentials into the env file to enable Connect buttons for ALL their clients.

- `.platform-oauth.env.example` committed with step-by-step registration instructions per provider
- `.platform-oauth.env` is gitignored — operator supplies real values
- New `_platform_config_dir()` resolver works for Docker (`/mnt/system/base`), Pinokio (`PLATFORM_CONFIG_DIR` env var), and npm (XDG standard) install modes
- New `_is_oauth_platform_configured()` helper checks env vars (supports both `<PROVIDER>_OAUTH_CLIENT_ID/SECRET` and Facebook's `APP_ID/APP_SECRET` naming convention)
- `get_credentials_status()` adds `platform_configured: bool` to every credential so the UI can render OAuth cards differently based on operator setup
- `build_oauth_url()` / `exchange_oauth_code()` read client_id/secret from `os.environ` (loaded from `.platform-oauth.env` at module init), with legacy fallback to the old `platform-oauth.json`
- Redirect URI is built from the requesting client's `DOMAIN` so every client has its own per-client OAuth callback

### Cycle C — `eb99467` — Platform Setup admin page

New admin section at `/admin#platform-setup` where operators register OAuth apps without SSH. Reads/writes `.platform-oauth.env` directly and updates `os.environ` in the running Flask process so changes take effect **immediately** — no container restart needed (avoids the self-recreate rename collision we hit in Cycle A).

- Four provider cards (Google, Facebook/Meta, QuickBooks/Intuit, LinkedIn) with:
  - Status badge (CONFIGURED / NOT CONFIGURED)
  - Collapsible "How to set up" with deep link to the provider's developer console
  - Numbered setup steps + docs link
  - Auto-generated redirect URI list (reads `registry.json`, builds one URI per live client) + Copy button
  - Client ID + Client Secret input fields with `autocomplete="new-password"` + `data-lpignore` + `data-1p-ignore` to suppress browser/LastPass/1Password autofill
  - Save / Clear buttons with current-secret hint
- Backend endpoints: `GET /api/vault/platform-setup`, `PUT /api/vault/platform-setup/<provider>`, `DELETE /api/vault/platform-setup/<provider>`
- NOT role-gated — all admins see Platform Setup (per product spec)

Bonus polish in Cycle C:
- Every credential card in the Connections page now has a small "Get key ↗" link next to its name (uses `docs_url` field from the catalog, populated for all 32 credentials). One-click jump to the provider's signup/API-key page.

### Post-cycle fix — `d3f8c9a` — JSONC parser handles unquoted keys + openclaw.json resolver

`_parse_jsonc()` now accepts JavaScript object literal syntax (unquoted identifier keys), not just strict JSON. 11 of 15 live clients had `openclaw.json` files in JS-object-literal form (`agents: { defaults: { model: ...` instead of `"agents": { "defaults": ...`), so the model-selection display was returning empty defaults on most of the fleet. The regex pass runs after comment stripping and only quotes keys *outside* string literals (URLs like `"postgresql://..."` and string values like `"12:34:56"` stay untouched). Full regression suite: URL preservation, unquoted keys, mixed quoted+unquoted, colon-in-string, comment-followed-by-unquoted.

Also added a new model-selection resolver that tries `/app/runtime/openclaw-client.json` first (a single-file read-only bind mount added in a sister fleet script — bypasses the 700-perm parent dir so `get_current_model_selection` can actually read `openclaw.json` from the openvoiceui container).

## What's NOT in this PR

- Fleet rollout scripts, helper scripts, operator walkthroughs, plan docs — those live in the separate `MIKE-AI` infrastructure repo, not OpenVoiceUI
- Full vault-v2 redesign (encrypted single file per client) — saved for future work; plan doc committed separately
- Image promotion (`:phase1.5` → `:latest`) — operator decision, not in code

## What's running on this branch right now

- **15 live Phase 1.5 containers** on `jambot/openvoiceui:phase1.5`, all healthy
- **All 15 verified** reporting correct model selection (`mx/MiniMax-M2.7-highspeed` primary + `zai/glm-5-turbo` fallback) via the new JSONC parser
- **All 32 credentials** have `docs_url` for the "Get key ↗" link
- **OAuth section** renders as opt-in disabled cards (no operator has set up a real Google/Facebook app yet — when they do, the cards flip to active instantly via live `os.environ` mutation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)