### PR TITLE
fix(conversation): retry on same session key on fast-empty response

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1584,15 +1584,17 @@ def _conversation_inner():
                                 yield json.dumps({'type': 'retrying'}) + '\n'
                                 time.sleep(2)
                                 # Re-send the message through the gateway.
-                                # If the first empty was suspiciously fast (< 500ms), the session
-                                # is likely dead (openclaw restarted, no state). Use a fresh
-                                # session key so the retry doesn't hit the same dead session.
+                                # Always retry on the SAME session key first. The gateway
+                                # may have been momentarily busy (queue flush, lane transition)
+                                # and the same key will work 2 seconds later with full context.
+                                # Switching to a recovery key here loses all conversation history
+                                # (the agent doesn't know what was just discussed).
+                                # Only the double-empty handler switches to a stable "recovery" key.
                                 _retry_key = _session_key
                                 if metrics.get('llm_inference_ms', 9999) < 500:
-                                    _retry_key = f"recovery-{int(time.time())}"
                                     logger.warning(
                                         f"### Fast empty ({metrics['llm_inference_ms']}ms) — "
-                                        f"session likely dead, retrying on key '{_retry_key}'"
+                                        f"retrying on same session key '{_retry_key}'"
                                     )
                                 retry_queue = queue.Queue()
                                 captured_actions.clear()


### PR DESCRIPTION
## Summary

- Fast-empty retries (< 500ms empty response) now keep the **same** session key instead of switching to a timestamped `recovery-*` key
- Previous behavior was losing all conversation history on transient gateway hiccups — the agent would retry with zero context and give a confused response
- Double-empty handler (two empties in a row) still escalates to a stable recovery key — that path is unchanged
- Warning log preserved so fast empties remain visible in logs

## Why

In practice a fast empty response usually means the gateway was momentarily busy (queue flush, lane transition) rather than actually dead. Waiting 2s and retrying on the same key works fine and keeps the full conversation history intact. The "session is dead, switch keys" heuristic was too aggressive and caused user-visible context loss.