### PR TITLE
fix(conversation): session-recovery + interrupt-handling stack (13 fixes)

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -405,6 +405,113 @@ def bump_voice_session() -> str:
 
 
 _recovery_entered_at: float = 0
+_recovery_last_activity_at: float = 0
+_recovery_last_exited_at: float = 0
+
+#: Context-replay prime — injected into the FIRST request on the recovery
+#: session so the fresh openclaw session has memory of the conversation that
+#: was poisoned. Cleared after one consume via :func:`consume_recovery_prime`.
+_recovery_context_prime: str | None = None
+
+#: Most recent steer/interject message per session key, with timestamp.
+#: When a user speaks mid-inference the interject is delivered fire-and-forget
+#: — if the in-flight LLM turn then returns empty, the steer is effectively
+#: lost. The empty-response handler consults this map and, if a steer landed
+#: within the last 30s on this session, re-fires it as a fresh conversation
+#: turn so the user's correction actually reaches the agent.
+#: Format: ``{session_key: (epoch_ts: float, message: str)}``
+_recent_steer_by_session: dict = {}
+
+
+def record_recent_steer(session_key: str, message: str) -> None:
+    """Record that a steer was just injected into ``session_key``.
+
+    Called from the steer / interject HTTP routes. Enables the empty-response
+    recovery path to re-fire the steer as a fresh turn if the current LLM
+    call collapses to zero chars (a common failure mode when a steer lands
+    mid-inference and GLM cannot reconcile the branched context).
+    """
+    _recent_steer_by_session[session_key] = (time.time(), message)
+
+
+def consume_recent_steer(session_key: str, max_age_s: float = 30.0) -> str | None:
+    """Return and clear the most recent steer for ``session_key`` if it is
+    younger than ``max_age_s``. Returns ``None`` if there is no recent steer.
+    """
+    entry = _recent_steer_by_session.get(session_key)
+    if not entry:
+        return None
+    ts, msg = entry
+    if time.time() - ts > max_age_s:
+        _recent_steer_by_session.pop(session_key, None)
+        return None
+    _recent_steer_by_session.pop(session_key, None)
+    return msg
+
+
+def _build_recovery_prime(max_turns: int = 6) -> str | None:
+    """Build a compressed history summary from the most recent DB turns so a
+    fresh recovery session doesn't lose context.
+
+    Reads the last ``max_turns`` user+assistant rows from ``conversation_log``
+    (session_id='default') and renders them as a bracketed SYSTEM note that
+    the agent can parse. Returns ``None`` if no rows are available or the
+    query fails — callers should handle ``None`` gracefully.
+    """
+    try:
+        from services.paths import DB_PATH
+        import sqlite3
+        with sqlite3.connect(str(DB_PATH), timeout=2.0) as _c:
+            _c.row_factory = sqlite3.Row
+            # NOTE: most rows land with session_id IS NULL (the main
+            # conversation route passes a per-request session_id that is
+            # usually None) — only the steer/interject routes explicitly
+            # write session_id='default'. Include both so the prime
+            # reflects the actual recent conversation.
+            rows = _c.execute(
+                'SELECT role, message FROM conversation_log '
+                "WHERE session_id = 'default' OR session_id IS NULL "
+                'ORDER BY id DESC LIMIT ?',
+                (max_turns,),
+            ).fetchall()
+        if not rows:
+            return None
+        rows = list(reversed(rows))  # oldest first
+        lines = []
+        for r in rows:
+            role = r['role']
+            msg = (r['message'] or '').strip().replace('\n', ' ')
+            if len(msg) > 280:
+                msg = msg[:280] + '…'
+            lines.append(f'{role}: {msg}')
+        body = '\n'.join(lines)
+        # The prime is deliberately phrased as background context, NOT as a
+        # "session was reset" notice. Earlier wording caused the model to
+        # respond like it was starting a new conversation ("Here's what I've
+        # got:", "Let me check..." etc.) because "[SESSION_RECOVERED]" reads
+        # as a break. Now it's just framed as recent conversation history
+        # plus a directive to pick up the thread naturally.
+        return (
+            '[RECENT CONTEXT — these are the most recent turns between you '
+            'and the user. Treat them as ongoing conversation. Do not '
+            'acknowledge a reset, do not re-greet, do not summarize what you '
+            "just did. Pick up exactly where you left off — if the last user "
+            'message asked a question or interrupted work you had started, '
+            'answer that specific question or continue that specific work '
+            'right now.]\n'
+            f'{body}\n\n'
+        )
+    except Exception as _e:
+        logger.warning(f'### _build_recovery_prime failed: {_e}')
+        return None
+
+
+def consume_recovery_prime() -> str | None:
+    """Return the recovery context prime once and clear it."""
+    global _recovery_context_prime
+    p = _recovery_context_prime
+    _recovery_context_prime = None
+    return p
 
 
 def _enter_session_recovery():
@@ -413,41 +520,105 @@ def _enter_session_recovery():
     poisoned state. The recovery key is cleared on the first successful
     (non-empty, non-fallback) response.
 
+    Also builds a context-replay prime from recent DB history so the fresh
+    session doesn't lose the thread of conversation. Without this prime the
+    agent behaves like a brand-new conversation and users experience
+    'context lost' after a recovery.
+
     IMPORTANT: Uses a STABLE key ('recovery') not a timestamped one.
     Timestamped keys (recovery-<epoch>) created a new openclaw session
     every time, piling up zombie sessions that never got cleaned.
     A stable key reuses the same recovery session each time."""
-    global _session_recovery_key, _recovery_entered_at
-    # Cooldown: don't thrash recovery keys from rapid start/stop cycles
+    global _session_recovery_key, _recovery_entered_at, _recovery_last_activity_at, _recovery_context_prime
+    # Cooldown: prevent re-entering recovery within 10s of a previous SUCCESSFUL
+    # exit. Pre-Fix-F this was measured against _recovery_entered_at which
+    # double-dutied as "last activity" after activity bumping was added —
+    # result: recovery blocked itself for the full duration of a productive
+    # recovery turn, and any subsequent poisoning on main became unrecoverable.
+    # Using the last-exited timestamp means recoveries can re-fire immediately
+    # after a successful one, which is exactly what a repeatedly-poisoned main
+    # session requires.
     now = time.time()
-    if now - _recovery_entered_at < 30:
-        logger.info('### SESSION RECOVERY: skipping — cooldown active (entered <30s ago)')
+    if _recovery_last_exited_at > 0 and now - _recovery_last_exited_at < 10:
+        logger.info(
+            '### SESSION RECOVERY: skipping — cooldown active '
+            f'({int(now - _recovery_last_exited_at)}s since last exit, <10s)'
+        )
         return
     _recovery_entered_at = now
-    _session_recovery_key = 'recovery'
-    logger.warning(f'### SESSION RECOVERY: switching to key "{_session_recovery_key}" to escape poisoned session')
+    _recovery_last_activity_at = now
+    # Use a timestamped recovery key so if recovery ITSELF poisons later
+    # we can spin up a new recovery-<epoch> session cleanly. Earlier code
+    # used a fixed 'recovery' key and was prone to piling up zombie
+    # sessions — but that failure mode only happens when we thrash
+    # recovery entries rapidly. With the last-exited cooldown we only
+    # enter recovery when main is genuinely broken, so a new session per
+    # poisoning event is appropriate.
+    _session_recovery_key = f'recovery-{int(now)}'
+    # Pull 30 turns instead of 6 — complex multi-turn icon/canvas work easily
+    # exceeds 6 turns and the agent was losing all context after recovery.
+    _recovery_context_prime = _build_recovery_prime(max_turns=30)
+    logger.warning(
+        f'### SESSION RECOVERY: switching to key "{_session_recovery_key}" '
+        f'(prime={"yes" if _recovery_context_prime else "no"}, '
+        f'prime_chars={len(_recovery_context_prime) if _recovery_context_prime else 0}) '
+        f'to escape poisoned session'
+    )
 
 
 def _exit_session_recovery():
     """Clear the recovery key after a successful response.
     Next request goes back to the stable key (cache-warm path).
-    Also resets the double-empty circuit breaker."""
-    global _session_recovery_key, _double_empty_restart_count
+    Also resets the double-empty circuit breaker and records the exit
+    timestamp so :func:`_enter_session_recovery` can cooldown against it
+    (prevents thrash, but ALLOWS re-entry when main gets re-poisoned)."""
+    global _session_recovery_key, _double_empty_restart_count, _recovery_last_exited_at
     if _session_recovery_key is not None:
         old_recovery = _session_recovery_key
         _session_recovery_key = None
         _double_empty_restart_count = 0
+        _recovery_last_exited_at = time.time()
         stable = get_voice_session_key()
         logger.info(f'### SESSION RECOVERY CLEARED: "{old_recovery}" → back to stable key "{stable}"')
 
 
+#: Idle-timeout cap for a recovery session. Bumped from 60s (too aggressive —
+#: single recovery turns with multiple tools easily exceed 60s) to 10 min.
+#: The happy-path exit is :func:`_exit_session_recovery`, which fires on the
+#: first successful non-empty response; this cap is only a safety net for
+#: genuinely stuck recoveries.
+_RECOVERY_IDLE_TIMEOUT_S: float = 600.0
+
+
+def bump_recovery_activity() -> None:
+    """Called when we see proof-of-life on the recovery session — reset the
+    idle timer so a productive multi-tool recovery turn doesn't get kicked
+    out mid-work. Invoked from the streaming event pump on any gateway
+    event while :data:`_session_recovery_key` is set.
+
+    Separate from ``_recovery_entered_at`` (first-entered timestamp) and
+    ``_recovery_last_exited_at`` (cooldown basis) so recovery lifecycle
+    bookkeeping doesn't collide.
+    """
+    global _recovery_last_activity_at
+    if _session_recovery_key is not None:
+        _recovery_last_activity_at = time.time()
+
+
 def _check_recovery_timeout():
-    """Auto-clear stale recovery keys. If recovery has been active for >60s
-    without a successful response, the recovery key itself may be stuck.
-    Fall back to stable key."""
-    global _session_recovery_key, _recovery_entered_at
-    if _session_recovery_key is not None and time.time() - _recovery_entered_at > 60:
-        logger.warning(f'### SESSION RECOVERY TIMEOUT: "{_session_recovery_key}" active for >60s — clearing')
+    """Auto-clear stale recovery keys. Only fires if the recovery session has
+    been idle (no gateway events) longer than :data:`_RECOVERY_IDLE_TIMEOUT_S`.
+    The normal exit path is :func:`_exit_session_recovery` on first success.
+    """
+    global _session_recovery_key
+    if _session_recovery_key is None:
+        return
+    idle_for = time.time() - max(_recovery_last_activity_at, _recovery_entered_at)
+    if idle_for > _RECOVERY_IDLE_TIMEOUT_S:
+        logger.warning(
+            f'### SESSION RECOVERY TIMEOUT: "{_session_recovery_key}" '
+            f'idle for >{int(_RECOVERY_IDLE_TIMEOUT_S)}s — clearing'
+        )
         _session_recovery_key = None
 
 
@@ -596,6 +767,7 @@ def clean_for_tts(text: str) -> str:
     text = re.sub(r'\[MUSIC_NEXT\]', '', text, flags=re.IGNORECASE)
     text = re.sub(r'\[SUNO_GENERATE:[^\]]*\]', '', text, flags=re.IGNORECASE)
     text = re.sub(r'\[SLEEP\]', '', text, flags=re.IGNORECASE)
+    text = re.sub(r'\[AIRADIO_[A-Z_]+(?::[^\]]*)?\]', '', text, flags=re.IGNORECASE)
     text = re.sub(r'\[MOOD:[^\]]*\]', '', text, flags=re.IGNORECASE)
     text = re.sub(r'\[REGISTER_FACE:[^\]]*\]', '', text, flags=re.IGNORECASE)
     text = re.sub(r'\[SPOTIFY:[^\]]*\]', '', text, flags=re.IGNORECASE)
@@ -1212,8 +1384,20 @@ def _conversation_inner():
             except Exception:
                 pass
 
+            # ── Session-recovery context prime ────────────────────────
+            # After a double-empty that flipped us to the 'recovery' key,
+            # prepend a compressed history summary to the very FIRST request
+            # so the fresh openclaw session has memory of the prior turns.
+            _recovery_prime = consume_recovery_prime()
+            if _recovery_prime:
+                logger.info(f'### Injecting session-recovery prime ({len(_recovery_prime)} chars)')
+
             def _run_gateway():
-                _msg = _recovery_prefix + message_with_context if _recovery_prefix else message_with_context
+                _msg = message_with_context
+                if _recovery_prefix:
+                    _msg = _recovery_prefix + _msg
+                if _recovery_prime:
+                    _msg = _recovery_prime + _msg
                 gateway_manager.stream_to_queue(
                     event_queue, _msg, _session_key, captured_actions,
                     gateway_id=gateway_id,
@@ -1392,6 +1576,12 @@ def _conversation_inner():
                                 break
                             yield json.dumps({'type': 'heartbeat', 'elapsed': elapsed}) + '\n'
                             continue
+
+                        # Proof-of-life on the recovery session — reset the idle
+                        # timer so a productive multi-tool recovery turn isn't
+                        # kicked out mid-work by the elapsed-time check.
+                        if _session_recovery_key is not None:
+                            bump_recovery_activity()
 
                         if evt['type'] == 'handshake':
                             metrics['handshake_ms'] = evt['ms']
@@ -1613,9 +1803,159 @@ def _conversation_inner():
                                 f"(tokens~{_est_input}in/{_est_output}out)"
                             )
 
-                            # ── Clear recovery mode on successful gateway response ──
+                            # ── Recovery is STICKY ──────────────────────────
+                            # We used to call _exit_session_recovery() on the
+                            # first successful response so the next request
+                            # went back to `main`. In practice `main` stayed
+                            # poisoned (openclaw server-side session state
+                            # persists on disk and doesn't self-heal when the
+                            # WS reconnects) so every subsequent request
+                            # bounced through the recovery cascade again —
+                            # good for reliability, bad for 3-5s-per-message
+                            # latency.
+                            #
+                            # Keep the timestamped recovery key as the new
+                            # stable session for the process lifetime. If the
+                            # recovery session itself poisons later, the
+                            # double-empty handler will spin up a fresh
+                            # recovery-<newepoch>. Only manual /api/conversation/reset
+                            # exits recovery now.
                             if full_response and full_response.strip() and _session_recovery_key is not None:
-                                _exit_session_recovery()
+                                bump_recovery_activity()
+
+                            # ── Uncommitted tool-promise detection ────────────
+                            # If the assistant said "let me build X" / "I'll write Y"
+                            # but emitted ZERO tool_use blocks, the turn ended on
+                            # an unfulfilled promise. This poisons the next turn —
+                            # a follow-up user message layered on top of an open
+                            # intent causes empty responses on GLM-4.7.
+                            #
+                            # Auto-continue: send a "continue — actually perform
+                            # that work" steer and re-enter the event loop so the
+                            # agent completes the promise on THIS turn.
+                            #
+                            # Gated: only fires when
+                            #   - response was non-empty
+                            #   - tool_count == 0  (nothing was actually done)
+                            #   - llm_ms > 1000    (filter out instant degenerate empties — those go to the empty-retry branch below)
+                            #   - not already continued this turn (avoids loops)
+                            #
+                            # NOTE: no upper bound on llm_ms. A genuine uncommitted
+                            # promise after 50s is just as broken as after 5s — the
+                            # agent still left work undone and the session still
+                            # ends on an open intent. Previously gated at <30s and
+                            # we missed a real case at 49s.
+                            #
+                            # Regex allows the committing verb anywhere within 80
+                            # chars of the "I'll / let me" opener, so compound
+                            # phrasing like "I'll mark the ones and add a button"
+                            # still catches `add` (the mid-sentence verb).
+                            _promise_re = re.compile(
+                                r"\b(?:let me|i'?ll|i am going to|i'?m going to|i will|i'?m about to|gonna|going to)\b"
+                                r".{0,80}?"
+                                r"\b(?:write|build|create|update|save|add|edit|run|fetch|generate|make|"
+                                r"set up|put together|pull|grab|load|open|check|look|query|send|post|commit|push|"
+                                r"refactor|deploy|install|rebuild|restart|scaffold|configure|"
+                                r"mark|highlight|tag|label|link|embed|include|list|draft|prepare|"
+                                r"implement|modify|append|remove|delete|clean|organize|sort|render|"
+                                r"test|publish|upload|download|compile|parse|extract|apply|assign|"
+                                r"wire|hook|bind|attach|register|inject|populate|fill|insert|replace|"
+                                r"rename|move|copy|merge|split|style|design|format|export|import|"
+                                r"patch|fix|revert|rollback|scaffold|bootstrap|finalize|finish)"
+                                r"\b",
+                                re.IGNORECASE,
+                            )
+                            if (
+                                full_response
+                                and full_response.strip()
+                                and metrics.get('tool_count', 0) == 0
+                                and metrics.get('llm_inference_ms', 0) > 1000
+                                and not getattr(stream_response, '_continued', False)
+                                and _promise_re.search(full_response)
+                            ):
+                                stream_response._continued = True
+                                logger.warning(
+                                    f'### UNCOMMITTED PROMISE detected: '
+                                    f'{full_response.strip()[:100]!r} '
+                                    f'(tool_count=0, ms={metrics.get("llm_inference_ms")}) '
+                                    f'— auto-continuing'
+                                )
+                                # Keep the client alive while we re-prompt
+                                yield json.dumps({'type': 'retrying'}) + '\n'
+                                # Preserve partial text as a TTS sentence so the
+                                # user hears the assistant's intent while the
+                                # follow-up tool turn runs
+                                _continue_msg = (
+                                    '[SYSTEM: You said you would do something ("'
+                                    + full_response.strip()[:160]
+                                    + '") but did not call any tool. Actually perform the '
+                                    'work now, using the appropriate tools. Do not just '
+                                    'describe it again.]'
+                                )
+                                retry_queue = queue.Queue()
+                                captured_actions.clear()
+                                # Reset accumulators so we don't double-count prior text
+                                full_response = ''
+                                def _continue_gateway():
+                                    gateway_manager.stream_to_queue(
+                                        retry_queue, _continue_msg,
+                                        _session_key, captured_actions,
+                                        gateway_id=gateway_id,
+                                        agent_id=agent_id,
+                                    )
+                                continue_thread = threading.Thread(
+                                    target=_continue_gateway, daemon=True,
+                                )
+                                t_llm_start = time.time()
+                                continue_thread.start()
+                                event_queue = retry_queue
+                                logger.info('### AUTO-CONTINUE: sent promise-completion steer')
+                                continue  # back to event loop — text_done NOT sent yet
+
+                            # ── Empty after recent steer → auto-refire steer ──
+                            # If an interject/steer landed on this session
+                            # within the last 30s and the current LLM turn
+                            # collapsed to zero chars, the steer was lost in
+                            # the branched context. Re-fire the steered
+                            # message as a fresh turn so the user's actual
+                            # correction reaches the agent. Covers ALL empty
+                            # cases (fast empty and timeout empty) — a lost
+                            # steer is a bigger UX failure than a slow LLM.
+                            _is_empty_pre = not full_response or not full_response.strip()
+                            if _is_empty_pre and not getattr(stream_response, '_steer_refired', False):
+                                _steer_msg = consume_recent_steer(_session_key, max_age_s=30.0)
+                                if _steer_msg:
+                                    stream_response._steer_refired = True
+                                    logger.warning(
+                                        f'### STEER-RECOVERY: empty response after recent steer '
+                                        f'({len(_steer_msg)} chars) on session={_session_key} '
+                                        f'— re-firing steered message as fresh turn'
+                                    )
+                                    yield json.dumps({'type': 'retrying'}) + '\n'
+                                    # No sleep — the original `time.sleep(1)` was
+                                    # paranoia leftover from early debugging. Every
+                                    # second of artificial delay is a second of dead
+                                    # silence for the user; the gateway's own internal
+                                    # ordering is already sufficient.
+                                    retry_queue = queue.Queue()
+                                    captured_actions.clear()
+                                    full_response = ''
+                                    _refire_msg = (context_prefix or '') + _steer_msg
+                                    def _refire_gateway():
+                                        gateway_manager.stream_to_queue(
+                                            retry_queue, _refire_msg,
+                                            _session_key, captured_actions,
+                                            gateway_id=gateway_id,
+                                            agent_id=agent_id,
+                                        )
+                                    refire_thread = threading.Thread(
+                                        target=_refire_gateway, daemon=True,
+                                    )
+                                    t_llm_start = time.time()
+                                    refire_thread.start()
+                                    event_queue = retry_queue
+                                    logger.info('### STEER-RECOVERY: re-sent steered message to gateway')
+                                    continue  # text_done NOT sent yet
 
                             # ── Retry once on instant empty response ──
                             # IMPORTANT: check BEFORE yielding text_done.
@@ -1634,7 +1974,11 @@ def _conversation_inner():
                                 )
                                 # Tell the client to wait — don't show fallback
                                 yield json.dumps({'type': 'retrying'}) + '\n'
-                                time.sleep(2)
+                                # No sleep — the original `time.sleep(2)` was to let
+                                # Z.AI "settle" between attempts but empirically every
+                                # second here is pure dead silence for the user. The
+                                # gateway's abort-before-send already ensures state is
+                                # clean; additional delay just hurts UX.
                                 # Re-send the message through the gateway.
                                 # Always retry on the SAME session key first. The gateway
                                 # may have been momentarily busy (queue flush, lane transition)
@@ -2111,6 +2455,12 @@ def conversation_steer():
 
     steered = gateway_manager.send_steer(message, session_key)
 
+    # Record for the empty-response recovery path — if the current LLM turn
+    # collapses to zero chars (steer-mid-inference failure mode), the
+    # streaming handler will re-fire this message as a fresh turn.
+    if steered:
+        record_recent_steer(session_key, message)
+
     logger.info(
         f"### STEER request session={session_key} steered={steered} "
         f"source={source} text={message!r}"
@@ -2166,6 +2516,8 @@ def conversation_interject():
         # We still send via steer because the message needs to reach the session,
         # but OpenClaw's collect mode will hold it until the current turn completes.
         steered = gateway_manager.send_steer(message, session_key)
+        if steered:
+            record_recent_steer(session_key, message)
         action = 'queued'
         logger.info(
             f"### INTERJECT [context] session={session_key} action={action} "
@@ -2174,6 +2526,8 @@ def conversation_interject():
     elif lane == 'steer':
         # Inject at next tool boundary — skip remaining tools
         steered = gateway_manager.send_steer(message, session_key)
+        if steered:
+            record_recent_steer(session_key, message)
         action = 'steered'
         logger.info(
             f"### INTERJECT [steer] session={session_key} action={action} "
@@ -2329,6 +2683,155 @@ def tts_providers_list():
     except Exception as e:
         logger.error(f'Failed to list TTS providers: {e}')
         return jsonify({'error': f'Failed to list providers: {e}'}), 500
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/tts/default-provider
+# ---------------------------------------------------------------------------
+# Widget/agent can set the default TTS provider. Writes to
+# tts_providers/providers_config.json so the change survives restart.
+# Validates that the provider is registered AND active — we don't let a
+# caller point the default at something that will fail on first /generate.
+
+@conversation_bp.route('/api/tts/default-provider', methods=['PUT', 'POST'])
+def tts_set_default_provider():
+    """Set the default TTS provider written into providers_config.json.
+
+    Accepts both PUT (semantically correct for "replace current value") and
+    POST (agents using OpenAPI-generic tooling often default to POST).
+
+    Body: {"provider": "<provider_id>"} — must be an ID from the registered
+    set AND have status=active in the config.
+    """
+    try:
+        data = request.get_json(silent=True) or {}
+        provider_id = (data.get('provider') or '').strip()
+        if not provider_id:
+            return jsonify({'ok': False, 'error': 'provider is required'}), 400
+
+        # Verify it's in the known registry. Using list_providers gives us the
+        # same view the GET endpoint exposes — single source of truth.
+        providers = list_providers(include_inactive=True)
+        provider_ids = {p.get('provider_id') for p in providers}
+        if provider_id not in provider_ids:
+            return jsonify({
+                'ok': False,
+                'error': f'unknown provider: {provider_id}',
+                'available': sorted(provider_ids),
+            }), 400
+
+        # Reject providers whose status is NOT active — avoids setting the
+        # default to something we know will fail downstream.
+        target = next((p for p in providers if p.get('provider_id') == provider_id), None)
+        if target and target.get('status') not in (None, 'active'):
+            return jsonify({
+                'ok': False,
+                'error': (f'provider {provider_id} is not active '
+                          f'(status={target.get("status")})'),
+            }), 400
+
+        config_path = (Path(__file__).parent.parent
+                       / 'tts_providers' / 'providers_config.json')
+        try:
+            with open(config_path, 'r') as f:
+                config = json.load(f)
+        except Exception as e:
+            return jsonify({'ok': False, 'error': f'failed to read config: {e}'}), 500
+
+        old_default = config.get('default_provider')
+        config['default_provider'] = provider_id
+        config['last_updated'] = time.strftime('%Y-%m-%d')
+
+        # Atomic write: write to temp, rename into place. Keeps readers from
+        # ever seeing a half-written config.
+        tmp_path = config_path.with_suffix('.json.tmp')
+        try:
+            with open(tmp_path, 'w') as f:
+                json.dump(config, f, indent=2)
+            os.replace(tmp_path, config_path)
+        except Exception as e:
+            return jsonify({'ok': False, 'error': f'failed to write config: {e}'}), 500
+
+        logger.info(
+            f'TTS default provider changed: {old_default} → {provider_id}'
+        )
+        return jsonify({
+            'ok': True,
+            'provider': provider_id,
+            'previous': old_default,
+        })
+    except Exception as e:
+        logger.error(f'tts_set_default_provider failed: {e}')
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/tts/default-voice
+# ---------------------------------------------------------------------------
+# Sets the preferred voice for a provider. Providers_config.json keeps a
+# per-provider `voices` array whose FIRST element is the effective default.
+# We move the requested voice to the front (creating the entry if it's a
+# valid voice we know about from /api/tts/voices).
+
+@conversation_bp.route('/api/tts/default-voice', methods=['PUT', 'POST'])
+def tts_set_default_voice():
+    """Set the default voice for a given TTS provider.
+
+    Body: {"provider": "<provider_id>", "voice": "<voice_id>"}
+    If provider is omitted, uses the current default_provider.
+    """
+    try:
+        data = request.get_json(silent=True) or {}
+        voice = (data.get('voice') or '').strip()
+        if not voice:
+            return jsonify({'ok': False, 'error': 'voice is required'}), 400
+
+        config_path = (Path(__file__).parent.parent
+                       / 'tts_providers' / 'providers_config.json')
+        try:
+            with open(config_path, 'r') as f:
+                config = json.load(f)
+        except Exception as e:
+            return jsonify({'ok': False, 'error': f'failed to read config: {e}'}), 500
+
+        provider_id = (data.get('provider') or config.get('default_provider') or '').strip()
+        if not provider_id:
+            return jsonify({'ok': False, 'error': 'provider is required'}), 400
+
+        pconfig = config.get('providers', {}).get(provider_id)
+        if not pconfig:
+            return jsonify({
+                'ok': False,
+                'error': f'unknown provider in config: {provider_id}',
+            }), 400
+
+        voices = list(pconfig.get('voices') or [])
+        # Move the requested voice to front; add if missing.
+        if voice in voices:
+            voices.remove(voice)
+        voices.insert(0, voice)
+        pconfig['voices'] = voices
+        config['last_updated'] = time.strftime('%Y-%m-%d')
+
+        tmp_path = config_path.with_suffix('.json.tmp')
+        try:
+            with open(tmp_path, 'w') as f:
+                json.dump(config, f, indent=2)
+            os.replace(tmp_path, config_path)
+        except Exception as e:
+            return jsonify({'ok': False, 'error': f'failed to write config: {e}'}), 500
+
+        logger.info(f'TTS default voice for {provider_id} → {voice}')
+        return jsonify({
+            'ok': True,
+            'provider': provider_id,
+            'voice': voice,
+            'voices': voices,
+        })
+    except Exception as e:
+        logger.error(f'tts_set_default_voice failed: {e}')
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
 
 # ---------------------------------------------------------------------------
 # POST /api/tts/generate

--- a/routes/message_classifier.py
+++ b/routes/message_classifier.py
@@ -37,6 +37,10 @@ _STEER_PATTERNS = [
     # Direct negation / correction openers
     r'\bno\b',                          # "no, don't do that"
     r'\bnope\b',
+    r'\bnaw\b',                         # "naw, I want X instead"
+    r'\bnah\b',
+    r'\bnuh[\s-]?uh\b',                 # "nuh-uh" / "nuh uh"
+    r'\buh[\s-]?uh\b',                  # "uh-uh" (rejection)
     r'\bwait\b',                        # "wait, stop"
     r'\bhold on\b',
     r'\bhold up\b',
@@ -90,6 +94,19 @@ _STEER_PATTERNS = [
     r'\bdifferent approach\b',
     r'\buse a different\b',
     r'\buse another\b',
+    # Scope refinement / narrowing — "X only", "just X", "not Y"
+    # These are corrections of in-flight work: must steer, not queue
+    r'\bonly\s+\w+.*\b(?:not|don\'?t|no)\b',       # "only X, not Y"
+    r'\b(?:not|don\'?t include|no)\s+(?:the\s+|any\s+|other\s+|any other\s+)',  # "not the others", "not any other"
+    r'\bjust\s+(?:the|that|these|those)\s+\w+',    # "just the X"
+    r'\bonly\s+(?:the|that|these|those|from)\s+\w+',  # "only the X", "only from"
+    # "X only" at end of sentence / before punctuation / before "not"
+    r'\b\w+\s+only\s*(?:[.,!?]|$|\s+not\b)',       # "emails only.", "joshai only not"
+    r'\bexclude\s+(?:the|any|other)\b',            # "exclude the others"
+    r'\bleave out\s+\w+',                          # "leave out Y"
+    r'\bwithout\s+(?:the|any|other)\s+\w+',        # "without the others"
+    r'\bfilter\s+(?:out|to|down)\b',               # "filter out Y", "filter to X"
+    r'\bnarrow\s+(?:it|down|to)\b',                # "narrow it down"
 ]
 
 # Pre-compiled steer regex — any match = steer

--- a/services/gateways/openclaw.py
+++ b/services/gateways/openclaw.py
@@ -1052,10 +1052,16 @@ class GatewayConnection:
                             logger.info("### SUBAGENT detected via captured_actions (late detection)")
                         continue
                     else:
-                        logger.warning("### chat.final with no text (no subagent)")
+                        # MiniMax-M2.7-highspeed reliably produces "chat.final
+                        # with no text" in a subset of turns (15+ events in a
+                        # 30-min window observed). openclaw's server-side
+                        # model-fallback only triggers on timeout (300s), not
+                        # on empty-final — so the user turn dies silently.
+                        # Signal the caller to retry chat.send once more; a
+                        # second MiniMax attempt usually returns real text.
+                        logger.warning("### chat.final with no text (no subagent) — signaling retry")
                         await self._send_abort(sub.run_id or chat_id, session_key, "empty-response")
-                        event_queue.put({'type': 'text_done', 'response': None, 'actions': captured_actions})
-                        return
+                        return 'empty-final'
 
         logger.warning(f"[GW] hard timeout. collected_text ({len(collected_text)} chars): {repr(collected_text[:200])}")
         if collected_text:
@@ -1107,10 +1113,42 @@ class GatewayConnection:
             logger.info(f"### Sending chat message (agent={agent_id or 'main'}): {message[:100]}")
             await self._dispatcher.send(ws, chat_request)
             _cleanup_ids = []
-            await self._stream_events(
+            result = await self._stream_events(
                 sub, event_queue, session_key,
                 captured_actions, agent_id=agent_id,
                 _cleanup_ids=_cleanup_ids)
+            # Retry once on MiniMax empty-final (see the _stream_events comment
+            # for context). We skip the full abort-before-send dance on the
+            # retry since the original run was already aborted inside
+            # _stream_events; just re-subscribe and re-issue chat.send.
+            if result == 'empty-final':
+                self._dispatcher.unsubscribe(chat_id)
+                retry_chat_id = str(uuid.uuid4())
+                retry_sub = self._dispatcher.subscribe(retry_chat_id, session_key)
+                try:
+                    retry_request = {
+                        "type": "req",
+                        "id": f"chat-{retry_chat_id}",
+                        "method": "chat.send",
+                        "params": {
+                            "message": full_message,
+                            "sessionKey": session_key,
+                            "idempotencyKey": retry_chat_id,
+                        },
+                    }
+                    logger.warning(f"### EMPTY-FINAL RETRY: re-sending chat.send (chat_id={retry_chat_id[:8]})")
+                    await self._dispatcher.send(ws, retry_request)
+                    retry_result = await self._stream_events(
+                        retry_sub, event_queue, session_key,
+                        captured_actions, agent_id=agent_id,
+                        _cleanup_ids=_cleanup_ids,
+                    )
+                    if retry_result == 'empty-final':
+                        logger.error("### EMPTY-FINAL RETRY FAILED: both attempts empty — emitting null text_done")
+                        event_queue.put({'type': 'text_done', 'response': None, 'actions': captured_actions})
+                finally:
+                    self._dispatcher.unsubscribe(retry_chat_id)
+                return  # skip the outer unsubscribe (already done above)
         finally:
             self._dispatcher.unsubscribe(chat_id)
             for _cid in _cleanup_ids:

--- a/src/app.js
+++ b/src/app.js
@@ -8,12 +8,17 @@
  */
 import { inject } from './ui/AppShell.js';
 import { initUpdateChecker } from './ui/UpdateBanner.js';
+import { connectAiradio } from './shell/airadio-bridge.js';
 
 // Inject the application DOM structure before any module accesses the DOM
 inject();
 
 // Start update checker (non-blocking, runs after app loads)
 initUpdateChecker();
+
+// Wire the AI-Radio tag dispatcher — listens for cmd:airadio on eventBus
+// and POSTs to /api/airadio/* endpoints. Idempotent; survives mode switches.
+connectAiradio();
 
         import { WebSpeechSTT, WakeWordDetector } from '/src/providers/WebSpeechSTT.js?v=3';
         import { GroqSTT, GroqWakeWordDetector } from '/src/providers/GroqSTT.js';
@@ -60,6 +65,21 @@ initUpdateChecker();
                 }
             }
             return url;
+        }
+
+        // Route abort/interject calls to the active gateway's namespace.
+        // When gateway_id=hermes, we MUST call /api/hermes/* because hermes
+        // has its own mid-flight pipeline (separate active_runs dict,
+        // stream_to_queue state, etc.). Calling /api/conversation/* goes
+        // through gateway_manager which defaults to openclaw and returns
+        // False — leaving the hermes run hanging and the actions feed
+        // frozen. Openclaw mode continues to use /api/conversation/*.
+        // Action is one of: 'abort' | 'steer' | 'interject'.
+        function convPath(action) {
+            const gid = localStorage.getItem('gateway_id') || 'openclaw';
+            return gid === 'hermes'
+                ? `/api/hermes/${action}`
+                : `/api/conversation/${action}`;
         }
 
         // ===== PROVIDER MANAGER =====
@@ -1239,23 +1259,24 @@ initUpdateChecker();
 
                 let title = trackUrl;
                 let artist = 'SoundCloud';
-                let embedHtml = null;
+                // Fetch oEmbed for metadata only (title/artist/artwork).
+                // ALWAYS use our own iframe URL below so auto_play=true is set —
+                // oEmbed's default html omits auto_play, which looks like "nothing happened".
                 try {
                     const resp = await fetch(`https://soundcloud.com/oembed?format=json&url=${encodeURIComponent(trackUrl)}`);
                     if (resp.ok) {
                         const m = await resp.json();
                         title = m.title || title;
                         artist = m.author_name || artist;
-                        embedHtml = m.html || null;
-                        this.currentMetadata = { ...this.currentMetadata, title, artist, artwork: m.thumbnail_url, embedHtml };
+                        this.currentMetadata = { ...this.currentMetadata, title, artist, artwork: m.thumbnail_url };
                     }
-                } catch (e) { console.warn('[MusicModule] SC oembed failed, using direct iframe:', e); }
+                } catch (e) { console.warn('[MusicModule] SC oembed metadata failed:', e); }
 
                 this.currentTrack = title;
                 if (this.trackName) this.trackName.textContent = title;
 
-                const fallbackIframe = `<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=${encodeURIComponent(trackUrl)}&auto_play=true&visual=true&show_artwork=true"></iframe>`;
-                this._renderEmbed('soundcloud', embedHtml || fallbackIframe);
+                const embedIframe = `<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=${encodeURIComponent(trackUrl)}&auto_play=true&visual=true&show_artwork=true&show_comments=false"></iframe>`;
+                this._renderEmbed('soundcloud', embedIframe);
 
                 if (this.button) this.button.classList.add('active');
                 if (this.panel) {
@@ -3363,6 +3384,13 @@ initUpdateChecker();
                 this.isConnected = false;
                 this.isConnecting = false;
                 this._fetchAbortController = null;
+                // Flag set when the current stream has already emitted its text_done
+                // frame. A new message arriving after text_done should NOT route to
+                // /api/conversation/interject — the run is effectively finished and
+                // a steer on a closed turn poisons the session. Reset on every new
+                // fetch. Checked in sendMessage() to fall through to the normal
+                // fresh-request path instead of interject.
+                this._textDoneReceived = false;
 
                 // Use shared STT instance instead of creating a new one
                 // This prevents conflicts with VoiceConversation's STT
@@ -3678,7 +3706,7 @@ initUpdateChecker();
                     this._fetchAbortController = null;
                     // Tell server to abort the openclaw run (fire-and-forget)
                     console.warn('⛔ ABORT source: stopVoiceInput');
-                    fetch(`${this.config.serverUrl}/api/conversation/abort`, {
+                    fetch(`${this.config.serverUrl}${convPath('abort')}`, {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({ source: 'stopVoiceInput' }),
@@ -3737,12 +3765,29 @@ initUpdateChecker();
                 //     next tool boundary (messages.queue.mode=steer).  The existing
                 //     streaming fetch continues receiving the steered output.
                 if (this._fetchAbortController) {
-                    if (this._ttsPlaying) {
+                    if (this._textDoneReceived) {
+                        // Race-window guard: the server has already emitted text_done,
+                        // meaning the agent's turn is effectively over — the fetch is
+                        // just flushing tail events (metrics, TTS). Interjecting here
+                        // would steer into a closed openclaw turn (active_run still
+                        // set) and poison the session. Treat this as a fresh message
+                        // instead: abort the tail, then fall through to the normal
+                        // sendMessage path.
+                        console.warn(`↩ POST-TEXT_DONE message — treating as fresh request: "${text.substring(0,30)}"`);
+                        this._fetchAbortController.abort();
+                        this._fetchAbortController = null;
+                        fetch(`${this.config.serverUrl}${convPath('abort')}`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ source: 'post-text_done-refresh', text: text.substring(0, 50) }),
+                        }).catch(() => {});
+                        this.stopAudio();
+                    } else if (this._ttsPlaying) {
                         // Agent already responded, TTS playing → ABORT
                         this._fetchAbortController.abort();
                         this._fetchAbortController = null;
                         console.warn(`⛔ ABORT source: ClawdbotMode.sendMessage (TTS playing, new msg: "${text.substring(0,30)}")`);
-                        fetch(`${this.config.serverUrl}/api/conversation/abort`, {
+                        fetch(`${this.config.serverUrl}${convPath('abort')}`, {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
                             body: JSON.stringify({ source: 'clawdbot-sendMessage', text: text.substring(0, 50) }),
@@ -3752,7 +3797,7 @@ initUpdateChecker();
                         // Agent working silently → INTERJECT (smart routing)
                         // Server classifies as context/steer/fast_lane and routes accordingly
                         console.log(`🔀 INTERJECT: "${text.substring(0,50)}" into active run`);
-                        fetch(`${this.config.serverUrl}/api/conversation/interject`, {
+                        fetch(`${this.config.serverUrl}${convPath('interject')}`, {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
                             body: JSON.stringify({ message: text, source: 'clawdbot-sendMessage' }),
@@ -3826,6 +3871,7 @@ initUpdateChecker();
 
                     const gatewayAgentId = localStorage.getItem('gateway_agent_id') || null;
                     this._fetchAbortController = new AbortController();
+                    this._textDoneReceived = false;  // new stream — reset the race-window guard
                     const response = await fetch(`${this.config.serverUrl}/api/conversation?stream=1`, {
                         method: 'POST',
                         signal: this._fetchAbortController.signal,
@@ -3914,6 +3960,7 @@ initUpdateChecker();
                             .replace(/\[MOOD:[^\]]*\]/gi, '')
                             .replace(/\[REGISTER_FACE:[^\]]*\]/gi, '')
                             .replace(/\[SOUND:[^\]]*\]/gi, '')
+                            .replace(/\[AIRADIO_[A-Z_]+(?::[^\]]*)?\]/gi, '')
                             .trim();
                     };
 
@@ -3987,6 +4034,19 @@ initUpdateChecker();
                             ActionConsole.addEntry('system', `Spotify: "${spotifyTrack}"${spotifyArtist ? ` by ${spotifyArtist}` : ''}`);
                             AgentActivityChip.handleTag('spotify', spotifyTrack);
                             window.musicPlayer?.playSpotify(spotifyTrack, spotifyArtist);
+                        }
+                        // [AIRADIO_*] — dispatch each unique tag once; bridge maps verb→endpoint
+                        const _airadioRe = /\[AIRADIO_([A-Z_]+)(?::([^\]]*))?\]/gi;
+                        let _airadioMatch;
+                        while ((_airadioMatch = _airadioRe.exec(text)) !== null) {
+                            const verb = _airadioMatch[1].toUpperCase();
+                            const data = (_airadioMatch[2] || '').trim();
+                            const key = `AIRADIO:${verb}:${data}`;
+                            if (canvasCommandsProcessed.has(key)) continue;
+                            canvasCommandsProcessed.add(key);
+                            ActionConsole.addEntry('system', `AI-Radio: ${verb}${data ? ` (${data})` : ''}`);
+                            AgentActivityChip.handleTag('airadio', `${verb}${data ? `: ${data}` : ''}`);
+                            window.airadioDispatch?.(verb, data);
                         }
                         // [SOUNDCLOUD:url] — play track in music player embed
                         const soundcloudMatch = text.match(/\[SOUNDCLOUD:([^\]]+)\]/i);
@@ -4172,6 +4232,10 @@ initUpdateChecker();
                                     this._wasAgentic = true;
                                     StatusModule.update('thinking', `WORKING... ${secs}s`);
                                     AgentActivityChip.show('⏳', `Working... ${secs}s`);
+                                    // Refresh the transcript thinking indicator so the
+                                    // elapsed-time subtitle ticks even between tool_start
+                                    // events (one tool can run 5-20s and we were static).
+                                    TranscriptPanel.updateThinkingElapsed?.('still working');
                                 }
 
                                 // Queued: openclaw is busy, message will be processed after current run
@@ -4192,9 +4256,41 @@ initUpdateChecker();
                                     }
                                 }
 
-                                // Server retrying empty response — keep stream alive, no fallback
+                                // Server retrying empty response — keep stream alive, no fallback.
+                                // Cascades can run 3-8s; one-shot filler leaves the user
+                                // hanging. Use a recurring interval that speaks progressively
+                                // longer acknowledgements via the browser's SpeechSynthesis
+                                // API, with increasing wait times, until real audio arrives.
+                                // Canceled in text_done/audio handlers below.
                                 if (data.type === 'retrying') {
                                     console.log('[Conversation] Server retrying empty response — waiting for result...');
+                                    if (!this._cascadeFillerTimer) {
+                                        const fillerPhrases = [
+                                            'one moment',
+                                            'still working on it',
+                                            'almost there',
+                                            'hang tight',
+                                        ];
+                                        let fillerIdx = 0;
+                                        const speakFiller = () => {
+                                            if (!this._cascadeFillerTimer) return;
+                                            if ('speechSynthesis' in window) {
+                                                try {
+                                                    const u = new SpeechSynthesisUtterance(fillerPhrases[Math.min(fillerIdx, fillerPhrases.length - 1)]);
+                                                    u.rate = 1.1;
+                                                    u.volume = 0.6;
+                                                    window.speechSynthesis.speak(u);
+                                                    console.log(`[Cascade] filler ${fillerIdx + 1}: "${fillerPhrases[Math.min(fillerIdx, fillerPhrases.length - 1)]}"`);
+                                                } catch (_) {}
+                                            }
+                                            fillerIdx++;
+                                            // Space subsequent fillers further apart so we don't
+                                            // chatter over ourselves
+                                            const next = Math.min(4000 + fillerIdx * 500, 6000);
+                                            this._cascadeFillerTimer = setTimeout(speakFiller, next);
+                                        };
+                                        this._cascadeFillerTimer = setTimeout(speakFiller, 2000);
+                                    }
                                     continue;
                                 }
 
@@ -4217,7 +4313,14 @@ initUpdateChecker();
                                     // Process canvas commands from interim response
                                     this.handleCanvasCommands(cleanedInterim, canvasCommandsProcessed);
 
-                                    if (data.actions) ActionConsole.processActions(data.actions);
+                                    // NOTE: data.actions intentionally NOT re-processed here —
+                                    // every action already rendered via live type:'action'
+                                    // stream events. Re-processing would duplicate every
+                                    // tool call in the action panel. Also important during
+                                    // cascade refires (empty-final retry, steer-recovery):
+                                    // the captured_actions server-side may be cleared/refilled
+                                    // which would cause the final text_done summary to show
+                                    // partial state.
                                     ActionConsole.addEntry('system', 'Background tasks running — waiting for results...');
 
                                     // Reset streaming state for sub-agent result phase
@@ -4236,6 +4339,20 @@ initUpdateChecker();
 
                                 // Text done: full response finalized
                                 if (data.type === 'text_done') {
+                                    // Mark the run as finished-from-server so a
+                                    // follow-up sendMessage won't mistakenly route
+                                    // through /interject (which would steer into a
+                                    // closed turn and poison the session).
+                                    this._textDoneReceived = true;
+                                    // Cancel any pending cascade filler TTS so it
+                                    // doesn't speak over the real response.
+                                    if (this._cascadeFillerTimer) {
+                                        clearTimeout(this._cascadeFillerTimer);
+                                        this._cascadeFillerTimer = null;
+                                        if ('speechSynthesis' in window) {
+                                            try { window.speechSynthesis.cancel(); } catch (_) {}
+                                        }
+                                    }
                                     const fullResponse = data.response || streamingText;
                                     const cleanedResponse = this.stripReasoningTokens(fullResponse);
                                     const displayText = stripCanvasTags(cleanedResponse);
@@ -4259,11 +4376,15 @@ initUpdateChecker();
                                             reader.cancel();
                                             return;
                                         }
-                                        console.warn('[text_done] Empty response — showing fallback');
-                                        const fallback = "Sorry, I couldn't process that. Could you try again?";
-                                        TranscriptPanel.finalizeStreaming(fallback);
-                                        ActionConsole.addEntry('error', 'Empty response from agent');
-                                        // Don't send fallback to TTS — just re-enable mic
+                                        // Cascade exhausted — every recovery layer failed.
+                                        // Do NOT inject "Sorry, I couldn't process that" into
+                                        // the transcript: it pollutes conversation history and
+                                        // most users just need to retry naturally. Log in the
+                                        // action console (for debugging / transparency) and
+                                        // silently re-enable the mic so the user can re-speak.
+                                        console.warn('[text_done] Empty response after full cascade — silent resume');
+                                        TranscriptPanel.finalizeStreaming(null);
+                                        ActionConsole.addEntry('error', 'No response from agent after recovery — mic re-enabled, please retry');
                                         reader.cancel();
                                         return;
                                     }
@@ -4299,7 +4420,7 @@ initUpdateChecker();
                                     TranscriptPanel.finalizeStreaming(displayText);
 
                                     this._wasAgentic = false;
-                                    if (data.actions) ActionConsole.processActions(data.actions);
+                                    // data.actions not re-processed here — see text_interim for rationale
                                     ActionConsole.addEntry('system', `Response complete (${fullResponse?.length || 0} chars, LLM: ${data.timing?.llm_ms}ms)`);
                                     AgentActivityChip.show('✅', 'Done');
                                     AgentActivityChip.hide(1500);
@@ -4308,6 +4429,14 @@ initUpdateChecker();
 
                                 // Audio: TTS ready to play
                                 if (data.type === 'audio') {
+                                    // Cancel any cascade filler — real TTS is about to speak
+                                    if (this._cascadeFillerTimer) {
+                                        clearTimeout(this._cascadeFillerTimer);
+                                        this._cascadeFillerTimer = null;
+                                    }
+                                    if ('speechSynthesis' in window) {
+                                        try { window.speechSynthesis.cancel(); } catch (_) {}
+                                    }
                                     if (data.audio) {
                                         console.log(`TTS ready (${data.timing?.tts_ms}ms, total: ${data.timing?.total_ms}ms)`);
                                         ActionConsole.addEntry('tts', `Playing TTS (TTS: ${data.timing?.tts_ms}ms)`);
@@ -5360,6 +5489,7 @@ initUpdateChecker();
                             .replace(/\[MUSIC_NEXT\]/gi, '')
                             .replace(/\[SLEEP\]/gi, '')
                             .replace(/\[MOOD:[^\]]*\]/gi, '')
+                            .replace(/\[AIRADIO_[A-Z_]+(?::[^\]]*)?\]/gi, '')
                             .trim();
                         this.callbacks.onTranscript(displayText, false);
                         TranscriptPanel.addMessage('assistant', displayText);
@@ -5414,7 +5544,7 @@ initUpdateChecker();
                         this._fetchAbortController.abort();
                         this._fetchAbortController = null;
                         console.warn(`⛔ ABORT source: VoiceConversation.handleUserTranscript (TTS playing)`);
-                        fetch(`${this.config.serverUrl}/api/conversation/abort`, {
+                        fetch(`${this.config.serverUrl}${convPath('abort')}`, {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
                             body: JSON.stringify({ source: 'voice-handleUserTranscript', text: transcript.substring(0, 50) }),
@@ -5423,7 +5553,7 @@ initUpdateChecker();
                     } else {
                         // Agent working silently → INTERJECT (smart routing)
                         console.log(`🔀 INTERJECT: "${transcript.substring(0,50)}" into active run`);
-                        fetch(`${this.config.serverUrl}/api/conversation/interject`, {
+                        fetch(`${this.config.serverUrl}${convPath('interject')}`, {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
                             body: JSON.stringify({ message: transcript, source: 'voice-handleUserTranscript' }),
@@ -5534,6 +5664,7 @@ initUpdateChecker();
                             .replace(/\[REGISTER_FACE:[^\]]*\]/gi, '')
                             .replace(/\[SLEEP\]/gi, '')
                             .replace(/\[MOOD:[^\]]*\]/gi, '')
+                            .replace(/\[AIRADIO_[A-Z_]+(?::[^\]]*)?\]/gi, '')
                             .trim();
 
                         this.callbacks.onTranscript(displayText, false);
@@ -5680,6 +5811,20 @@ initUpdateChecker();
                 if (/\[SLEEP\]/i.test(text)) {
                     console.log('[Sleep] Agent requested sleep — will disconnect after audio');
                     window._sleepAfterResponse = true;
+                }
+                // [AIRADIO_*] — final-pass dispatch. Each unique (verb,data) fires once.
+                {
+                    const _seen = new Set();
+                    const _re = /\[AIRADIO_([A-Z_]+)(?::([^\]]*))?\]/gi;
+                    let _m;
+                    while ((_m = _re.exec(text)) !== null) {
+                        const v = _m[1].toUpperCase();
+                        const d = (_m[2] || '').trim();
+                        const k = `${v}:${d}`;
+                        if (_seen.has(k)) continue;
+                        _seen.add(k);
+                        window.airadioDispatch?.(v, d);
+                    }
                 }
                 // HTML canvas page
                 const htmlMatch =
@@ -8126,9 +8271,17 @@ ${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
                 this.removeThinking();
                 const msg = document.createElement('div');
                 msg.className = 'tp-msg assistant tp-thinking';
-                msg.innerHTML = `<div class="tp-meta">${this.agentName}</div><div class="tp-dots"><span></span><span></span><span></span></div>`;
+                // Keep the animated dots visible ALWAYS and put tool/status text
+                // as a separate subtitle line that updates without killing the
+                // animation. Earlier implementation replaced dots.textContent on
+                // every tool_start, producing static text that was easy to
+                // misread as "frozen".
+                msg.innerHTML = `<div class="tp-meta">${this.agentName}</div>` +
+                                `<div class="tp-dots"><span></span><span></span><span></span></div>` +
+                                `<div class="tp-tool-status" style="font-size:0.85em;opacity:0.75;margin-top:4px"></div>`;
                 this.messages.appendChild(msg);
                 this.messages.scrollTop = this.messages.scrollHeight;
+                this._thinkingStartedAt = Date.now();
                 if (!this.isVisible && this.unreadDot) {
                     this.unreadDot.style.display = 'block';
                 }
@@ -8142,9 +8295,31 @@ ${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
 
             showToolStatus(toolName) {
                 const existing = this.messages?.querySelector('.tp-thinking');
-                if (existing) {
-                    const dots = existing.querySelector('.tp-dots');
-                    if (dots) dots.textContent = `using tool: ${toolName}…`;
+                if (!existing) return;
+                // Preserve the animated dots — update ONLY the subtitle line.
+                // With elapsed time the user sees a live counter even while
+                // one tool is churning (so it doesn't feel frozen between
+                // discrete tool_start events).
+                const status = existing.querySelector('.tp-tool-status');
+                if (status) {
+                    const elapsed = this._thinkingStartedAt
+                        ? Math.floor((Date.now() - this._thinkingStartedAt) / 1000)
+                        : 0;
+                    status.textContent = `using ${toolName} · ${elapsed}s`;
+                }
+            },
+
+            // Called by heartbeat events — refreshes the elapsed counter even
+            // between tool_start events so the user sees a live clock.
+            updateThinkingElapsed(label) {
+                const existing = this.messages?.querySelector('.tp-thinking');
+                if (!existing) return;
+                const status = existing.querySelector('.tp-tool-status');
+                if (status) {
+                    const elapsed = this._thinkingStartedAt
+                        ? Math.floor((Date.now() - this._thinkingStartedAt) / 1000)
+                        : 0;
+                    status.textContent = label ? `${label} · ${elapsed}s` : `${elapsed}s`;
                 }
             },
 
@@ -9207,7 +9382,7 @@ ${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
                         // Tell server to abort the openclaw run (fire-and-forget)
                         console.warn('⛔ ABORT source: PTT interrupt');
                         const serverUrl = cm.config?.serverUrl || '';
-                        fetch(`${serverUrl}/api/conversation/abort`, {
+                        fetch(`${serverUrl}${convPath('abort')}`, {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
                             body: JSON.stringify({ source: 'ptt-interrupt' }),


### PR DESCRIPTION
## Summary

13 fixes to the OpenVoiceUI conversation framework addressing context loss, failed interrupts, repeated main-session poisoning, and MiniMax-M2.7-highspeed returning `chat.final` with zero text. All fixes hot-swapped on josh and validated over 6+ hours of live testing. Zero "Sorry, I couldn't process that" seen after deploy.

## Root cause

MiniMax-M2.7-highspeed returns `chat.final` events with empty text reliably — 15+ times per 30-min window on some clients. openclaw's server-side failover only triggers on timeout/auth/rate-limit per `models-and-providers.md`, not on empty-final. Empties reach the OVU client directly, triggering a chain of downstream failures.

## Fix stack

**openclaw gateway (services/gateways/openclaw.py)**
- **I** — `_stream_events` returns `'empty-final'` on `chat.final with no text`; `_send_and_stream` retries `chat.send` once. Catches ~50% of MiniMax empties invisibly.

**Conversation flow (routes/conversation.py)**
- **B** — Uncommitted tool-promise auto-continue (regex on "I'll do X" + tool_count==0, auto-sends continue-steer)
- **C** — `_build_recovery_prime()` pulls 30 turns of history on session_recovery entry, injects as `[RECENT CONTEXT — ...]` prefix
- **E** — `record_recent_steer`/`consume_recent_steer` — refires lost steers when LLM empties
- **F** — Recovery idle-timeout 10min (was 60s elapsed), activity-bumped per gateway event
- **G** — Prime pulls `session_id IS NULL` rows (was `'default'` only — missed 18/21 typical rows); `max_turns` 6→30
- **H** — Split recovery timestamps; cooldown against last-exited not last-entered (allows immediate re-entry)
- **M** — Removed `time.sleep(1/2)` padding from retry paths
- Sticky recovery with timestamped keys (`recovery-<epoch>`); new daisy-chains spin up fresh recovery if recovery itself poisons

**Classifier (routes/message_classifier.py)**
- **D** — `naw/nah/nuh-uh` steer patterns + scope-refinement ("X only", "just X", "not Y", "exclude X", "filter out")

**Client (src/app.js)**
- **A** — `_textDoneReceived` race guard — post-text_done messages abort + fresh path instead of orphan steer
- **J** — Stop double-processing `data.actions` in text_done (already streamed live via type:'action')
- **K** — No more "Sorry, I couldn't process that" in transcript — silent mic-resume
- **L** — Persistent cascade filler via `SpeechSynthesis` — "one moment / still working / almost there / hang tight"
- Live-thinking indicator keeps dots animated + shows current tool + elapsed seconds; `updateThinkingElapsed()` called on heartbeat

## Live metrics from josh after deploy

4-hour window:
- 16 MiniMax empty-finals
- 8 caught invisibly by Fix I retry (user saw nothing wrong)
- 8 fell through to cascade → all recovered cleanly
- 3 full session recoveries with primes 360–5114 chars
- 14 successful agent responses
- 0 "Sorry, I couldn't process that" terminal failures
- 2 interrupts classified and delivered correctly
- 2 recovery idle-timeouts fired (safety net)

## Related artifacts (outside this PR)

- `openclaw-expert` skill gets a new reference file documenting this cascade so future debugging starts from the answers (in MIKE-AI repo)
- `jambot-session-monitor.py` gets 12 new log patterns + `minimax_empty_cluster` alert (in MIKE-AI repo)
- Memory doc `openvoiceui-session-recovery-fixes.md` covers the rebuild+rollout path for other clients