### PR TITLE
chore: bump version to 2026.4.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openvoiceui",
-  "version": "2026.4.10",
+  "version": "2026.4.13",
   "description": "Voice-powered AI assistant platform \u2014 connect any LLM, any TTS, with a live web canvas, music generation, and agent orchestration",
   "bin": {
     "openvoiceui": "cli/index.js"


### PR DESCRIPTION
Version bump for the v2026.4.13 release. Once merged into dev, the dev → main release PR will follow.