### PR TITLE
chore: bump version to 2026.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openvoiceui",
-  "version": "2026.4.28-1",
+  "version": "2026.5.4",
   "description": "Voice-powered AI assistant platform \u2014 connect any LLM, any TTS, with a live web canvas, music generation, and agent orchestration",
   "bin": {
     "openvoiceui": "cli/index.js"


### PR DESCRIPTION
Version bump for the next release.

**Release contents (commits going from 2026.4.28-1 → 2026.5.4):**

### Fixes
- fix(suno): cap paid Suno API at 1 call per song (was firing 5-30+ per song silently) — #294
- fix(conversation): eradicate bare "NO"/"YES" voice-agent leak — #296
- fix(auth): prevent users from reading or burning other users' usage quotas — already on dev
- fix: suppress status TTS after interim response; guard playTTS against text mode — already on dev

### Features
- feat(office): persist clerk_user_id + extend CURRENT_USER with office briefing — #297
- feat: add Qwen3-local TTS provider + fix desktop first-run seeding — already on dev

### Chore / infrastructure
- chore(server): make song_tagger import optional (release blocker fix) — #295
- ci(deps): bump actions/upload-pages-artifact 3 → 5 — #286
- deps(deps): bump groq 1.1.2 → 1.2.0 — #287
- ci(deps): bump trivy-action 0.35.0 → 0.36.0 — #288
- deps(deps): update python-pptx ≥0.6.23 → ≥1.0.2 — #289
- deps(deps): update openpyxl ≥3.1.0 → ≥3.1.5 — #290