### PR TITLE
fix(canvas): allow blob: in canvas page CSP connect-src

### DIFF
--- a/routes/canvas.py
+++ b/routes/canvas.py
@@ -849,7 +849,7 @@ def canvas_pages_proxy(path):
                     "img-src 'self' data: blob: https:; "
                     "media-src 'self' blob: https:; "
                     "font-src 'self' https://fonts.gstatic.com; "
-                    "connect-src 'self' https://games.jam-bot.com "
+                    "connect-src 'self' blob: https://games.jam-bot.com "
                         "https://*.jam-bot.com wss://*.jam-bot.com "
                         "https://api.openai.com https://generativelanguage.googleapis.com "
                         "https://api.x.ai https://api.groq.com "


### PR DESCRIPTION
## Summary

- Adds `blob:` to the `connect-src` directive of the canvas page Content Security Policy
- `img-src`, `media-src`, `script-src`, and `worker-src` already allowed `blob:` — `connect-src` was the missing one

## Why

Canvas pages sometimes need to `fetch()` a blob URL — for example when loading a client-side-generated audio/video that was turned into a Blob before being POSTed to the server. Without `blob:` in `connect-src`, `fetch(blobUrl)` is blocked by CSP with no visible browser error, and the page just silently fails to load the asset.