### PR TITLE
chore(server): make song_tagger import optional (release blocker)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,4 @@ app/static/canvas-pages/
 # Phase 1.5: platform OAuth credentials — operator-supplied secrets,
 # never committed. The committed template is .platform-oauth.env.example.
 .platform-oauth.env
+routes/song_tagger.py

--- a/server.py
+++ b/server.py
@@ -169,8 +169,11 @@ app.register_blueprint(suno_bp)
 from routes.airadio_bridge import airadio_bp
 app.register_blueprint(airadio_bp)
 
-from routes.song_tagger import song_tagger_bp
-app.register_blueprint(song_tagger_bp)
+try:
+    from routes.song_tagger import song_tagger_bp
+    app.register_blueprint(song_tagger_bp)
+except ImportError:
+    pass
 
 from routes.vision import vision_bp
 app.register_blueprint(vision_bp)


### PR DESCRIPTION
## Summary

\`routes/song_tagger.py\` is a JamBot/AI-Radio-specific proxy to a host-side torch/librosa service that doesn't exist in the public repo. \`server.py\` was importing it unconditionally, so a fresh image build from \`dev\` would have crashed on Flask startup with \`ImportError: routes.song_tagger\`.

The image baked Apr 30 happened to predate the import line, which is why current live containers don't crash — but the moment we rebuild for the next release every client breaks.

## Fix

- Wrap the import in \`try/except ImportError\` so the public repo (and any deploy without the host tagger service) starts cleanly
- Add \`routes/song_tagger.py\` to \`.gitignore\` so the JamBot-only local file never gets accidentally committed

## Verification

\`server.py\` still registers \`song_tagger_bp\` when the file is present (JamBot deploy), and silently skips when it isn't (public deploy).