### PR TITLE
fix(auth): bypass Clerk for vault OAuth callback endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -116,6 +116,7 @@ def create_app(config_override: dict = None):
             '/api/uploads',   # uploads list — files are already public at /uploads/, listing is fine
             '/api/profiles',  # read-only profile config — loaded before Clerk init
             '/api/plugins',   # Plugin system — asset loading, install/uninstall
+            '/api/vault/oauth/callback/',  # OAuth callbacks — redirected from external providers
             '/plugins/',      # Plugin static assets — face scripts, CSS, previews
             '/api/chat',      # LLM proxy (Groq) — used by canvas pages for inline AI
             '/api/tts/',      # TTS provider list — loaded before Clerk init


### PR DESCRIPTION
## Summary

- Adds `/api/vault/oauth/callback/` to the Clerk auth bypass list in `app.py`
- External OAuth providers redirect back to this path with their auth code in the query string
- The redirect is a browser navigation from a third-party origin — it cannot carry a Clerk JWT header, and the Clerk cookie may be stale or missing at this point in the flow
- The callback endpoint itself still validates the OAuth state token, so bypassing Clerk here is safe (the OAuth state/PKCE flow provides its own authentication)

## Why

Without this bypass, every OAuth connection flow (GitHub, Google, etc.) fails at the callback redirect with a 401 because Clerk rejects the unauthenticated navigation. The vault's OAuth feature is unusable.