### PR TITLE
Release: Hermes gateway_id sync on profile switch

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -381,6 +381,10 @@ initUpdateChecker();
                     const profile = this._profiles.find(p => p.id === profileId);
                     const agentId = profile?.adapter_config?.agentId || null;
                     localStorage.setItem('gateway_agent_id', agentId || '');
+                    // Keep gateway_id in sync so the Action Console label reflects
+                    // the backend gateway of the newly-activated profile (openclaw / hermes).
+                    const gatewayId = profile?.adapter_config?.gateway_id || 'openclaw';
+                    localStorage.setItem('gateway_id', gatewayId);
                     if (profile) TranscriptPanel.agentName = profile.name;
                     console.log(`[QuickSettings] switched to ${profileId}, agentId=${agentId || 'main'}`);
                     // Apply full profile settings from activate response


### PR DESCRIPTION
## Summary

Single-commit follow-up release. Picks up PR #273 which landed on dev after the previous main release (#272).

## Included

- **#273** — `fix(ui): update gateway_id on profile switch so Action Console reflects active gateway` — `QuickSettings.switchAgent()` was updating `gateway_agent_id` but not `gateway_id`, so the Action Console's "Connected to X gateway" label kept showing whichever gateway was active at page load. When switching from an openclaw profile to a hermes profile, responses routed correctly to hermes but the label still said openclaw. Mirrors the existing sync in `_updateProfiles()` (line 307).