### PR TITLE
fix(suno): Suno API Song Generation Fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,6 @@
 </head>
 <body>
     <!-- App entry point: injects DOM shell + initializes all modules -->
-    <script type="module" src="src/app.js?v=24"></script>
+    <script type="module" src="src/app.js?v=25"></script>
 </body>
 </html>

--- a/src/app.js
+++ b/src/app.js
@@ -1654,6 +1654,12 @@ connectAiradio();
             activeJobId: null,
             pollInterval: null,
             statusEl: null,
+            // Dedup guard — any prompt fired in the last DEDUP_WINDOW_MS is ignored.
+            // The agent's [SUNO_GENERATE:...] tag gets re-parsed on every streaming
+            // chunk + final pass + secondary handler; without this guard a single
+            // intent fires the paid API 30+ times in one second.
+            _recentPrompts: new Map(),
+            _DEDUP_WINDOW_MS: 60000,
 
             init() {
                 // Create a status banner element for generation feedback
@@ -1681,6 +1687,17 @@ connectAiradio();
             },
 
             async generate(prompt) {
+                // Dedup: drop repeat fires of the same prompt within the window
+                const now = Date.now();
+                for (const [k, t] of this._recentPrompts) {
+                    if (now - t > this._DEDUP_WINDOW_MS) this._recentPrompts.delete(k);
+                }
+                if (this._recentPrompts.has(prompt)) {
+                    console.warn('[Suno] dedup: dropping repeat generate for prompt:', prompt.substring(0, 80));
+                    return;
+                }
+                this._recentPrompts.set(prompt, now);
+
                 console.log('[Suno] Generating:', prompt);
                 this._showStatus('🎵 Suno: submitting song request...');
 


### PR DESCRIPTION
## Summary

`SunoModule.generate()` was getting called 5-30+ times for a single agent song request, burning paid Suno API credits.

The agent's `[SUNO_GENERATE:...]` tag is parsed in three different code paths in app.js (streaming chunk handler, final-pass tag stripper, and the secondary `_processCommandTags`). Combined with session-recovery refires landed in commit 83904bd (Apr 18), every song request was triggering parallel paid generations to Suno's API in the same second.

## Evidence

Suno dashboard audit:
- **Apr 16-18:** 1 fire per song (normal, baseline)
- **May 2 'Hermes Learn Loop':** 8 fires in 1 second, all returned distinct taskIds and unique songs = **96 credits burned for 1 song's worth of intent**
- **May 3 (today, content-rejection scenario):** 147 + 23 fires for two prompts; ~30 paid generations per attempt before Suno's rate-limiter started returning 430s

## Fix

`SunoModule.generate()` keeps a `Map` of recently-fired prompts. Any repeat of the same prompt within a 60-second window returns immediately before the `fetch()` to `/api/suno?action=generate`. Caps cost at exactly 1 paid API call per unique prompt regardless of how many times the upstream parser re-fires.

This is a safety net at the destination, not a root-cause fix. The underlying re-parse loop in the streaming chunk path should also be addressed in a follow-up — but this stops the bleeding for every user of the public repo immediately.

Cache-buster bump (`?v=24` → `?v=25`) forces all browsers to fetch the patched JS.

## Verification

Deployed live to test-dev.jam-bot.com — confirmed via real song request: exactly 1 `Suno generate:` log line, 1 taskId, 1 song produced. Hot-patched into all 9 live OVUI containers (test-dev, mike, josh, src, bun, bricks, danielle, nick, dsf, admin).