### PR TITLE
feat(plugins): declare vault credentials for twenty-crm and seo-platform

### DIFF
--- a/plugins/seo-platform/plugin.json
+++ b/plugins/seo-platform/plugin.json
@@ -28,5 +28,14 @@
       "blueprint": "seo_platform_bp",
       "prefix": "/api/seo-platform"
     }
+  ],
+  "credentials": [
+    {
+      "id": "dataforseo",
+      "extend": true,
+      "consumers": {
+        "seo_platform": {"type": "env_var"}
+      }
+    }
   ]
 }

--- a/plugins/twenty-crm/plugin.json
+++ b/plugins/twenty-crm/plugin.json
@@ -29,5 +29,19 @@
     }
   ],
 
-  "requires_env": ["TWENTY_CRM_API_KEY"]
+  "requires_env": ["TWENTY_CRM_API_KEY"],
+  "credentials": [
+    {
+      "id": "twenty_crm",
+      "name": "Twenty CRM API Key",
+      "description": "API key for your Twenty CRM workspace",
+      "type": "api_key",
+      "group": "Services",
+      "env_var": "TWENTY_CRM_API_KEY",
+      "docs_url": "https://twenty.com/developers/section/core/getting-started",
+      "consumers": {
+        "openclaw": {"type": "env_var"}
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- `twenty-crm` plugin declares a full `twenty_crm` credential (api_key, with docs_url pointing at the Twenty dev docs). OpenClaw container consumes it as an env var (`TWENTY_CRM_API_KEY`).
- `seo-platform` plugin extends the existing shared `dataforseo` credential (`extend: true`). The `seo_platform` consumer pulls it in as an env var.
- No runtime behavior change — same env vars resolve the same way. The difference is that both credentials are now manageable through the Connections UI instead of hand-placed env files.

## Why

Both plugins previously required hand-placed env vars (`TWENTY_CRM_API_KEY`, `DATAFORSEO_*`) which meant every new client needed a manual provision step. Declaring them as vault credentials lets the credential vault handle provisioning, rotation, and per-client key isolation.