### PR TITLE
feat(music): SoundCloud + Bandcamp in-player embeds

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,6 @@
 </head>
 <body>
     <!-- App entry point: injects DOM shell + initializes all modules -->
-    <script type="module" src="src/app.js?v=23"></script>
+    <script type="module" src="src/app.js?v=24"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -111,6 +111,6 @@
 </head>
 <body>
     <!-- App entry point: injects DOM shell + initializes all modules -->
-    <script type="module" src="src/app.js?v=21"></script>
+    <script type="module" src="src/app.js?v=23"></script>
 </body>
 </html>

--- a/prompts/voice-system-prompt.md
+++ b/prompts/voice-system-prompt.md
@@ -103,10 +103,23 @@ After generation, the new song appears in the [Available tracks:] list by its ti
 
 ---
 
-SPOTIFY:
-[SPOTIFY:song name] or [SPOTIFY:song name|artist name] switches the player to Spotify and plays that track.
-Example: [SPOTIFY:Bohemian Rhapsody|Queen]
-Only use when the user specifically asks for a Spotify track.
+SOUNDCLOUD (real playback, no auth, embedded iframe):
+[SOUNDCLOUD:<full-track-url>] embeds the SoundCloud widget in the music player panel and plays the track.
+URL format must be https://soundcloud.com/<user>/<slug>. NEVER invent URLs — either:
+  1. Use a URL listed in CLIENT.md (if the client has artist-specific SoundCloud URLs there), OR
+  2. Run the soundcloud skill: `python3 /mnt/shared-skills/soundcloud/scripts/find_track.py "artist - track" --json` — then use the `url` field from the JSON response.
+For a full-screen canvas page instead of the compact player, use [SOUNDCLOUD_PAGE:<url>].
+Default to this for any "play <track>" request when the track exists on SoundCloud.
+Example: [SOUNDCLOUD:https://soundcloud.com/deadmau5/strobe]
+
+---
+
+BANDCAMP (real playback, no auth, embedded iframe):
+[BANDCAMP:<full-album-or-track-url>] embeds the Bandcamp player in the music panel.
+URL format must be <artist>.bandcamp.com/album/<slug> or .../track/<slug>. NEVER invent URLs — use the bandcamp skill:
+`python3 /mnt/shared-skills/bandcamp/scripts/find_track.py "artist - album" --json` — use the `url` field.
+For full-screen canvas page: [BANDCAMP_PAGE:<url>].
+Example: [BANDCAMP:https://phoebebridgers.bandcamp.com/track/motion-sickness]
 
 ---
 

--- a/routes/canvas.py
+++ b/routes/canvas.py
@@ -857,7 +857,8 @@ def canvas_pages_proxy(path):
                         "https://api.anthropic.com https://api.cohere.ai "
                         "https://api.dataforseo.com https://sandbox.dataforseo.com; "
                     "worker-src blob:; "
-                    "frame-src 'self' https://*.jam-bot.com https://*.netlify.app https://midiviz.com"
+                    "frame-src 'self' https://*.jam-bot.com https://*.netlify.app https://midiviz.com "
+                        "https://w.soundcloud.com https://bandcamp.com https://*.bandcamp.com"
                 )
                 return resp
             else:

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -173,9 +173,19 @@ _VOICE_INSTRUCTIONS = (
     "After generation, the new song appears in [Available tracks:] by its title. "
     "Use [MUSIC_PLAY:song title] to play it — do NOT use exec/shell to find the file. "
 
-    # --- Spotify ---
-    "SPOTIFY: [SPOTIFY:song name] or [SPOTIFY:song name|artist name] — plays from Spotify. "
-    "Example: [SPOTIFY:Bohemian Rhapsody|Queen]. Only use when user specifically asks. "
+    # --- SoundCloud (real playback, no auth) ---
+    "SOUNDCLOUD: [SOUNDCLOUD:<full-track-url>] — embeds the track in the music player and plays it. "
+    "Always use with a full https://soundcloud.com/<user>/<slug> URL. NEVER invent URLs — get them from "
+    "CLIENT.md (if present) or run the `soundcloud` skill: "
+    "`python3 /mnt/shared-skills/soundcloud/scripts/find_track.py \"artist - track\" --json`. "
+    "For a full-screen embed page instead of the small player: [SOUNDCLOUD_PAGE:<url>]. "
+    "Default to this for any 'play <track>' request when the artist has SoundCloud presence. "
+
+    # --- Bandcamp (real playback, no auth) ---
+    "BANDCAMP: [BANDCAMP:<full-album-or-track-url>] — embeds the Bandcamp player in the music panel. "
+    "URL must match <artist>.bandcamp.com/album/<slug> or .../track/<slug>. NEVER invent URLs — "
+    "use the `bandcamp` skill: `python3 /mnt/shared-skills/bandcamp/scripts/find_track.py \"artist - album\" --json`. "
+    "For full-screen canvas page: [BANDCAMP_PAGE:<url>]. "
 
     # --- Facial expressions / mood ---
     "EXPRESSIONS: [MOOD:happy] [MOOD:sad] [MOOD:angry] [MOOD:surprised] [MOOD:thinking] [MOOD:neutral] — "
@@ -589,6 +599,10 @@ def clean_for_tts(text: str) -> str:
     text = re.sub(r'\[MOOD:[^\]]*\]', '', text, flags=re.IGNORECASE)
     text = re.sub(r'\[REGISTER_FACE:[^\]]*\]', '', text, flags=re.IGNORECASE)
     text = re.sub(r'\[SPOTIFY:[^\]]*\]', '', text, flags=re.IGNORECASE)
+    text = re.sub(r'\[SOUNDCLOUD:[^\]]*\]', '', text, flags=re.IGNORECASE)
+    text = re.sub(r'\[SOUNDCLOUD_PAGE:[^\]]*\]', '', text, flags=re.IGNORECASE)
+    text = re.sub(r'\[BANDCAMP:[^\]]*\]', '', text, flags=re.IGNORECASE)
+    text = re.sub(r'\[BANDCAMP_PAGE:[^\]]*\]', '', text, flags=re.IGNORECASE)
     text = re.sub(r'\[SOUND:[^\]]*\]', '', text, flags=re.IGNORECASE)
     text = re.sub(r'\[SESSION_RESET\]', '', text, flags=re.IGNORECASE)
 
@@ -1572,6 +1586,10 @@ def _conversation_inner():
                                     f"spoken text: {full_response.strip()[:60]}"
                                 )
                                 full_response = "Here you go. " + full_response
+                                # Also update TTS buffer so the downstream flush
+                                # at line ~1844 speaks "Here you go." instead of
+                                # firing TTS on the bare tag (which strips to "").
+                                _tts_buf = "Here you go."
 
                             metrics['llm_inference_ms'] = int((time.time() - t_llm_start) * 1000)
                             metrics['tool_count'] = sum(

--- a/routes/music.py
+++ b/routes/music.py
@@ -14,10 +14,15 @@ Registers routes:
   PUT  /api/music/track/<playlist>/<filename>/metadata  (CRUD: update track metadata)
 """
 
+import html as _html
 import json
 import random
+import re
 import threading
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
 import uuid
 from pathlib import Path
 
@@ -308,8 +313,38 @@ def handle_music():
         "playlist", current_music_state.get("current_playlist", "library")
     )
 
-    if playlist in ("library", "generated", "spotify"):
+    if playlist in ("library", "generated", "spotify", "external"):
         current_music_state["current_playlist"] = playlist
+
+    # ── EXTERNAL (SoundCloud / Bandcamp iframe embeds) ────────────────────
+    # Handle before get_music_files — external tracks have no local files
+    if action == "external":
+        provider = request.args.get("provider", "unknown")
+        url = request.args.get("url", "")
+        title = request.args.get("title", url)
+        artist = request.args.get("artist", provider)
+        current_music_state["current_playlist"] = "external"
+        current_music_state["playing"] = True
+        current_music_state["track_started_at"] = time.time()
+        external_track = {
+            "title": title,
+            "name": title,
+            "artist": artist,
+            "playlist": "external",
+            "source": provider,
+            "url": url,
+            "filename": None,
+        }
+        current_music_state["current_track"] = external_track
+        print(f"🎵 External mode ({provider}): '{title}' — {url}")
+        return jsonify({
+            "action": "external",
+            "provider": provider,
+            "track": external_track,
+            "playlist": "external",
+            "source": provider,
+            "response": f"Now streaming '{title}' from {provider}.",
+        })
 
     # ── SPOTIFY ───────────────────────────────────────────────────────────
     # Handle before get_music_files — Spotify has no local files
@@ -836,3 +871,132 @@ def update_track_metadata(playlist, filename):
     save_meta(metadata)
 
     return jsonify({"status": "updated", "filename": safe_filename, "playlist": playlist, "metadata": entry})
+
+
+# ---------------------------------------------------------------------------
+# External track resolvers (SoundCloud oEmbed, Bandcamp OG-meta)
+# ---------------------------------------------------------------------------
+
+_BC_URL_RE = re.compile(
+    r"^https?://([a-z0-9-]+)\.bandcamp\.com/(album|track)/([a-z0-9-]+)/?(?:\?.*)?$",
+    re.IGNORECASE,
+)
+_META_RE = re.compile(
+    r'<meta[^>]+(?:property|name)=["\']([^"\']+)["\'][^>]*content=["\']([^"\']*)["\']',
+    re.IGNORECASE,
+)
+_BC_PROPS_RE = re.compile(
+    r'<meta\s+name=["\']bc-page-properties["\']\s+content=["\']([^"\']+)["\']',
+    re.IGNORECASE,
+)
+_BC_KIND_MAP = {"a": "album", "t": "track", "album": "album", "track": "track"}
+
+
+def _fetch_bc_page(url):
+    req = urllib.request.Request(url, headers={
+        "User-Agent": "Mozilla/5.0 (OpenVoiceUI music-resolver/1.0)",
+    })
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.read(1_500_000).decode("utf-8", errors="replace")
+    except (urllib.error.HTTPError, urllib.error.URLError):
+        return None
+
+
+def _parse_meta(page):
+    out = {}
+    for k, v in _META_RE.findall(page):
+        out.setdefault(k.lower(), _html.unescape(v))
+    return out
+
+
+def _parse_bc_props(page):
+    m = _BC_PROPS_RE.search(page)
+    if not m:
+        return None
+    try:
+        return json.loads(_html.unescape(m.group(1)))
+    except json.JSONDecodeError:
+        return None
+
+
+def _bc_embed(item_id, kind):
+    kind_key = _BC_KIND_MAP.get(kind, "track")
+    embed_url = (
+        f"https://bandcamp.com/EmbeddedPlayer/{kind_key}={item_id}/"
+        "size=large/bgcol=ffffff/linkcol=0687f5/tracklist=false/"
+        "artwork=small/transparent=true/"
+    )
+    iframe = (
+        f'<iframe style="border:0;width:100%;height:120px;" '
+        f'src="{embed_url}" seamless></iframe>'
+    )
+    return embed_url, iframe
+
+
+@music_bp.route("/api/music/bandcamp/resolve", methods=["GET"])
+def bandcamp_resolve():
+    """Resolve metadata for a known Bandcamp album/track URL."""
+    url = request.args.get("url", "").strip()
+    m = _BC_URL_RE.match(url)
+    if not m:
+        return jsonify({"ok": False, "error": "not a bandcamp track/album url"}), 400
+
+    kind = m.group(2).lower()
+    page = _fetch_bc_page(url)
+    if not page:
+        return jsonify({"ok": False, "error": "page fetch failed"}), 502
+
+    meta = _parse_meta(page)
+    props = _parse_bc_props(page) or {}
+    item_id = props.get("item_id")
+    item_type = _BC_KIND_MAP.get(props.get("item_type") or kind, kind)
+
+    result = {
+        "ok": True,
+        "url": url,
+        "kind": item_type,
+        "title": meta.get("og:title"),
+        "artist": meta.get("og:site_name") or meta.get("twitter:app:name:iphone"),
+        "artwork": meta.get("og:image"),
+        "description": meta.get("og:description"),
+        "provider": "Bandcamp",
+    }
+    if item_id:
+        embed_url, iframe = _bc_embed(int(item_id), item_type)
+        result["embed_url"] = embed_url
+        result["embed_html"] = iframe
+    return jsonify(result)
+
+
+@music_bp.route("/api/music/soundcloud/resolve", methods=["GET"])
+def soundcloud_resolve():
+    """Resolve metadata for a SoundCloud track URL via public oEmbed endpoint."""
+    url = request.args.get("url", "").strip()
+    if not url.startswith(("http://soundcloud.com", "https://soundcloud.com",
+                           "http://www.soundcloud.com", "https://www.soundcloud.com")):
+        return jsonify({"ok": False, "error": "not a soundcloud url"}), 400
+
+    params = urllib.parse.urlencode({"format": "json", "url": url})
+    try:
+        req = urllib.request.Request(
+            f"https://soundcloud.com/oembed?{params}",
+            headers={"User-Agent": "Mozilla/5.0 (OpenVoiceUI music-resolver/1.0)"},
+        )
+        with urllib.request.urlopen(req, timeout=8) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return jsonify({"ok": False, "error": f"oembed returned {e.code}"}), 502
+    except (urllib.error.URLError, json.JSONDecodeError) as e:
+        return jsonify({"ok": False, "error": f"oembed failed: {e}"}), 502
+
+    return jsonify({
+        "ok": True,
+        "url": url,
+        "title": data.get("title"),
+        "artist": data.get("author_name"),
+        "author_url": data.get("author_url"),
+        "artwork": data.get("thumbnail_url"),
+        "embed_html": data.get("html"),
+        "provider": "SoundCloud",
+    })

--- a/src/app.js
+++ b/src/app.js
@@ -1212,10 +1212,140 @@ initUpdateChecker();
                 this.currentMetadata = null;
                 this.button.classList.remove('active');
                 this.panel.classList.remove('playing');
+                this.panel.classList.remove('external-mode');
+                this.panel.classList.remove('spotify-mode');
+                delete this.panel.dataset.provider;
+                const _embedSlot = document.getElementById('music-external-embed');
+                if (_embedSlot) { _embedSlot.innerHTML = ''; _embedSlot.style.display = 'none'; }
                 this._syncPlayButtons(false);
-                // Stop visualizer
                 VisualizerModule.stopAnimation();
                 this.closePanel();
+            },
+
+            // ── External embeds (SoundCloud + Bandcamp) ──────────────────
+
+            async playSoundCloud(trackUrl) {
+                console.log('[MusicModule] playSoundCloud:', trackUrl);
+                try { this.audio?.pause?.(); } catch {}
+                this.currentPlaylist = 'external';
+                this.isPlaying = true;
+                this.currentMetadata = { source: 'soundcloud', url: trackUrl, playlist: 'external' };
+
+                let title = trackUrl;
+                let artist = 'SoundCloud';
+                let embedHtml = null;
+                try {
+                    const resp = await fetch(`https://soundcloud.com/oembed?format=json&url=${encodeURIComponent(trackUrl)}`);
+                    if (resp.ok) {
+                        const m = await resp.json();
+                        title = m.title || title;
+                        artist = m.author_name || artist;
+                        embedHtml = m.html || null;
+                        this.currentMetadata = { ...this.currentMetadata, title, artist, artwork: m.thumbnail_url, embedHtml };
+                    }
+                } catch (e) { console.warn('[MusicModule] SC oembed failed, using direct iframe:', e); }
+
+                this.currentTrack = title;
+                if (this.trackName) this.trackName.textContent = title;
+
+                const fallbackIframe = `<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=${encodeURIComponent(trackUrl)}&auto_play=true&visual=true&show_artwork=true"></iframe>`;
+                this._renderEmbed('soundcloud', embedHtml || fallbackIframe);
+
+                if (this.button) this.button.classList.add('active');
+                if (this.panel) {
+                    this.panel.classList.add('playing', 'external-mode');
+                    this.panel.dataset.provider = 'soundcloud';
+                }
+                this._syncPlayButtons(true);
+                if (this.panelState === 'closed') this.openPanel();
+                this._postExternalState('soundcloud', trackUrl, title, artist);
+            },
+
+            async playBandcamp(trackOrAlbumUrl) {
+                console.log('[MusicModule] playBandcamp:', trackOrAlbumUrl);
+                try { this.audio?.pause?.(); } catch {}
+                this.currentPlaylist = 'external';
+                this.isPlaying = true;
+                this.currentMetadata = { source: 'bandcamp', url: trackOrAlbumUrl, playlist: 'external' };
+
+                let title = trackOrAlbumUrl;
+                let artist = 'Bandcamp';
+                let embedHtml = null;
+                try {
+                    const r = await fetch(`${CONFIG.serverUrl}/api/music/bandcamp/resolve?url=${encodeURIComponent(trackOrAlbumUrl)}`).then(r => r.json());
+                    if (r && r.ok) {
+                        title = r.title || title;
+                        artist = r.artist || artist;
+                        embedHtml = r.embed_html || null;
+                        this.currentMetadata = { ...this.currentMetadata, title, artist, kind: r.kind, artwork: r.artwork, embedUrl: r.embed_url, embedHtml };
+                    }
+                } catch (e) { console.warn('[MusicModule] BC resolve failed:', e); }
+
+                this.currentTrack = title;
+                if (this.trackName) this.trackName.textContent = title;
+
+                if (!embedHtml) {
+                    embedHtml = `<div style="padding:12px;text-align:center;"><a href="${trackOrAlbumUrl}" target="_blank" rel="noopener" style="color:#3b82f6">Open on Bandcamp</a></div>`;
+                }
+                this._renderEmbed('bandcamp', embedHtml);
+
+                if (this.button) this.button.classList.add('active');
+                if (this.panel) {
+                    this.panel.classList.add('playing', 'external-mode');
+                    this.panel.dataset.provider = 'bandcamp';
+                }
+                this._syncPlayButtons(true);
+                if (this.panelState === 'closed') this.openPanel();
+                this._postExternalState('bandcamp', trackOrAlbumUrl, title, artist);
+            },
+
+            _renderEmbed(provider, iframeHtml) {
+                // Render the embed as a SEPARATE floating element attached to <body>, not inside
+                // the music panel. Music panel is bottom-anchored, so content appended inside it
+                // grows it upward and pushes everything above (chat, controls) up the screen.
+                // Instead, place the embed as its own fixed overlay sitting just above the
+                // music panel, centered, with z-index below the chat panel (9999) so chat
+                // still overlays it, but above the music panel (200) so it looks like it's
+                // popping out of the player.
+                let slot = document.getElementById('music-external-embed');
+                if (!slot) {
+                    slot = document.createElement('div');
+                    slot.id = 'music-external-embed';
+                    slot.style.cssText = [
+                        'position:fixed',
+                        'left:50%',
+                        'transform:translateX(-50%)',
+                        // Sit just above the music panel. Music panel is ~70-90px tall when
+                        // open. Use 80px — if the player grows, the iframe still has breathing
+                        // room and the user can scroll within it.
+                        'bottom:86px',
+                        'width:calc(100% - 128px)',
+                        'max-width:520px',
+                        'background:rgba(5, 10, 20, 0.97)',
+                        'border:1px solid rgba(0, 229, 255, 0.25)',
+                        'border-radius:12px 12px 0 0',
+                        'box-shadow:0 -4px 25px rgba(0,229,255,0.25)',
+                        'padding:8px',
+                        'z-index:201',
+                        'display:none',
+                    ].join(';');
+                    document.body.appendChild(slot);
+                }
+                slot.dataset.provider = provider;
+                slot.innerHTML = iframeHtml || '';
+                slot.style.display = iframeHtml ? 'block' : 'none';
+            },
+
+            async _postExternalState(provider, url, title, artist) {
+                try {
+                    const u = new URL(`${CONFIG.serverUrl}/api/music`);
+                    u.searchParams.set('action', 'external');
+                    u.searchParams.set('provider', provider);
+                    u.searchParams.set('url', url);
+                    if (title) u.searchParams.set('title', title);
+                    if (artist) u.searchParams.set('artist', artist);
+                    await fetch(u);
+                } catch (e) { console.warn('[MusicModule] external state sync failed:', e); }
             },
 
             togglePlay() {
@@ -2367,6 +2497,10 @@ initUpdateChecker();
                     music_stop:    ['■',    'music stopped'],
                     music_next:    ['▶▶',   'next track'],
                     spotify:       ['SPT',  d ? `"${d}"` : 'playing spotify'],
+                    soundcloud:    ['SC',   d ? `soundcloud: ${su(d)}` : 'playing soundcloud'],
+                    soundcloud_page: ['SC', d ? `sc page: ${su(d)}` : 'soundcloud page'],
+                    bandcamp:      ['BC',   d ? `bandcamp: ${su(d)}` : 'playing bandcamp'],
+                    bandcamp_page: ['BC',   d ? `bc page: ${su(d)}` : 'bandcamp page'],
                     sound:         ['SFX',  d || 'playing sound'],
                     register_face: ['FACE', d ? `registering ${d}` : 'registering face'],
                     sleep:         ['ZZZ',  'going to sleep'],
@@ -3726,6 +3860,10 @@ initUpdateChecker();
                             .replace(/\[SESSION_RESET\]/gi, '')
                             .replace(/\[SUNO_GENERATE:[^\]]*\]/gi, '')
                             .replace(/\[SPOTIFY:[^\]]*\]/gi, '')
+                            .replace(/\[SOUNDCLOUD:[^\]]*\]/gi, '')
+                            .replace(/\[SOUNDCLOUD_PAGE:[^\]]*\]/gi, '')
+                            .replace(/\[BANDCAMP:[^\]]*\]/gi, '')
+                            .replace(/\[BANDCAMP_PAGE:[^\]]*\]/gi, '')
                             .replace(/\[SLEEP\]/gi, '')
                             .replace(/\[MOOD:[^\]]*\]/gi, '')
                             .replace(/\[REGISTER_FACE:[^\]]*\]/gi, '')
@@ -3803,6 +3941,42 @@ initUpdateChecker();
                             ActionConsole.addEntry('system', `Spotify: "${spotifyTrack}"${spotifyArtist ? ` by ${spotifyArtist}` : ''}`);
                             AgentActivityChip.handleTag('spotify', spotifyTrack);
                             window.musicPlayer?.playSpotify(spotifyTrack, spotifyArtist);
+                        }
+                        // [SOUNDCLOUD:url] — play track in music player embed
+                        const soundcloudMatch = text.match(/\[SOUNDCLOUD:([^\]]+)\]/i);
+                        if (soundcloudMatch && !canvasCommandsProcessed.has('SOUNDCLOUD')) {
+                            canvasCommandsProcessed.add('SOUNDCLOUD');
+                            const scUrl = soundcloudMatch[1].trim();
+                            ActionConsole.addEntry('system', `SoundCloud: ${scUrl}`);
+                            AgentActivityChip.handleTag('soundcloud', scUrl);
+                            window.musicPlayer?.playSoundCloud(scUrl);
+                        }
+                        // [SOUNDCLOUD_PAGE:url] — open full-screen canvas page with the embed
+                        const soundcloudPageMatch = text.match(/\[SOUNDCLOUD_PAGE:([^\]]+)\]/i);
+                        if (soundcloudPageMatch && !canvasCommandsProcessed.has('SOUNDCLOUD_PAGE')) {
+                            canvasCommandsProcessed.add('SOUNDCLOUD_PAGE');
+                            const scUrl = soundcloudPageMatch[1].trim();
+                            ActionConsole.addEntry('system', `SoundCloud page: ${scUrl}`);
+                            AgentActivityChip.handleTag('soundcloud_page', scUrl);
+                            window.openEmbedCanvasPage?.('soundcloud', scUrl);
+                        }
+                        // [BANDCAMP:url] — play in music player embed
+                        const bandcampMatch = text.match(/\[BANDCAMP:([^\]]+)\]/i);
+                        if (bandcampMatch && !canvasCommandsProcessed.has('BANDCAMP')) {
+                            canvasCommandsProcessed.add('BANDCAMP');
+                            const bcUrl = bandcampMatch[1].trim();
+                            ActionConsole.addEntry('system', `Bandcamp: ${bcUrl}`);
+                            AgentActivityChip.handleTag('bandcamp', bcUrl);
+                            window.musicPlayer?.playBandcamp(bcUrl);
+                        }
+                        // [BANDCAMP_PAGE:url] — full-screen canvas page
+                        const bandcampPageMatch = text.match(/\[BANDCAMP_PAGE:([^\]]+)\]/i);
+                        if (bandcampPageMatch && !canvasCommandsProcessed.has('BANDCAMP_PAGE')) {
+                            canvasCommandsProcessed.add('BANDCAMP_PAGE');
+                            const bcUrl = bandcampPageMatch[1].trim();
+                            ActionConsole.addEntry('system', `Bandcamp page: ${bcUrl}`);
+                            AgentActivityChip.handleTag('bandcamp_page', bcUrl);
+                            window.openEmbedCanvasPage?.('bandcamp', bcUrl);
                         }
                         // Check for [REGISTER_FACE:name] — agent registers current camera frame
                         const registerFaceMatch = text.match(/\[REGISTER_FACE:([^\]]+)\]/i);
@@ -5307,6 +5481,10 @@ initUpdateChecker();
                             .replace(/\[SESSION_RESET\]/gi, '')
                             .replace(/\[SUNO_GENERATE:[^\]]*\]/gi, '')
                             .replace(/\[SPOTIFY:[^\]]*\]/gi, '')
+                            .replace(/\[SOUNDCLOUD:[^\]]*\]/gi, '')
+                            .replace(/\[SOUNDCLOUD_PAGE:[^\]]*\]/gi, '')
+                            .replace(/\[BANDCAMP:[^\]]*\]/gi, '')
+                            .replace(/\[BANDCAMP_PAGE:[^\]]*\]/gi, '')
                             .replace(/\[REGISTER_FACE:[^\]]*\]/gi, '')
                             .replace(/\[SLEEP\]/gi, '')
                             .replace(/\[MOOD:[^\]]*\]/gi, '')
@@ -5404,6 +5582,26 @@ initUpdateChecker();
                 const spotifyMatch = text.match(/\[SPOTIFY:([^|\]]+)(?:\|([^\]]+))?\]/i);
                 if (spotifyMatch) {
                     window.musicPlayer?.playSpotify(spotifyMatch[1].trim(), spotifyMatch[2]?.trim() || '');
+                }
+                // [SOUNDCLOUD:url]
+                const soundcloudMatch = text.match(/\[SOUNDCLOUD:([^\]]+)\]/i);
+                if (soundcloudMatch) {
+                    window.musicPlayer?.playSoundCloud(soundcloudMatch[1].trim());
+                }
+                // [SOUNDCLOUD_PAGE:url]
+                const soundcloudPageMatch = text.match(/\[SOUNDCLOUD_PAGE:([^\]]+)\]/i);
+                if (soundcloudPageMatch) {
+                    window.openEmbedCanvasPage?.('soundcloud', soundcloudPageMatch[1].trim());
+                }
+                // [BANDCAMP:url]
+                const bandcampMatch = text.match(/\[BANDCAMP:([^\]]+)\]/i);
+                if (bandcampMatch) {
+                    window.musicPlayer?.playBandcamp(bandcampMatch[1].trim());
+                }
+                // [BANDCAMP_PAGE:url]
+                const bandcampPageMatch = text.match(/\[BANDCAMP_PAGE:([^\]]+)\]/i);
+                if (bandcampPageMatch) {
+                    window.openEmbedCanvasPage?.('bandcamp', bandcampPageMatch[1].trim());
                 }
                 // [REGISTER_FACE:name]
                 const registerFaceMatch = text.match(/\[REGISTER_FACE:([^\]]+)\]/i);
@@ -6528,6 +6726,87 @@ initUpdateChecker();
             window.sunoModule = SunoModule;
             SunoModule.init();
 
+            // openEmbedCanvasPage — create a full-screen canvas page for a
+            // SoundCloud or Bandcamp track and route the UI to it.
+            window.openEmbedCanvasPage = async function openEmbedCanvasPage(provider, url) {
+                const esc = (s) => String(s || '').replace(/[&<>"']/g, (c) => (
+                    {'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'}[c]
+                ));
+                let meta = { title: url, artist: provider, artwork: '', embedHtml: '' };
+
+                try {
+                    if (provider === 'soundcloud') {
+                        // oEmbed direct from browser (CORS-enabled) — avoids server WAF
+                        const r = await fetch(`https://soundcloud.com/oembed?format=json&url=${encodeURIComponent(url)}`);
+                        if (r.ok) {
+                            const oe = await r.json();
+                            meta.title = oe.title || url;
+                            meta.artist = oe.author_name || provider;
+                            meta.artwork = oe.thumbnail_url || '';
+                            meta.embedHtml = oe.html || '';
+                        }
+                    } else if (provider === 'bandcamp') {
+                        // Bandcamp has no oEmbed + page needs server-side fetch (no CORS)
+                        const r = await fetch(`${CONFIG.serverUrl}/api/music/bandcamp/resolve?url=${encodeURIComponent(url)}`).then(r => r.json());
+                        if (r && r.ok) {
+                            meta.title = r.title || url;
+                            meta.artist = r.artist || provider;
+                            meta.artwork = r.artwork || '';
+                            meta.embedHtml = r.embed_html || '';
+                        }
+                    }
+                } catch (e) {
+                    console.warn('[openEmbedCanvasPage] resolve failed:', e);
+                }
+
+                const pageHtml = `<!doctype html><html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<title>${esc(meta.title)}</title>
+<style>
+  :root{color-scheme:dark}
+  *{box-sizing:border-box}
+  body{margin:0;background:linear-gradient(180deg,#0a0a0b 0%,#111 100%);color:#e5e7eb;font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;min-height:100vh;display:flex;flex-direction:column;align-items:center;padding:24px 16px;}
+  .art{width:min(420px,92vw);aspect-ratio:1/1;object-fit:cover;border-radius:14px;box-shadow:0 20px 60px rgba(0,0,0,.55);background:#1a1a1c;}
+  h1{margin:22px 0 2px;font-size:22px;font-weight:600;text-align:center;max-width:92vw;overflow-wrap:anywhere}
+  .artist{color:#9ca3af;margin-bottom:22px;font-size:14px;}
+  .embed{width:min(640px,96vw)}
+  .embed iframe{width:100%;border:0;border-radius:8px;background:#1a1a1c;}
+  .open{display:inline-block;margin-top:20px;padding:10px 16px;background:#3b82f6;color:#fff;text-decoration:none;border-radius:8px;font-size:14px;font-weight:500;}
+  .open:hover{background:#2563eb;}
+  .provider{position:fixed;top:14px;right:14px;font-size:11px;padding:4px 10px;background:rgba(255,255,255,.08);border-radius:999px;text-transform:uppercase;letter-spacing:.06em;color:#9ca3af;}
+</style></head><body>
+<div class="provider">${esc(provider)}</div>
+${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
+<h1>${esc(meta.title) || '(untitled)'}</h1>
+<div class="artist">${esc(meta.artist)}</div>
+<div class="embed">${meta.embedHtml || `<a class="open" href="${esc(url)}" target="_blank" rel="noopener">Open on ${esc(provider)}</a>`}</div>
+</body></html>`;
+
+                const stamp = Date.now().toString(36);
+                const filename = `${provider}-${stamp}.html`;
+                const pageTitle = meta.title ? `${meta.title}` : `${provider} track`;
+
+                try {
+                    const saveRes = await fetch(`${CONFIG.serverUrl}/api/canvas/pages`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ filename, title: pageTitle, html: pageHtml }),
+                    }).then(r => r.json());
+
+                    if (saveRes && saveRes.filename) {
+                        try {
+                            await fetch(`${CONFIG.serverUrl}/api/canvas/manifest/sync`, { method: 'POST' });
+                            await window.CanvasMenu?.loadManifest?.();
+                        } catch {}
+                        const pageId = saveRes.page_id || saveRes.filename.replace(/\.html$/, '');
+                        window.CanvasControl?.showPage?.(pageId);
+                    }
+                } catch (e) {
+                    console.error('[openEmbedCanvasPage] save failed:', e);
+                }
+            };
+
             console.log('OpenVoiceUI initialized!');
             console.log('Mode:', activeMode);
             console.log('TTS Provider:', ProviderManager.selectedProvider);
@@ -6607,6 +6886,32 @@ initUpdateChecker();
                             break;
                         case 'close':
                             CanvasControl.hide();
+                            break;
+                        case 'play-external':
+                            // Canvas page asking the music player to play a SoundCloud/Bandcamp embed
+                            // event.data: { type, action: 'play-external', provider: 'soundcloud'|'bandcamp', url }
+                            {
+                                const prov = event.data.provider;
+                                const trackUrl = event.data.url;
+                                if (!trackUrl) break;
+                                if (prov === 'soundcloud') {
+                                    window.musicPlayer?.playSoundCloud(trackUrl);
+                                } else if (prov === 'bandcamp') {
+                                    window.musicPlayer?.playBandcamp(trackUrl);
+                                } else {
+                                    console.warn('[Canvas] play-external unknown provider:', prov);
+                                }
+                            }
+                            break;
+                        case 'open-embed-page':
+                            // Canvas page asking for a full-screen embed canvas page (same as [SOUNDCLOUD_PAGE:url])
+                            {
+                                const prov = event.data.provider;
+                                const trackUrl = event.data.url;
+                                if (trackUrl && (prov === 'soundcloud' || prov === 'bandcamp')) {
+                                    window.openEmbedCanvasPage?.(prov, trackUrl);
+                                }
+                            }
                             break;
                     }
                 });

--- a/src/app.js
+++ b/src/app.js
@@ -976,6 +976,10 @@ initUpdateChecker();
                     return;
                 }
 
+                // Crossfading into a local track — dismiss any SC/BC embed first
+                this._clearExternalEmbed();
+                if (this.currentPlaylist === 'external') this.currentPlaylist = 'library';
+
                 this.crossfadeInProgress = true;
                 const outgoing = this.activeAudio === 1 ? this.audio1 : this.audio2;
                 const incoming = this.activeAudio === 1 ? this.audio2 : this.audio1;
@@ -1141,6 +1145,11 @@ initUpdateChecker();
             _playId: 0,
 
             async play(trackName) {
+                // Switching to library/generated — tear down any SC/BC external embed
+                // that may still be on-screen from a prior [SOUNDCLOUD:...] / [BANDCAMP:...]
+                this._clearExternalEmbed();
+                if (this.currentPlaylist === 'external') this.currentPlaylist = 'library';
+
                 const playId = ++this._playId;
                 try {
                     const url = new URL(`${CONFIG.serverUrl}/api/music`);
@@ -1212,11 +1221,8 @@ initUpdateChecker();
                 this.currentMetadata = null;
                 this.button.classList.remove('active');
                 this.panel.classList.remove('playing');
-                this.panel.classList.remove('external-mode');
                 this.panel.classList.remove('spotify-mode');
-                delete this.panel.dataset.provider;
-                const _embedSlot = document.getElementById('music-external-embed');
-                if (_embedSlot) { _embedSlot.innerHTML = ''; _embedSlot.style.display = 'none'; }
+                this._clearExternalEmbed();
                 this._syncPlayButtons(false);
                 VisualizerModule.stopAnimation();
                 this.closePanel();
@@ -1307,17 +1313,14 @@ initUpdateChecker();
                 // music panel, centered, with z-index below the chat panel (9999) so chat
                 // still overlays it, but above the music panel (200) so it looks like it's
                 // popping out of the player.
-                let slot = document.getElementById('music-external-embed');
-                if (!slot) {
-                    slot = document.createElement('div');
-                    slot.id = 'music-external-embed';
-                    slot.style.cssText = [
+                let wrap = document.getElementById('music-external-embed');
+                if (!wrap) {
+                    wrap = document.createElement('div');
+                    wrap.id = 'music-external-embed';
+                    wrap.style.cssText = [
                         'position:fixed',
                         'left:50%',
                         'transform:translateX(-50%)',
-                        // Sit just above the music panel. Music panel is ~70-90px tall when
-                        // open. Use 80px — if the player grows, the iframe still has breathing
-                        // room and the user can scroll within it.
                         'bottom:86px',
                         'width:calc(100% - 128px)',
                         'max-width:520px',
@@ -1325,15 +1328,58 @@ initUpdateChecker();
                         'border:1px solid rgba(0, 229, 255, 0.25)',
                         'border-radius:12px 12px 0 0',
                         'box-shadow:0 -4px 25px rgba(0,229,255,0.25)',
-                        'padding:8px',
+                        'padding:8px 8px 8px 8px',
                         'z-index:201',
                         'display:none',
                     ].join(';');
-                    document.body.appendChild(slot);
+
+                    // Close button (top-right) — user can dismiss without stopping playback
+                    const closeBtn = document.createElement('button');
+                    closeBtn.type = 'button';
+                    closeBtn.setAttribute('aria-label', 'Close embed');
+                    closeBtn.textContent = '×';
+                    closeBtn.style.cssText = [
+                        'position:absolute',
+                        'top:4px',
+                        'right:6px',
+                        'width:24px',
+                        'height:24px',
+                        'border:none',
+                        'background:rgba(0,0,0,.4)',
+                        'color:#e2e8f0',
+                        'font-size:18px',
+                        'line-height:1',
+                        'border-radius:50%',
+                        'cursor:pointer',
+                        'z-index:1',
+                    ].join(';');
+                    closeBtn.addEventListener('click', () => this._clearExternalEmbed());
+                    wrap.appendChild(closeBtn);
+
+                    // Inner content slot (iframe lives here)
+                    const slot = document.createElement('div');
+                    slot.className = 'embed-content';
+                    wrap.appendChild(slot);
+
+                    document.body.appendChild(wrap);
                 }
-                slot.dataset.provider = provider;
-                slot.innerHTML = iframeHtml || '';
-                slot.style.display = iframeHtml ? 'block' : 'none';
+                wrap.dataset.provider = provider;
+                const slot = wrap.querySelector('.embed-content');
+                if (slot) slot.innerHTML = iframeHtml || '';
+                wrap.style.display = iframeHtml ? 'block' : 'none';
+            },
+
+            _clearExternalEmbed() {
+                const wrap = document.getElementById('music-external-embed');
+                if (wrap) {
+                    const slot = wrap.querySelector('.embed-content');
+                    if (slot) slot.innerHTML = '';  // Stops iframe audio
+                    wrap.style.display = 'none';
+                }
+                if (this.panel) {
+                    this.panel.classList.remove('external-mode');
+                    delete this.panel.dataset.provider;
+                }
             },
 
             async _postExternalState(provider, url, title, artist) {


### PR DESCRIPTION
## Summary

Adds real in-player playback for SoundCloud and Bandcamp via each platform's public embed mechanism (no auth, no API key). Replaces the Spotify display-only stub that confused the agent into emitting `[SPOTIFY:...]` tags that produced no audio.

## Action tags

- `[SOUNDCLOUD:<url>]` — embed SC widget in the music panel, plays via SC infrastructure
- `[SOUNDCLOUD_PAGE:<url>]` — open as full-screen canvas page (artwork + embed)
- `[BANDCAMP:<url>]` — embed BC player in the music panel
- `[BANDCAMP_PAGE:<url>]` — open as canvas page

All four tags are stripped from TTS output before being spoken, and dispatched to the music player via the existing tag-detection pipeline in `src/app.js`.

## Frontend (`src/app.js`)

- `MusicModule` gains `playSoundCloud()`, `playBandcamp()`, `_renderEmbed()`, `_clearExternalEmbed()`, `_postExternalState()`
- Embed renders as a separate fixed-position overlay (`#music-external-embed`) sitting above the music panel (z-index 201). Doesn't grow the bottom-anchored music panel up the screen.
- Close button (top-right ×) dismisses the overlay without stopping playback
- `play()` and `crossfade()` auto-clear the overlay when switching to library/generated playback, and coerce `currentPlaylist` back to `'library'` — prevents the "stuck embed + library audio bleeds" regression
- `window.openEmbedCanvasPage()` — creates a canvas page with artwork + embed for full-screen view
- `postMessage` bridge: canvas iframes can emit `{type:'canvas-action', action:'play-external', provider, url}` to drive the music player

## Backend (`routes/music.py`)

- New action `"external"` — records provider-qualified track metadata in `current_music_state` so `[Music PLAYING:]` context reflects SC/BC playback
- `GET /api/music/soundcloud/resolve` — proxies SC oEmbed (fallback; browser normally calls oEmbed direct for CORS)
- `GET /api/music/bandcamp/resolve` — fetches BC page, parses OG meta + `bc-page-properties`, returns constructed embed URL + iframe

## CSP (`routes/canvas.py`)

`frame-src` allowlists:
- `https://w.soundcloud.com`
- `https://bandcamp.com`
- `https://*.bandcamp.com`

## System prompt (`prompts/voice-system-prompt.md`)

- **Spotify section removed entirely** — was a display-only stub, agent kept defaulting to it for any "play X" request
- SoundCloud + Bandcamp sections added with explicit instructions to use the discovery skills to find URLs (never invent them)

## TTS regression fix (`routes/conversation.py`)

- Tag-only response fallback (`"Here you go. " +` prepend) now also updates `_tts_buf` so the downstream TTS flush speaks the prepended text. Previously fired TTS on the raw tag which `clean_for_tts` reduced to empty → silent response.
- `clean_for_tts` strips the 4 new SC/BC tags before the TTS provider gets the text.

## Cache bust

`index.html`: `app.js?v=23` → `app.js?v=24`

## Related

- Agent discovery skills (`soundcloud`, `bandcamp`) ship separately in MCERQUA/jam-skills (they use `serper-search` for URL discovery). Agents can still emit these tags without those skills if they have URLs from elsewhere (e.g. CLIENT.md).