### PR TITLE
Release: 2026.4.13 — STT/TTS reliability, vault Phase 1.5, Hermes plugin, byterover quarantine

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openvoiceui",
-  "version": "2026.4.10",
+  "version": "2026.4.13",
   "description": "Voice-powered AI assistant platform \u2014 connect any LLM, any TTS, with a live web canvas, music generation, and agent orchestration",
   "bin": {
     "openvoiceui": "cli/index.js"


### PR DESCRIPTION
## Release: v2026.4.13

Version bump from `2026.4.10` to `2026.4.13` plus all the work merged into dev since the last release.

## What's New

### Voice / STT
- Conversation retry preserves session key on fast-empty (no recovery-key context loss) (#261)
- Server-side garbage STT filter — lower threshold + NDJSON format so UI doesn't lock on "thinking" (#270)
- Canvas pages context list cap raised 1000 → 5000 chars — agent can now see all ~230 canvas pages (#266)
- **Deepgram STT reliability bundle**: PTT release mute defer + AudioContext idempotence + interim results cancel accumulation timer + endpointing 300 → 500 (#268)
- WebSpeech PTT release mute defer (parallel fix for the fallback STT provider) (#267)

### TTS
- **Resemble TTS reliability**: shared httpx connection pool, chunk size 500 → 1500, request_id error logging, retry budget 5 → 8 (#269)
- Suno tag normalization + ghost-LLM completion flow removal (#255)

### Auth & API
- Clerk `__session` cookie 30-day Max-Age (no more re-auth on browser restart) (#265)
- Auth bypass for vault OAuth callback path (#263)
- Canvas page CSP `connect-src` allows `blob:` (#264)

### Vault & Plugins
- **Credential Vault Phase 1.5** — Cycles A/B/C: writes reach running agents, opt-in OAuth pattern, Platform Setup admin page (#256)
- Twenty CRM and SEO Platform plugins declare vault credentials (#262)
- Hermes plugin install flow finished + vault sync via provision service HTTP API (#256)
- byterover-memory plugin removed and parked in catalog repo (#260)

### UI / UX
- Action Console verbose tool detail + Hermes gateway shape support (#257)
- Hermes gateway indicator (initial load + on profile switch) (#256, #273)
- Mute UX fix + Clawdbot → Agent rename
- Admin Connections "Not enabled by platform" link now navigates to Platform Setup (#271)

### Docs
- `.claude/CLAUDE.md` project context for contributors with parked-plugin quarantine convention (#259)

**Full Changelog**: https://github.com/MCERQUA/OpenVoiceUI/compare/v2026.4.10...v2026.4.13