### PR TITLE
fix(ui): update gateway_id on profile switch so Action Console reflects active gateway

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -381,6 +381,10 @@ initUpdateChecker();
                     const profile = this._profiles.find(p => p.id === profileId);
                     const agentId = profile?.adapter_config?.agentId || null;
                     localStorage.setItem('gateway_agent_id', agentId || '');
+                    // Keep gateway_id in sync so the Action Console label reflects
+                    // the backend gateway of the newly-activated profile (openclaw / hermes).
+                    const gatewayId = profile?.adapter_config?.gateway_id || 'openclaw';
+                    localStorage.setItem('gateway_id', gatewayId);
                     if (profile) TranscriptPanel.agentName = profile.name;
                     console.log(`[QuickSettings] switched to ${profileId}, agentId=${agentId || 'main'}`);
                     // Apply full profile settings from activate response


### PR DESCRIPTION
## Summary

- `QuickSettings.switchAgent()` was updating `gateway_agent_id` in localStorage but not `gateway_id`, so the Action Console's "Connected to X gateway" label kept showing whichever gateway was active at page load.
- When switching from an `openclaw` profile to a `hermes` profile, responses routed correctly to hermes but the label still said openclaw.
- This mirrors the existing sync already in `_updateProfiles()` at line 307 — the init path handled it, the switch path didn't.

This should have landed with the earlier Hermes gateway indicator work (PR #256 / #257) but was missed.