### PR TITLE
fix(admin): make 'Not enabled by platform' link actually navigate

### DIFF
--- a/src/admin.html
+++ b/src/admin.html
@@ -1942,7 +1942,7 @@ const Connections={
           '<button class="btn btn-sm" style="background:var(--panel3);color:var(--dim);border:1px dashed var(--border);cursor:not-allowed" disabled title="Platform operator needs to configure this OAuth provider in Platform Setup">'+
             'Connect '+esc(c.name)+
           '</button>'+
-          '<a href="#platform-setup" style="font-size:11px;color:#3b82f6;text-decoration:none">⚠ Not enabled by platform — set up →</a>'+
+          '<a href="#" onclick="show(\'platform-setup\');return false" style="font-size:11px;color:#3b82f6;text-decoration:none;cursor:pointer">⚠ Not enabled by platform — set up →</a>'+
         '</div>';
       }else{
         body='<button class="btn btn-sm" style="background:#3b82f6;color:#fff;border:none" onclick="Connections.connectOAuth(\''+esc(id)+'\')">Connect '+esc(c.name)+'</button>';


### PR DESCRIPTION
## Summary

On the admin Connections page, OAuth credentials that aren't yet configured by the platform operator show a disabled "Connect" button next to a blue link reading `⚠ Not enabled by platform — set up →`. The link used `href="#platform-setup"` — but the admin panel doesn't navigate via URL hashes; it uses a `show(name)` function called from each nav item's `onclick`. So clicking the link did nothing.

Replaced with `onclick="show('platform-setup');return false"` so it actually switches to the Platform Setup panel where the operator can configure the OAuth provider.