### PR TITLE
fix(conversation): raise canvas pages list cap from 1000 → 5000 chars

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1046,7 +1046,7 @@ def _conversation_inner():
             from routes.canvas import load_canvas_manifest
             _manifest = load_canvas_manifest()
             _page_ids = sorted(_manifest.get('pages', {}).keys())
-            _page_list = _cap_list(_page_ids, max_chars=1000)
+            _page_list = _cap_list(_page_ids, max_chars=5000)
         except Exception:
             _page_list = 'unknown'
         context_parts.append(f'[Canvas pages: {_page_list}]')


### PR DESCRIPTION
## Summary

- The `[Canvas pages: ...]` context entry sent to the agent on every conversation turn was being capped at 1000 chars
- With ~230 canvas pages averaging ~15 chars per id, the list filled up around the alphabetical 'c' boundary and silently truncated everything else as `... and N more`
- Result: agent had no idea pages like `desktop`, `seo-*`, `dj-*` existed — would either improvise diagnostic steps or correctly say "I don't have that page"
- Music tracks have a 2000 char cap in the same function; canvas pages were inexplicably half that

## Why now

This caused the "I press 'open the desktop' and the agent says it doesn't exist" symptom we hit during the post-rebuild test. Raising to 5000 covers the current 230 pages with ~1500 char headroom for growth. Cost: ~1000 extra prompt tokens per turn — negligible against 64K context.