### PR TITLE
fix(auth): persist Clerk __session cookie for 30 days (Max-Age)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2681,7 +2681,7 @@ initUpdateChecker();
                     try {
                         const token = await Clerk.session?.getToken();
                         if (token) {
-                            document.cookie = `__session=${token}; path=/; SameSite=Lax; Secure`;
+                            document.cookie = `__session=${token}; path=/; Max-Age=2592000; SameSite=Lax; Secure`;
                             // Also push fresh token to canvas iframe so long-running
                             // uploads/API calls never hit an expired cookie
                             const iframe = document.getElementById('canvas-iframe');


### PR DESCRIPTION
## Summary

- Adds `Max-Age=2592000` (30 days) to the `__session` cookie set by the Clerk sync helper in `src/app.js`
- Without an explicit `Max-Age`, the cookie was a session cookie that died when the browser closed

## Why

Users had to re-authenticate on every fresh browser session even though their Clerk session was still valid on the server side. Setting a 30-day `Max-Age` lets the cookie survive browser restarts. Clerk tokens refresh automatically via `Clerk.session.getToken()` on a timer, so the cookie value stays current while the expiration stays a month out.