### PR TITLE
chore(ci): dependabot targets dev not main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   # Python dependencies
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -20,6 +21,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -35,6 +37,7 @@ updates:
   # Docker (if using docker-compose.yml or Dockerfile)
   - package-ecosystem: "docker"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Small config change — adds `target-branch: "dev"` to all three dependabot ecosystems (pip, github-actions, docker). Pairs with the branch protection tightening on main (now requires 1 approval). Prevents dep bumps from accidentally landing on main.