### PR TITLE
fix(uploads): preserve original filename + signal truncation + 50KB preview cap

### DIFF
--- a/routes/static_files.py
+++ b/routes/static_files.py
@@ -131,8 +131,17 @@ def serve_sound(filepath):
 # Hard limit enforced before writing to disk (100 MB)
 _MAX_UPLOAD_BYTES = 100 * 1024 * 1024
 
-# Maximum characters returned to the AI as content_preview
-_MAX_PREVIEW_CHARS = 6000
+# Maximum characters returned to the AI as content_preview for text files.
+# Files at or below this threshold are inlined verbatim into the conversation.
+# Larger files set content_preview_truncated=True and the agent is directed to
+# use its Read tool on the saved path instead (which lives in a prunable
+# tool-result block rather than an un-prunable user message).
+_MAX_PREVIEW_CHARS = 50_000
+
+# Maximum characters for extracted text from binary documents (PDF/DOCX/XLSX/PPTX).
+# Binary extractors sanitize their own output, so they share this cap via
+# _sanitize_text below.
+_MAX_BINARY_PREVIEW_CHARS = 20_000
 
 # Only block executables — accept everything else (weird exports, unknown formats, etc.)
 _BLOCKED_EXTENSIONS = {
@@ -146,10 +155,24 @@ _CTRL_RE = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]')
 
 
 def _sanitize_text(text: str) -> str:
-    """Strip control chars, collapse excessive blank lines, cap at _MAX_PREVIEW_CHARS."""
+    """Strip control chars, collapse excessive blank lines, cap at binary preview limit.
+    Used by PDF/DOCX/XLSX/PPTX extractors — they don't signal truncation back to
+    the upload handler so use the tighter cap."""
     text = _CTRL_RE.sub('', text)
     text = re.sub(r'\n{4,}', '\n\n\n', text)  # no more than 3 consecutive blank lines
-    return text[:_MAX_PREVIEW_CHARS].strip()
+    return text[:_MAX_BINARY_PREVIEW_CHARS].strip()
+
+
+def _read_text_preview(path: Path) -> tuple[str, bool]:
+    """Read a text file for inline preview. Returns (sanitized_text, truncated).
+    Never loads more than _MAX_PREVIEW_CHARS + 1 chars into memory, so large
+    uploads don't spike RSS."""
+    with open(path, 'r', errors='replace') as fh:
+        raw = fh.read(_MAX_PREVIEW_CHARS + 1)
+    truncated = len(raw) > _MAX_PREVIEW_CHARS
+    cleaned = _CTRL_RE.sub('', raw[:_MAX_PREVIEW_CHARS])
+    cleaned = re.sub(r'\n{4,}', '\n\n\n', cleaned)
+    return cleaned.strip(), truncated
 
 
 def _extract_pdf(path: Path) -> str:
@@ -284,6 +307,7 @@ def upload_file():
         'path': str(dest),
         'filename': safe_name,
         'url': f'/uploads/{safe_name}',
+        'file_size': file_size,
     }
 
     if is_image:
@@ -321,15 +345,17 @@ def upload_file():
                 )
 
         else:
-            # Plain text / code / CSV — read directly
+            # Plain text / code / CSV — stream the first _MAX_PREVIEW_CHARS only
             text_types = {'text/', 'application/json', 'application/xml', 'application/javascript'}
             if any(mime.startswith(t) for t in text_types) or ext in {
                 '.txt', '.md', '.csv', '.log',
                 '.py', '.js', '.ts', '.json', '.yaml', '.yml',
                 '.html', '.css',
             }:
-                raw = dest.read_text(errors='replace')
-                result['content_preview'] = _sanitize_text(raw)
+                preview, truncated = _read_text_preview(dest)
+                result['content_preview'] = preview
+                if truncated:
+                    result['content_preview_truncated'] = True
 
     except Exception as exc:
         logger.warning('Document extraction failed for %s: %s', original_name, exc)

--- a/routes/static_files.py
+++ b/routes/static_files.py
@@ -293,8 +293,11 @@ def upload_file():
     if file_size > _MAX_UPLOAD_BYTES:
         return jsonify({'error': 'File too large (100 MB max)'}), 413
 
-    # --- Save with UUID filename (no original name on disk) ---
-    safe_name = f"{uuid.uuid4().hex}{ext}"
+    # --- Save with original-stem prefix + short uuid suffix so the agent
+    #     can find files by the name the user uploaded them as. UUID suffix
+    #     prevents collisions when the same name is uploaded twice. ---
+    stem_safe = re.sub(r'[^A-Za-z0-9._-]+', '_', Path(original_name).stem)[:80].strip('._-') or 'file'
+    safe_name = f"{stem_safe}__{uuid.uuid4().hex[:8]}{ext}"
     dest = UPLOADS_DIR / safe_name
     UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
     f.save(str(dest))

--- a/src/app.js
+++ b/src/app.js
@@ -7902,7 +7902,12 @@ initUpdateChecker();
                             this._pendingImagePath = result.path;
                             messageToSend = text || `What do you see in this image? (${result.original_name})`;
                         } else if (result.content_preview) {
-                            messageToSend = `[USER ATTACHED FILE: ${result.original_name}, saved at ${result.path}]\n--- File contents ---\n${result.content_preview}\n--- End file ---\n${text}`;
+                            const sizeKb = result.file_size ? ` (${(result.file_size / 1024).toFixed(1)} KB)` : '';
+                            if (result.content_preview_truncated) {
+                                messageToSend = `[USER ATTACHED FILE: ${result.original_name}${sizeKb}, saved at ${result.path}]\nFile is large — preview below is TRUNCATED. To read the full file, use your Read tool on the path above.\n--- File preview (truncated) ---\n${result.content_preview}\n--- End preview ---\n${text}`;
+                            } else {
+                                messageToSend = `[USER ATTACHED FILE: ${result.original_name}${sizeKb}, saved at ${result.path}]\n--- File contents ---\n${result.content_preview}\n--- End file ---\n${text}`;
+                            }
                         } else {
                             messageToSend = `[USER ATTACHED FILE: ${result.original_name}, saved at ${result.path}] ${text}`;
                         }


### PR DESCRIPTION
## Summary
Fixes two bugs that made it impossible for the agent to find or read user-uploaded files.

**Bug 1 — anonymous filenames.** Every upload was renamed to a random UUID hex (\`7fd9f75b...html\`), so the agent could see the uploads folder but couldn't find a file by the name the user uploaded it as. New on-disk format: \`<sanitized_stem>__<8 hex chars><ext>\`, e.g. \`ttt_website_8__a1b2c3d4.html\`. Original name preserved, collisions still safe.

**Bug 2 — silent truncation.** Text uploads were silently truncated at 6000 chars in \`content_preview\`. The agent received a fragment with no signal it was cut off, so it told users *"the file was truncated in your message"* instead of using its Read tool on the saved path. Now:
- Inline preview cap raised from 6000 → 50000 chars
- Preview is streamed via \`open().read(N+1)\` instead of loading the whole file into RSS
- New \`content_preview_truncated\` flag in the upload response when a file exceeds the cap
- New \`file_size\` field returned for the frontend
- When truncated, \`src/app.js\` injects a message that explicitly directs the agent to use its Read tool on the saved path
- Binary document extractors (PDF/DOCX/XLSX/PPTX) keep their tighter 20000-char cap via \`_sanitize_text\`

## Files changed
- \`routes/static_files.py\` — \`_read_text_preview\` helper, new constants, filename stem preservation, truncation flag, file_size
- \`src/app.js\` — conditional message injection for truncated vs. full preview

## Note for jambot deployment
This fix also requires the openclaw container to mount \`/uploads:ro\` so the agent's Read tool can actually resolve the path. That mount has been added to the jambot template and rolled out to all 14 jambot client compose files separately — it is not part of this PR (compose files live outside the public OpenVoiceUI repo).