### PR TITLE
feat(office): persist clerk_user_id + extend CURRENT_USER with office briefing

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -29,7 +29,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-from flask import Blueprint, Response, jsonify, make_response, request
+from flask import Blueprint, Response, g, jsonify, make_response, request
 
 from routes.canvas import canvas_context, update_canvas_context, CANVAS_PAGES_DIR
 from routes.transcripts import save_conversation_turn
@@ -951,6 +951,10 @@ def _conversation_inner():
     session_id = data.get('session_id', 'default')
     ui_context = data.get('ui_context', {})
     identified_person = data.get('identified_person') or None
+    # Capture Clerk user id from request middleware (set by app.py auth check)
+    # so it can be persisted in the transcript JSON for The Office to attribute
+    # turns correctly. Fail-open: missing g.clerk_user_id → None.
+    _clerk_user_id = getattr(g, 'clerk_user_id', None)
     agent_id = data.get('agent_id') or None  # e.g. 'default'; None = default 'main'
     gateway_id = data.get('gateway_id') or None  # plugin gateway id; None = 'openclaw'
     # Fall back to active profile's adapter_config.gateway_id
@@ -2261,6 +2265,7 @@ def _conversation_inner():
                                         duration_ms=metrics.get('total_ms'),
                                         actions=captured_actions,
                                         identified_person=identified_person,
+                                        clerk_user_id=_clerk_user_id,
                                     )
                                 break
 
@@ -2296,6 +2301,7 @@ def _conversation_inner():
                                     duration_ms=metrics.get('total_ms'),
                                     actions=captured_actions,
                                     identified_person=identified_person,
+                                    clerk_user_id=_clerk_user_id,
                                 )
                             break
 
@@ -2411,6 +2417,7 @@ def _conversation_inner():
             duration_ms=metrics.get('total_ms'),
             actions=captured_actions,
             identified_person=identified_person,
+            clerk_user_id=_clerk_user_id,
         )
 
     response_data = {'response': ai_response, 'user_said': user_message}

--- a/routes/transcripts.py
+++ b/routes/transcripts.py
@@ -136,6 +136,7 @@ def save_conversation_turn(
     duration_ms: int = None,
     actions: list = None,
     identified_person: dict = None,
+    clerk_user_id: str = None,
 ) -> 'str | None':
     """Save one conversation turn as a JSON transcript file.
 
@@ -179,6 +180,7 @@ def save_conversation_turn(
             'assistant': ai_response,
             'tools': tools,
             'identified_person': identified_person,
+            'clerk_user_id': clerk_user_id,
             'word_count': {'user': user_words, 'assistant': ai_words},
         }
 

--- a/services/identity.py
+++ b/services/identity.py
@@ -15,11 +15,117 @@ is one JSON edit, no container restart.
 import json
 import logging
 import os
+import re
+from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 REGISTRY_PATH = os.getenv('IDENTITY_REGISTRY_PATH', '/app/data/identity-registry.json')
+
+# The Office filing cabinet (built by host cron from transcripts + ledger + anomalies).
+# Per-tenant path: <OFFICE_ROOT>/people/<slug>.md
+# OPENCLAW workspace is mounted into openvoiceui at /app/runtime/workspace/Agent (RO)
+# so the openvoiceui container can read these files at request time.
+OFFICE_PEOPLE_DIR = os.getenv(
+    'OFFICE_PEOPLE_DIR',
+    '/app/runtime/workspace/Agent/office/people',
+)
+OFFICE_MATTERS_DIR = os.getenv(
+    'OFFICE_MATTERS_DIR',
+    '/app/runtime/workspace/Agent/office/matters',
+)
+
+
+def _slugify(s: str) -> str:
+    s = re.sub(r'[^\w\s-]', '', s.lower())
+    s = re.sub(r'\s+', '-', s).strip('-')
+    return s[:60] or 'unknown'
+
+
+def _load_office_briefing(name: str) -> Optional[str]:
+    """Return a short briefing summary for `name` from the office filing cabinet.
+
+    Pulls the person file and the top 2-3 highest-severity open matters.
+    Returns None if no person file exists or office dir is missing.
+    Fail-open: any error → None (CURRENT_USER tag still goes out without briefing).
+    """
+    try:
+        slug = _slugify(name.split()[0])  # use first name only
+        person_file = Path(OFFICE_PEOPLE_DIR) / f'{slug}.md'
+        if not person_file.exists():
+            return None
+
+        text = person_file.read_text(errors='ignore')
+        # Pull last_seen + total_events from frontmatter
+        last_seen = None
+        total_events = None
+        for line in text.splitlines():
+            if line.startswith('last_seen:'):
+                last_seen = line.split(':', 1)[1].strip()
+            elif line.startswith('total_events:'):
+                total_events = line.split(':', 1)[1].strip()
+            if last_seen and total_events:
+                break
+
+        # Pull commitments (first ~3 from the "Open follow-ups" section)
+        commitments = []
+        in_block = False
+        for line in text.splitlines():
+            if line.strip().startswith('## Open follow-ups'):
+                in_block = True
+                continue
+            if in_block and line.startswith('## '):
+                break
+            if in_block and line.startswith('- ') and not line.startswith('- (none'):
+                commitments.append(line[2:].strip()[:120])
+                if len(commitments) >= 3:
+                    break
+
+        # Pull top 2 high/medium severity matters
+        matters_top = []
+        matters_dir = Path(OFFICE_MATTERS_DIR)
+        if matters_dir.exists():
+            scored = []
+            for f in matters_dir.glob('*.md'):
+                try:
+                    mt = f.read_text(errors='ignore')
+                    title = re.search(r'^title:\s*(.+)$', mt, re.M)
+                    status = re.search(r'^status:\s*(\w+)$', mt, re.M)
+                    sev = re.search(r'^severity:\s*(\w+)$', mt, re.M)
+                    if not title:
+                        continue
+                    if status and status.group(1).lower() not in ('open', 'waiting'):
+                        continue
+                    sev_v = sev.group(1).lower() if sev else 'medium'
+                    rank = 0 if sev_v == 'high' else 1
+                    scored.append((rank, title.group(1).strip()[:120]))
+                except Exception:
+                    continue
+            scored.sort()
+            matters_top = [t for _, t in scored[:2]]
+
+        # Build the briefing block
+        parts = []
+        if last_seen:
+            parts.append(f'last spoke {last_seen}')
+        if total_events and total_events != '0':
+            parts.append(f'{total_events} prior contact events')
+        meta = ', '.join(parts) if parts else 'first contact'
+
+        out = [f'Office file present ({meta}).']
+        if commitments:
+            out.append('Open with them: ' + ' | '.join(commitments))
+        else:
+            out.append('No outstanding commitments to them.')
+        if matters_top:
+            out.append('Live matters at this company: ' + ' | '.join(matters_top))
+        out.append('Lead with their name + 1 specific item. If they ask something not in this brief, say so honestly and log a follow-up — never guess.')
+
+        return ' '.join(out)
+    except Exception as e:
+        logger.debug(f'office briefing load failed (non-fatal): {e}')
+        return None
 
 
 def _load_registry() -> dict:
@@ -93,7 +199,14 @@ def get_current_user_tag(clerk_user_id: Optional[str], tenant: Optional[str] = N
         else:
             location = ''
         body = f'{name}{title_part}{location} {notes}'.strip()
-        return f'[CURRENT_USER: {body}]'
+        tag = f'[CURRENT_USER: {body}]'
+        # Append the office briefing for clients (the secretary's brief).
+        # This is the difference between greeting them as "user" vs greeting
+        # them with their open follow-ups + live matters at their company.
+        briefing = _load_office_briefing(name)
+        if briefing:
+            tag += f'\n[OFFICE_BRIEFING: {briefing}]'
+        return tag
 
     body = f'{name}{title_part}. {notes}'.strip()
     return f'[CURRENT_USER: {body}]'


### PR DESCRIPTION
## Summary

Wires **The Office** filing cabinet (built by host cron in MIKE-AI repo) into the live voice agent so when a known person logs in (Rory, Stephen, Josh, etc.), the agent's first turn includes their open follow-ups + open matters at the company — not a blank slate.

## Three additive patches, all fail-open

### \`routes/transcripts.py\`
- \`clerk_user_id\` field added to \`save_conversation_turn()\` signature + payload
- Persists the active Clerk user id with each transcript JSON so the office extractor can attribute turns correctly going forward (instead of relying on self-intro detection which only catches ~2 turns in 287).

### \`routes/conversation.py\`
- Captures \`_clerk_user_id = getattr(g, 'clerk_user_id', None)\` once at the top of \`_conversation_inner\` (after request data extraction)
- Passes to all 3 \`save_conversation_turn\` call sites
- No new I/O — \`g.clerk_user_id\` is already populated by \`app.py\`'s auth middleware

### \`services/identity.py\`
- \`_load_office_briefing(name)\`: reads \`/app/runtime/workspace/Agent/office/people/<slug>.md\` and \`matters/*.md\`, returns a one-line summary with the person's \`last_seen\` + event count + open commitments + top 2 high-severity open matters at the company
- Extends \`get_current_user_tag()\` for \`role='client'\` to append a separate \`[OFFICE_BRIEFING: ...]\` line below the existing CURRENT_USER tag
- Admin/dev tags unchanged (admins popping into a tenant don't get client briefings — they're there to work, not be greeted)
- All-or-nothing fail-open: any error reading office files → no briefing, CURRENT_USER tag still goes out as before

## Smoke test

Against \`/mnt/clients/src/openclaw/workspace/office/\` for Rory:

\`\`\`
[CURRENT_USER: Rory (client/owner) (logged into their own src tenant)...]
[OFFICE_BRIEFING: Office file present (last spoke 2026-05-01 23:10,
 2 prior contact events). No outstanding commitments. Live matters: ...
 Lead with their name + 1 specific item. If they ask something not in
 this brief, say so honestly and log a follow-up — never guess.]
\`\`\`