### PR TITLE
release: 2026.5.4 — Suno paid-API loop fix + bare-NO eradication + office injection

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: website/build
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Run Trivy filesystem scan (report-only)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,4 @@ app/static/canvas-pages/
 # Phase 1.5: platform OAuth credentials — operator-supplied secrets,
 # never committed. The committed template is .platform-oauth.env.example.
 .platform-oauth.env
+routes/song_tagger.py

--- a/default-pages/desktop.html
+++ b/default-pages/desktop.html
@@ -841,6 +841,10 @@ const ICONS = {
   claw:`<svg viewBox="0 0 48 48"><rect x="2" y="2" width="44" height="44" rx="8" fill="#1a0a0a"/><g transform="translate(24,26)"><path d="M-12,-14 C-14,-18 -16,-22 -14,-24 C-12,-26 -10,-24 -9,-20 C-8,-17 -8,-14 -9,-11" fill="#e63030" stroke="#cc2020" stroke-width="0.8"/><path d="M-9,-11 C-10,-8 -12,-5 -12,-2 C-12,2 -10,5 -7,7 C-4,9 -1,10 0,10 C1,10 4,9 7,7 C10,5 12,2 12,-2 C12,-5 10,-8 9,-11" fill="#e63030" stroke="#cc2020" stroke-width="0.8"/><path d="M9,-11 C8,-14 8,-17 9,-20 C10,-24 12,-26 14,-24 C16,-22 14,-18 12,-14" fill="#e63030" stroke="#cc2020" stroke-width="0.8"/><path d="M-14,-24 C-15,-26 -17,-27 -16,-24 C-15,-21 -13,-19 -12,-18" fill="#ff4040" stroke="#cc2020" stroke-width="0.5"/><path d="M14,-24 C15,-26 17,-27 16,-24 C15,-21 13,-19 12,-18" fill="#ff4040" stroke="#cc2020" stroke-width="0.5"/><circle cx="-4" cy="0" r="1.5" fill="#1a0a0a"/><circle cx="4" cy="0" r="1.5" fill="#1a0a0a"/><path d="M-3,4 C-1,6 1,6 3,4" fill="none" stroke="#1a0a0a" stroke-width="1" stroke-linecap="round"/><ellipse cx="0" cy="-2" rx="8" ry="6" fill="none" stroke="#ff5555" stroke-width="0.4" opacity="0.3"/></g></svg>`,
   crm:`<svg viewBox="0 0 48 48"><rect x="2" y="2" width="44" height="44" rx="8" fill="#1e293b"/><circle cx="24" cy="16" r="7" fill="#3b82f6"/><path d="M12 36c0-6.6 5.4-12 12-12s12 5.4 12 12" fill="#3b82f6" opacity="0.7"/><circle cx="36" cy="20" r="4" fill="#60a5fa"/><path d="M30 32c0-3.3 2.7-6 6-6s6 2.7 6 6" fill="#60a5fa" opacity="0.5"/><circle cx="12" cy="20" r="4" fill="#60a5fa"/><path d="M6 32c0-3.3 2.7-6 6-6s6 2.7 6 6" fill="#60a5fa" opacity="0.5"/></svg>`,
   seo:`<svg viewBox="0 0 48 48"><rect width="48" height="48" rx="10" fill="#0f172a"/><rect x="3" y="3" width="42" height="42" rx="8" fill="none" stroke="#60a5fa" stroke-width=".8" opacity=".3"/><rect x="7" y="29" width="5" height="10" rx="1" fill="#60a5fa" opacity=".5"/><rect x="14" y="23" width="5" height="16" rx="1" fill="#60a5fa" opacity=".65"/><rect x="21" y="17" width="5" height="22" rx="1" fill="#60a5fa" opacity=".8"/><polyline points="9.5,31 16.5,25 24,19 29,15 35,12 40,10" fill="none" stroke="#4ade80" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="40" cy="10" r="1.5" fill="#4ade80"/><text x="24" y="46" text-anchor="middle" font-family="system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="1.5" fill="#93c5fd">SEO</text></svg>`,
+  voice:`<svg viewBox="0 0 48 48"><rect x="19" y="4" width="10" height="22" rx="5" fill="#e74c3c"/><path d="M11 24c0 7.2 5.8 13 13 13s13-5.8 13-13" fill="none" stroke="#c0392b" stroke-width="3" stroke-linecap="round"/><line x1="24" y1="37" x2="24" y2="44" stroke="#c0392b" stroke-width="3" stroke-linecap="round"/><line x1="16" y1="44" x2="32" y2="44" stroke="#c0392b" stroke-width="3" stroke-linecap="round"/></svg>`,
+  terminal:`<svg viewBox="0 0 48 48"><rect x="2" y="6" width="44" height="36" rx="3" fill="#0d1117"/><rect x="2" y="6" width="44" height="8" rx="3" fill="#21262d"/><circle cx="9" cy="10" r="2" fill="#ff5f57"/><circle cx="16" cy="10" r="2" fill="#febc2e"/><circle cx="23" cy="10" r="2" fill="#28c840"/><path d="M8 27l8-5.5-8-5.5" fill="none" stroke="#4ade80" stroke-width="2.2" stroke-linejoin="round" stroke-linecap="round"/><rect x="18" y="28" width="20" height="2.5" rx="1" fill="#4ade80" opacity=".8"/><rect x="18" y="33" width="13" height="2" rx="1" fill="#475569"/></svg>`,
+  upload:`<svg viewBox="0 0 48 48"><rect x="4" y="30" width="40" height="14" rx="2" fill="#2c3e50"/><rect x="4" y="38" width="40" height="6" rx="0" fill="#34495e"/><line x1="24" y1="28" x2="24" y2="6" stroke="#3b82f6" stroke-width="3" stroke-linecap="round"/><path d="M14 16l10-10 10 10" fill="none" stroke="#3b82f6" stroke-width="3" stroke-linejoin="round" stroke-linecap="round"/></svg>`,
+  chart:`<svg viewBox="0 0 48 48"><rect x="2" y="2" width="44" height="44" rx="6" fill="#0f172a"/><rect x="7" y="28" width="7" height="13" rx="1" fill="#3b82f6" opacity=".6"/><rect x="16" y="20" width="7" height="21" rx="1" fill="#3b82f6" opacity=".75"/><rect x="25" y="13" width="7" height="28" rx="1" fill="#3b82f6" opacity=".9"/><rect x="34" y="8" width="7" height="33" rx="1" fill="#60a5fa"/><line x1="4" y1="44" x2="44" y2="44" stroke="#334155" stroke-width="1"/><line x1="4" y1="44" x2="4" y2="4" stroke="#334155" stroke-width="1"/></svg>`,
 };
 
 function getIcon(type) { return ICONS[type] || ICONS.document; }
@@ -1026,10 +1030,9 @@ async function fetchManifest(forceSync) {
       // a curated default set on the desktop. Without this, all 197+ pages
       // flood the desktop on first load or after a state reset.
       const DEFAULT_DESKTOP = [
-        'voice-studio', 'music-library', 'crm', 'crm-kanban',
-        'nightly-reflections', 'usage-costs', 'terminal', 'file-explorer',
-        'game-library', 'openclaw-dashboard', 'system-ops-v2', 'live-monitor',
-        'song-tagger', 'upload-center', 'hermes',
+        'voice-studio', 'music-library',
+        'nightly-reflections', 'usage-costs',
+        'openclaw-dashboard', 'upload-center', 'hermes',
       ];
       knownPages = currentIds.slice();
       desktopPages = DEFAULT_DESKTOP.filter(id => currentIds.includes(id));
@@ -1043,6 +1046,13 @@ async function fetchManifest(forceSync) {
         });
         saveState();
       }
+    }
+
+    // Remove pages that should never appear as loose desktop icons
+    const DESKTOP_HIDDEN = new Set(['file-explorer','ai-app-library','desktop','desktop-tablet','desktop-phone']);
+    if (desktopPages.some(id => DESKTOP_HIDDEN.has(id))) {
+      desktopPages = desktopPages.filter(id => !DESKTOP_HIDDEN.has(id));
+      saveState();
     }
 
     rebuildDesktopItems();
@@ -1107,13 +1117,11 @@ setInterval(updateClock, 30000);
    DESKTOP ICONS
    ══════════════════════════════════════════════════════════════ */
 const SYSTEM_ITEMS = [
-  {id:'my-computer',name:'My Computer',icon:'computer',action:'explorer',macName:'Macintosh HD',w31Name:'File Manager',ubuntuName:'Files'},
+  {id:'my-computer',name:'My Computer',icon:'computer',action:'my-computer',macName:'Macintosh HD',w31Name:'File Manager',ubuntuName:'Files'},
   {id:'recycle-bin',name:'Recycle Bin',icon:'recycle',action:'recycle',macName:'Trash',ubuntuName:'Trash'},
-  {id:'my-documents',name:'My Documents',icon:'folder',action:'docs',ubuntuName:'Documents'},
-  {id:'internet',name:'Internet',icon:'internet',action:'internet',ubuntuName:'Web Browser'},
+  {id:'my-documents',name:'My Documents',icon:'folder',action:'docsfolder',ubuntuName:'Documents'},
   {id:'settings',name:'Display Properties',icon:'settings',action:'settings',macName:'System Preferences',w31Name:'Control Panel',ubuntuName:'Settings'},
-  {id:'game-library-shortcut',name:'Game Library',icon:'game',action:'openPage',pageId:'game-library',macName:'Game Library',ubuntuName:'Games'},
-  {id:'crm',name:'CRM',icon:'crm',action:'openPage',pageId:'crm'},
+  {id:'game-library-shortcut',name:'Game Library',icon:'game',action:'gamefolder',macName:'Game Library',ubuntuName:'Games'},
 ];
 let DESKTOP_ITEMS = [];
 
@@ -1126,8 +1134,11 @@ function _isRecycled(item) {
 function rebuildDesktopItems() {
   // System items — filter out recycled ones (but never hide the recycle bin itself)
   DESKTOP_ITEMS = SYSTEM_ITEMS.filter(item => item.action === 'recycle' || !_isRecycled(item));
-  // Category folders — skip recycled
+  // Skip categories covered by dedicated system icons (My Documents, Game Library)
+  const SYSTEM_CAT_IDS = new Set(['ai-office', 'entertainment']);
+  // Category folders — skip recycled and system-covered
   Object.keys(CATEGORIES).forEach(catId => {
+    if (SYSTEM_CAT_IDS.has(catId)) return;
     const itemId = 'cat-' + catId;
     if (recycleBin.includes(itemId)) return;
     DESKTOP_ITEMS.push({
@@ -1338,8 +1349,8 @@ function findDropTarget(draggedEl, draggedItem) {
     const id = icon.dataset.id;
     const targetItem = DESKTOP_ITEMS.find(i => i.id === id);
     if (!targetItem) continue;
-    // Folders, custom folders, and recycle bin are valid drop targets
-    if (targetItem.action !== 'folder' && targetItem.action !== 'customFolder' && targetItem.action !== 'recycle') continue;
+    // Folders, custom folders, system folders (My Documents, Game Library), and recycle bin are valid drop targets
+    if (targetItem.action !== 'folder' && targetItem.action !== 'customFolder' && targetItem.action !== 'recycle' && targetItem.action !== 'docsfolder' && targetItem.action !== 'gamefolder') continue;
     // Don't allow dropping the recycle bin into itself
     if (targetItem.action === 'recycle' && draggedItem.action === 'recycle') continue;
     const r = icon.getBoundingClientRect();
@@ -1368,6 +1379,16 @@ function dropIntoFolder(draggedItem, targetId) {
     PAGES[pageId].cat = targetItem.category;
     savedPageCategories[pageId] = targetItem.category; // persist across fetchManifest
   }
+  // Move into My Documents (categorize as ai-office)
+  else if (targetItem.action === 'docsfolder') {
+    PAGES[pageId].cat = 'ai-office';
+    savedPageCategories[pageId] = 'ai-office';
+  }
+  // Move into Game Library (categorize as entertainment)
+  else if (targetItem.action === 'gamefolder') {
+    PAGES[pageId].cat = 'entertainment';
+    savedPageCategories[pageId] = 'entertainment';
+  }
   // Move into custom folder
   else if (targetItem.action === 'customFolder' && targetItem.folderId) {
     if (!customFolders[targetItem.folderId]) return;
@@ -1393,10 +1414,12 @@ function updateIconSelection() {
 }
 
 function onIconDblClick(item) {
-  if (item.action === 'explorer') openExplorer();
+  if (item.action === 'my-computer') openCanvasPage('file-explorer');
+  else if (item.action === 'explorer') openExplorer();
   else if (item.action === 'recycle') openRecycleBin();
+  else if (item.action === 'docsfolder') openExplorer('ai-office');
+  else if (item.action === 'gamefolder') { if (PAGES['game-library']) openCanvasPage('game-library'); else openExplorer('entertainment'); }
   else if (item.action === 'docs') openExplorer('ai-office');
-  else if (item.action === 'internet') openExplorer('api-developer');
   else if (item.action === 'settings') openThemeSettings();
   else if (item.action === 'folder') openExplorer(item.category);
   else if (item.action === 'customFolder') openCustomFolder(item.folderId);
@@ -2046,7 +2069,9 @@ function showProperties(item) {
 
   let type = 'System Folder';
   if (item.action === 'recycle') type = 'Recycle Bin';
-  else if (item.action === 'explorer') type = 'System Folder';
+  else if (item.action === 'my-computer' || item.action === 'explorer') type = 'System Folder';
+  else if (item.action === 'docsfolder') type = 'Folder (' + Object.values(PAGES).filter(p=>p.cat==='ai-office').length + ' items)';
+  else if (item.action === 'gamefolder') type = 'Folder (' + Object.values(PAGES).filter(p=>p.cat==='entertainment').length + ' items)';
   else if (item.action === 'folder' && item.category) {
     const cat = CATEGORIES[item.category];
     type = 'Folder (' + (cat ? Object.values(PAGES).filter(p=>p.cat===item.category).length : 0) + ' items)';
@@ -2056,7 +2081,6 @@ function showProperties(item) {
     type = 'Custom Folder (' + (cf ? cf.pages.length : 0) + ' items)';
   }
   else if (item.action === 'settings') type = 'Application';
-  else if (item.action === 'internet') type = 'Application';
   else type = 'System Item';
 
   const now = new Date().toLocaleDateString('en-US', {year:'numeric',month:'long',day:'numeric'});
@@ -2161,7 +2185,7 @@ function buildStartMenu() {
       html += `<div class="ctx-item" onclick="openExplorer('${catId}');closeAllMenus()">${CATEGORIES[catId].name}</div>`;
     });
     html += '<div class="ctx-separator"></div>';
-    html += '<div class="ctx-item" onclick="openExplorer();closeAllMenus()">'+(isMac?'Open Finder':(isUbuntu?'Files':'File Manager'))+'</div>';
+    html += '<div class="ctx-item" onclick="openCanvasPage(\'file-explorer\');closeAllMenus()">'+(isMac?'Open Finder':(isUbuntu?'Files':'File Manager'))+'</div>';
     menu.innerHTML = html;
     return;
   }
@@ -2196,7 +2220,7 @@ function buildStartMenu() {
 
   if (isXP) {
     html += '<div class="sm-right">';
-    html += `<div class="sm-item" onclick="openExplorer();closeAllMenus()"><div class="sm-icon">${getIcon('computer')}</div>My Computer</div>`;
+    html += `<div class="sm-item" onclick="openCanvasPage('file-explorer');closeAllMenus()"><div class="sm-icon">${getIcon('computer')}</div>My Computer</div>`;
     html += `<div class="sm-item" onclick="openExplorer('ai-office');closeAllMenus()"><div class="sm-icon">${getIcon('folder')}</div>My Documents</div>`;
     html += `<div class="sm-item" onclick="openThemeSettings();closeAllMenus()"><div class="sm-icon">${getIcon('settings')}</div>Control Panel</div>`;
     html += '<div class="sm-separator"></div>';
@@ -2414,17 +2438,33 @@ function buildExplorerGrid(catId) {
 }
 
 function getPageIconType(cat, pageId, pageName) {
-  // Page-name overrides take priority — avoids all entertainment pages getting same icon
   const n = (pageName || pageId || '').toLowerCase();
   const pid = (pageId || '').toLowerCase();
+  // Specific page ID overrides — precise icons for known pages
+  const pidMap = {
+    'voice-studio':'voice','music-library':'music','song-tagger':'music',
+    'openclaw-dashboard':'claw','hermes':'claw',
+    'nightly-reflections':'book',
+    'usage-costs':'chart','usage-tracking':'chart',
+    'upload-center':'upload','uploads':'upload',
+    'game-library':'game',
+    'crm':'crm','crm-kanban':'crm',
+    'terminal':'terminal','system-ops-v2':'terminal','live-monitor':'tools',
+    'file-explorer':'computer',
+    'ai-app-library':'folder','ai-image-creator':'folder',
+  };
+  if (pidMap[pid]) return pidMap[pid];
+  // Pattern-based overrides
   if (/openclaw/.test(pid)) return 'claw';
   if (/seo/.test(pid)) return 'seo';
   if (/website|site.setup/.test(pid)) return 'website';
-  if (/music|song|audio|tts|voice.clone|suno/.test(n)) return 'music';
+  if (/voice.studio|voice.clone/.test(n)) return 'voice';
+  if (/music|song|audio|tts|suno/.test(n)) return 'music';
   if (/game|arcade|wolf|doom|quake|duke|play|shooter|civ.sim|bored/.test(n)) return 'game';
   if (/video|film|remotion/.test(n)) return 'folder';
   if (/book|doc|ref|guide|manual/.test(n)) return 'book';
-  if (/tool|build|code|dev|api/.test(n)) return 'tools';
+  if (/tool|build|code|dev|api|terminal/.test(n)) return 'tools';
+  if (/crm|contact|lead/.test(n)) return 'crm';
   const map = {
     'entertainment':'game','tts-voice':'music','reference':'book',
     'api-developer':'tools','business-tools':'tools',
@@ -2547,8 +2587,6 @@ function refreshExplorers() {
    OPEN CANVAS PAGE
    ══════════════════════════════════════════════════════════════ */
 function openCanvasPage(pageId, newWindow) {
-  const page = PAGES[pageId];
-  if (!page) return;
   if (newWindow) {
     window.open('/pages/' + pageId + '.html', '_blank');
     return;
@@ -2557,6 +2595,8 @@ function openCanvasPage(pageId, newWindow) {
   // The desktop runs inside the OpenVoiceUI canvas iframe — sending a
   // 'navigate' action tells the parent to load the target page in this
   // same iframe, which is the standard canvas navigation mechanism.
+  // Note: we always send the message even if the page isn't in the local PAGES
+  // dict yet (manifest may be stale) — the parent decides if it can load it.
   window.parent.postMessage({
     type: 'canvas-action',
     action: 'navigate',
@@ -2863,7 +2903,7 @@ document.addEventListener('keydown', (e) => {
   // Delete key — send selected desktop icons to recycle bin
   if (e.key === 'Delete' && selectedIcons.size > 0) {
     e.preventDefault();
-    const toDelete = [...selectedIcons].map(id => DESKTOP_ITEMS.find(i => i.id === id)).filter(i => i && i.action !== 'recycle' && i.action !== 'explorer');
+    const toDelete = [...selectedIcons].map(id => DESKTOP_ITEMS.find(i => i.id === id)).filter(i => i && i.action !== 'recycle' && i.action !== 'explorer' && i.action !== 'my-computer' && i.action !== 'docsfolder' && i.action !== 'gamefolder' && i.action !== 'settings');
     if (!toDelete.length) return;
     const label = toDelete.length === 1 ? '"' + toDelete[0].name + '"' : toDelete.length + ' items';
     showConfirmModal('Move ' + label + ' to the Recycle Bin?', (ok) => {

--- a/default-pages/voice-studio.html
+++ b/default-pages/voice-studio.html
@@ -363,6 +363,7 @@ body {
   width: 0%;
 }
 .clone-row-fill.qwen3 { background: var(--cyan); }
+.clone-row-fill.qwen3-local { background: #7c3aed; }
 .clone-row-fill.elevenlabs { background: var(--green); }
 .clone-row-fill.resemble { background: var(--orange); }
 .clone-row-status { font-size: 11px; color: var(--text-secondary); text-align: right; font-variant-numeric: tabular-nums; }
@@ -654,6 +655,19 @@ body {
 
     <label class="form-label" style="margin-bottom:10px;">Select Platforms</label>
     <div class="platforms-grid" id="platformsGrid">
+
+      <div class="platform-card" data-provider="qwen3-local" onclick="togglePlatform(this)">
+        <div class="platform-check">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+        </div>
+        <div class="platform-name">Qwen3 Local</div>
+        <div class="platform-sub">RTX GPU · Free</div>
+        <div class="platform-time">~10-20 seconds</div>
+        <div class="platform-status" id="status-qwen3-local">
+          <span class="status-dot" id="dot-qwen3-local"></span>
+          <span id="statusText-qwen3-local">Checking...</span>
+        </div>
+      </div>
 
       <div class="platform-card" data-provider="qwen3" onclick="togglePlatform(this)">
         <div class="platform-check">
@@ -954,7 +968,7 @@ body {
       if (Array.isArray(providers)) {
         providers.forEach(function(p) {
           var pid = p.provider_id || p.name || '';
-          if (pid === 'qwen3' || pid === 'elevenlabs' || pid === 'resemble') {
+          if (pid === 'qwen3' || pid === 'qwen3-local' || pid === 'elevenlabs' || pid === 'resemble') {
             var available = p.status === 'active';
             providerStatus[pid] = available;
             var dot = $('dot-' + pid);
@@ -987,7 +1001,7 @@ body {
       updateCloneButton();
     }).catch(function() {
       // If providers endpoint fails, assume qwen3 is available (it has been working)
-      ['qwen3', 'elevenlabs', 'resemble'].forEach(function(pid) {
+      ['qwen3', 'qwen3-local', 'elevenlabs', 'resemble'].forEach(function(pid) {
         $('statusText-' + pid).textContent = 'Unknown';
         $('dot-' + pid).classList.add('err');
       });
@@ -1037,12 +1051,12 @@ body {
   };
 
   function platformLabel(pid) {
-    var labels = { qwen3: 'Qwen3', elevenlabs: 'ElevenLabs', resemble: 'Resemble' };
+    var labels = { 'qwen3-local': 'Qwen3 Local', qwen3: 'Qwen3', elevenlabs: 'ElevenLabs', resemble: 'Resemble' };
     return labels[pid] || pid;
   }
 
   function estimatedTime(pid) {
-    var times = { qwen3: 40000, elevenlabs: 12000, resemble: 180000 };
+    var times = { 'qwen3-local': 15000, qwen3: 40000, elevenlabs: 12000, resemble: 180000 };
     return times[pid] || 60000;
   }
 

--- a/default-pages/voice-studio.html
+++ b/default-pages/voice-studio.html
@@ -656,7 +656,7 @@ body {
     <label class="form-label" style="margin-bottom:10px;">Select Platforms</label>
     <div class="platforms-grid" id="platformsGrid">
 
-      <div class="platform-card" data-provider="qwen3-local" onclick="togglePlatform(this)">
+      <div class="platform-card" data-provider="qwen3-local" onclick="togglePlatform(this)" style="display:none">
         <div class="platform-check">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
         </div>
@@ -980,6 +980,7 @@ body {
               txt.textContent = 'Available';
               txt.style.color = 'var(--green)';
               card.classList.remove('unavailable');
+              card.style.display = ''; // reveal self-hosted cards when live
             } else {
               dot.classList.add('err');
               dot.classList.remove('ok');
@@ -987,6 +988,8 @@ body {
               txt.style.color = 'var(--text-dim)';
               card.classList.add('unavailable');
               card.classList.remove('selected');
+              // hide self-hosted providers when offline — no point showing them
+              if (pid === 'qwen3-local') card.style.display = 'none';
             }
           }
         });

--- a/index.html
+++ b/index.html
@@ -111,6 +111,6 @@
 </head>
 <body>
     <!-- App entry point: injects DOM shell + initializes all modules -->
-    <script type="module" src="src/app.js?v=24"></script>
+    <script type="module" src="src/app.js?v=25"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openvoiceui",
-  "version": "2026.4.28-1",
+  "version": "2026.5.4",
   "description": "Voice-powered AI assistant platform \u2014 connect any LLM, any TTS, with a live web canvas, music generation, and agent orchestration",
   "bin": {
     "openvoiceui": "cli/index.js"

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -6,4 +6,4 @@
 pypdf>=4.0.0
 python-docx>=1.1.0
 openpyxl>=3.1.5
-python-pptx>=0.6.23
+python-pptx>=1.0.2

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -5,5 +5,5 @@
 # Install: pip install -r requirements-docs.txt
 pypdf>=4.0.0
 python-docx>=1.1.0
-openpyxl>=3.1.0
+openpyxl>=3.1.5
 python-pptx>=0.6.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyYAML>=6.0
 # faster-whisper==1.2.1
 
 # TTS providers
-groq==1.1.2                 # Groq Orpheus TTS (required if using groq provider)
+groq==1.2.0                 # Groq Orpheus TTS (required if using groq provider)
 
 # Auth (Clerk JWT — optional, only if CANVAS_REQUIRE_AUTH=true)
 PyJWT==2.12.1

--- a/routes/airadio_bridge.py
+++ b/routes/airadio_bridge.py
@@ -508,13 +508,21 @@ def push_song():
 
     local_path, meta = _resolve_local_song(filename, playlist)
     if local_path is None:
-        return jsonify({
-            "ok": False,
-            "error": {
-                "code": "NOT_FOUND",
-                "message": f"Song '{filename}' not found in '{playlist}' playlist",
-            },
-        }), 404
+        # Auto-detect: if not found in the stated dir, try the other one.
+        # The JS bridge never sends a playlist param, so it always defaults to
+        # "library" — but most agent-pushed songs live in "generated".
+        alt_playlist = "generated" if playlist == "library" else "library"
+        local_path, meta = _resolve_local_song(filename, alt_playlist)
+        if local_path is not None:
+            playlist = alt_playlist
+        else:
+            return jsonify({
+                "ok": False,
+                "error": {
+                    "code": "NOT_FOUND",
+                    "message": f"Song '{filename}' not found in library or generated playlist",
+                },
+            }), 404
 
     fields = {
         "title": title or (meta or {}).get("title") or local_path.stem,

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1720,6 +1720,10 @@ def _conversation_inner():
                                 elif _res_i.get('audio'):
                                     yield _audio_event(_res_i['audio'], _chunks_sent)
                                     _chunks_sent += 1
+                                    # Reset silence clock — agent already spoke, don't
+                                    # fire "one moment" status TTS right after interim.
+                                    _last_audio_time = time.time()
+                                    _status_tts_count += 1  # suppress first status fire
                             _tts_pending = []
                             _tts_buf = ''
 

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -29,7 +29,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-from flask import Blueprint, Response, jsonify, make_response, request
+from flask import Blueprint, Response, g, jsonify, make_response, request
 
 from routes.canvas import canvas_context, update_canvas_context, CANVAS_PAGES_DIR
 from routes.transcripts import save_conversation_turn
@@ -951,6 +951,10 @@ def _conversation_inner():
     session_id = data.get('session_id', 'default')
     ui_context = data.get('ui_context', {})
     identified_person = data.get('identified_person') or None
+    # Capture Clerk user id from request middleware (set by app.py auth check)
+    # so it can be persisted in the transcript JSON for The Office to attribute
+    # turns correctly. Fail-open: missing g.clerk_user_id → None.
+    _clerk_user_id = getattr(g, 'clerk_user_id', None)
     agent_id = data.get('agent_id') or None  # e.g. 'default'; None = default 'main'
     gateway_id = data.get('gateway_id') or None  # plugin gateway id; None = 'openclaw'
     # Fall back to active profile's adapter_config.gateway_id
@@ -2261,6 +2265,7 @@ def _conversation_inner():
                                         duration_ms=metrics.get('total_ms'),
                                         actions=captured_actions,
                                         identified_person=identified_person,
+                                        clerk_user_id=_clerk_user_id,
                                     )
                                 break
 
@@ -2296,6 +2301,7 @@ def _conversation_inner():
                                     duration_ms=metrics.get('total_ms'),
                                     actions=captured_actions,
                                     identified_person=identified_person,
+                                    clerk_user_id=_clerk_user_id,
                                 )
                             break
 
@@ -2411,6 +2417,7 @@ def _conversation_inner():
             duration_ms=metrics.get('total_ms'),
             actions=captured_actions,
             identified_person=identified_person,
+            clerk_user_id=_clerk_user_id,
         )
 
     response_data = {'response': ai_response, 'user_said': user_message}

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1968,14 +1968,35 @@ def _conversation_inner():
                             # result never reaches it.
                             # Instead: yield {'type':'retrying'} to keep the
                             # client alive, then swap the event queue.
-                            _is_empty = not full_response or not full_response.strip()
+                            #
+                            # Bare "NO" / "YES" (with optional trailing punctuation)
+                            # is treated as a DEGENERATE response — same class of
+                            # broken-LLM output as empty. Confirmed in the wild:
+                            # MiniMax / GLM occasionally emit a 2-char "NO" reply
+                            # to normal user turns (sometimes after the empty-retry
+                            # itself fires). Speaking that to a customer is
+                            # unacceptable, so we route it through the same retry
+                            # → double-empty → graceful-fallback path. A real
+                            # voice answer should always elaborate beyond bare
+                            # YES/NO; the voice-system-prompt instructs the agent
+                            # accordingly.
+                            _resp_stripped = (full_response or '').strip()
+                            _resp_norm = _resp_stripped.upper().rstrip('.!?')
+                            _is_degenerate = _resp_norm in ('NO', 'YES')
+                            _is_empty = (not full_response or not _resp_stripped) or _is_degenerate
                             if _is_empty and metrics.get('llm_inference_ms', 9999) < 5000 \
                                     and not getattr(stream_response, '_retried', False):
                                 stream_response._retried = True
                                 logger.warning(
-                                    f"### EMPTY RESPONSE in {metrics['llm_inference_ms']}ms "
+                                    f"### {'DEGENERATE' if _is_degenerate else 'EMPTY'} RESPONSE "
+                                    f"({_resp_stripped!r} in {metrics['llm_inference_ms']}ms) "
                                     f"— retrying once (client kept alive via 'retrying' event)"
                                 )
+                                # Wipe any TTS buffer that may already hold "NO"
+                                # so the bare token is never spoken to the user.
+                                if _is_degenerate:
+                                    _tts_buf = ''
+                                    _tts_pending.clear()
                                 # Tell the client to wait — don't show fallback
                                 yield json.dumps({'type': 'retrying'}) + '\n'
                                 # No sleep — the original `time.sleep(2)` was to let
@@ -2117,6 +2138,26 @@ def _conversation_inner():
                                     f"### TIMEOUT EMPTY ({metrics['llm_inference_ms']}ms) — "
                                     f"graceful fallback, no session recovery"
                                 )
+
+                            # ── Final safety net: bare "NO" / "YES" must NEVER reach the user ──
+                            # Catches any degenerate single-token response that slipped past
+                            # the retry path above (slow-degenerate 5s–30s, or a retry that
+                            # itself returned bare NO/YES). A real voice answer always
+                            # elaborates; bare YES/NO is broken-LLM output.
+                            _final_norm = (full_response or '').strip().upper().rstrip('.!?')
+                            if _final_norm in ('NO', 'YES') and not user_message.startswith('__'):
+                                logger.warning(
+                                    f"### DEGENERATE FINAL ({metrics.get('llm_inference_ms')}ms) "
+                                    f"response={full_response!r} — replacing with graceful fallback"
+                                )
+                                full_response = (
+                                    "Sorry, my brain glitched for a second. "
+                                    "Could you say that again?"
+                                )
+                                metrics['fallback_used'] = 1
+                                # Wipe TTS buffer so the bare token isn't spoken
+                                _tts_buf = ''
+                                _tts_pending.clear()
 
                             yield json.dumps({
                                 'type': 'text_done',

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -2999,7 +2999,7 @@ def tts_clone_voice():
             }), 400
 
         # --- Validate provider ---
-        clone_providers = ('qwen3', 'elevenlabs', 'resemble')
+        clone_providers = ('qwen3', 'qwen3-local', 'elevenlabs', 'resemble')
         if provider_id not in clone_providers:
             return jsonify({
                 'error': f'Voice cloning not supported for provider "{provider_id}". '
@@ -3023,6 +3023,17 @@ def tts_clone_voice():
                 return jsonify({'error': 'Qwen3 requires audio_url'}), 400
             result = provider.clone_voice(
                 audio_url=audio_url,
+                name=name,
+                reference_text=reference_text,
+            )
+
+        elif provider_id == 'qwen3-local':
+            if not save_path:
+                return jsonify({
+                    'error': 'qwen3-local requires audio file upload (multipart form)'
+                }), 400
+            result = provider.clone_voice(
+                audio_path=str(save_path),
                 name=name,
                 reference_text=reference_text,
             )

--- a/routes/transcripts.py
+++ b/routes/transcripts.py
@@ -136,6 +136,7 @@ def save_conversation_turn(
     duration_ms: int = None,
     actions: list = None,
     identified_person: dict = None,
+    clerk_user_id: str = None,
 ) -> 'str | None':
     """Save one conversation turn as a JSON transcript file.
 
@@ -179,6 +180,7 @@ def save_conversation_turn(
             'assistant': ai_response,
             'tools': tools,
             'identified_person': identified_person,
+            'clerk_user_id': clerk_user_id,
             'word_count': {'user': user_words, 'assistant': ai_words},
         }
 

--- a/server.py
+++ b/server.py
@@ -169,6 +169,9 @@ app.register_blueprint(suno_bp)
 from routes.airadio_bridge import airadio_bp
 app.register_blueprint(airadio_bp)
 
+from routes.song_tagger import song_tagger_bp
+app.register_blueprint(song_tagger_bp)
+
 from routes.vision import vision_bp
 app.register_blueprint(vision_bp)
 

--- a/server.py
+++ b/server.py
@@ -1260,6 +1260,11 @@ def web_search():
 @app.route("/api/usage/<user_id>", methods=["GET"])
 def check_usage(user_id):
     """Return the current month's usage for a user."""
+    # Clerk-authenticated users may only query their own usage.
+    # Internal agent calls (X-Agent-Key, no g.clerk_user_id) are trusted.
+    authenticated_user = g.get('clerk_user_id')
+    if authenticated_user and authenticated_user != user_id:
+        return jsonify({'error': 'Unauthorized', 'code': 'user_mismatch'}), 403
     if user_id in UNLIMITED_USERS:
         return jsonify({
             "user_id": user_id,
@@ -1282,6 +1287,9 @@ def check_usage(user_id):
 @app.route("/api/usage/<user_id>/increment", methods=["POST"])
 def track_usage(user_id):
     """Increment usage count for a user (called after each agent response)."""
+    authenticated_user = g.get('clerk_user_id')
+    if authenticated_user and authenticated_user != user_id:
+        return jsonify({'error': 'Unauthorized', 'code': 'user_mismatch'}), 403
     if user_id in UNLIMITED_USERS:
         increment_usage(user_id)
         return jsonify({

--- a/server.py
+++ b/server.py
@@ -169,8 +169,11 @@ app.register_blueprint(suno_bp)
 from routes.airadio_bridge import airadio_bp
 app.register_blueprint(airadio_bp)
 
-from routes.song_tagger import song_tagger_bp
-app.register_blueprint(song_tagger_bp)
+try:
+    from routes.song_tagger import song_tagger_bp
+    app.register_blueprint(song_tagger_bp)
+except ImportError:
+    pass
 
 from routes.vision import vision_bp
 app.register_blueprint(vision_bp)

--- a/services/identity.py
+++ b/services/identity.py
@@ -15,11 +15,117 @@ is one JSON edit, no container restart.
 import json
 import logging
 import os
+import re
+from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 REGISTRY_PATH = os.getenv('IDENTITY_REGISTRY_PATH', '/app/data/identity-registry.json')
+
+# The Office filing cabinet (built by host cron from transcripts + ledger + anomalies).
+# Per-tenant path: <OFFICE_ROOT>/people/<slug>.md
+# OPENCLAW workspace is mounted into openvoiceui at /app/runtime/workspace/Agent (RO)
+# so the openvoiceui container can read these files at request time.
+OFFICE_PEOPLE_DIR = os.getenv(
+    'OFFICE_PEOPLE_DIR',
+    '/app/runtime/workspace/Agent/office/people',
+)
+OFFICE_MATTERS_DIR = os.getenv(
+    'OFFICE_MATTERS_DIR',
+    '/app/runtime/workspace/Agent/office/matters',
+)
+
+
+def _slugify(s: str) -> str:
+    s = re.sub(r'[^\w\s-]', '', s.lower())
+    s = re.sub(r'\s+', '-', s).strip('-')
+    return s[:60] or 'unknown'
+
+
+def _load_office_briefing(name: str) -> Optional[str]:
+    """Return a short briefing summary for `name` from the office filing cabinet.
+
+    Pulls the person file and the top 2-3 highest-severity open matters.
+    Returns None if no person file exists or office dir is missing.
+    Fail-open: any error → None (CURRENT_USER tag still goes out without briefing).
+    """
+    try:
+        slug = _slugify(name.split()[0])  # use first name only
+        person_file = Path(OFFICE_PEOPLE_DIR) / f'{slug}.md'
+        if not person_file.exists():
+            return None
+
+        text = person_file.read_text(errors='ignore')
+        # Pull last_seen + total_events from frontmatter
+        last_seen = None
+        total_events = None
+        for line in text.splitlines():
+            if line.startswith('last_seen:'):
+                last_seen = line.split(':', 1)[1].strip()
+            elif line.startswith('total_events:'):
+                total_events = line.split(':', 1)[1].strip()
+            if last_seen and total_events:
+                break
+
+        # Pull commitments (first ~3 from the "Open follow-ups" section)
+        commitments = []
+        in_block = False
+        for line in text.splitlines():
+            if line.strip().startswith('## Open follow-ups'):
+                in_block = True
+                continue
+            if in_block and line.startswith('## '):
+                break
+            if in_block and line.startswith('- ') and not line.startswith('- (none'):
+                commitments.append(line[2:].strip()[:120])
+                if len(commitments) >= 3:
+                    break
+
+        # Pull top 2 high/medium severity matters
+        matters_top = []
+        matters_dir = Path(OFFICE_MATTERS_DIR)
+        if matters_dir.exists():
+            scored = []
+            for f in matters_dir.glob('*.md'):
+                try:
+                    mt = f.read_text(errors='ignore')
+                    title = re.search(r'^title:\s*(.+)$', mt, re.M)
+                    status = re.search(r'^status:\s*(\w+)$', mt, re.M)
+                    sev = re.search(r'^severity:\s*(\w+)$', mt, re.M)
+                    if not title:
+                        continue
+                    if status and status.group(1).lower() not in ('open', 'waiting'):
+                        continue
+                    sev_v = sev.group(1).lower() if sev else 'medium'
+                    rank = 0 if sev_v == 'high' else 1
+                    scored.append((rank, title.group(1).strip()[:120]))
+                except Exception:
+                    continue
+            scored.sort()
+            matters_top = [t for _, t in scored[:2]]
+
+        # Build the briefing block
+        parts = []
+        if last_seen:
+            parts.append(f'last spoke {last_seen}')
+        if total_events and total_events != '0':
+            parts.append(f'{total_events} prior contact events')
+        meta = ', '.join(parts) if parts else 'first contact'
+
+        out = [f'Office file present ({meta}).']
+        if commitments:
+            out.append('Open with them: ' + ' | '.join(commitments))
+        else:
+            out.append('No outstanding commitments to them.')
+        if matters_top:
+            out.append('Live matters at this company: ' + ' | '.join(matters_top))
+        out.append('Lead with their name + 1 specific item. If they ask something not in this brief, say so honestly and log a follow-up — never guess.')
+
+        return ' '.join(out)
+    except Exception as e:
+        logger.debug(f'office briefing load failed (non-fatal): {e}')
+        return None
 
 
 def _load_registry() -> dict:
@@ -93,7 +199,14 @@ def get_current_user_tag(clerk_user_id: Optional[str], tenant: Optional[str] = N
         else:
             location = ''
         body = f'{name}{title_part}{location} {notes}'.strip()
-        return f'[CURRENT_USER: {body}]'
+        tag = f'[CURRENT_USER: {body}]'
+        # Append the office briefing for clients (the secretary's brief).
+        # This is the difference between greeting them as "user" vs greeting
+        # them with their open follow-ups + live matters at their company.
+        briefing = _load_office_briefing(name)
+        if briefing:
+            tag += f'\n[OFFICE_BRIEFING: {briefing}]'
+        return tag
 
     body = f'{name}{title_part}. {notes}'.strip()
     return f'[CURRENT_USER: {body}]'

--- a/src/app.js
+++ b/src/app.js
@@ -1654,6 +1654,12 @@ connectAiradio();
             activeJobId: null,
             pollInterval: null,
             statusEl: null,
+            // Dedup guard — any prompt fired in the last DEDUP_WINDOW_MS is ignored.
+            // The agent's [SUNO_GENERATE:...] tag gets re-parsed on every streaming
+            // chunk + final pass + secondary handler; without this guard a single
+            // intent fires the paid API 30+ times in one second.
+            _recentPrompts: new Map(),
+            _DEDUP_WINDOW_MS: 60000,
 
             init() {
                 // Create a status banner element for generation feedback
@@ -1681,6 +1687,17 @@ connectAiradio();
             },
 
             async generate(prompt) {
+                // Dedup: drop repeat fires of the same prompt within the window
+                const now = Date.now();
+                for (const [k, t] of this._recentPrompts) {
+                    if (now - t > this._DEDUP_WINDOW_MS) this._recentPrompts.delete(k);
+                }
+                if (this._recentPrompts.has(prompt)) {
+                    console.warn('[Suno] dedup: dropping repeat generate for prompt:', prompt.substring(0, 80));
+                    return;
+                }
+                this._recentPrompts.set(prompt, now);
+
                 console.log('[Suno] Generating:', prompt);
                 this._showStatus('🎵 Suno: submitting song request...');
 

--- a/src/app.js
+++ b/src/app.js
@@ -5791,6 +5791,11 @@ connectAiradio();
             }
 
             async playTTS(audioBase64) {
+                // Skip if user is in text mode
+                if (window.TranscriptPanel?.textMode) {
+                    console.log('[VoiceConversation] Skipping TTS — text mode active');
+                    return;
+                }
                 // Stop any currently playing audio — only one TTS plays at a time
                 this.stopAudio();
                 this.callbacks.onSpeaking();

--- a/tts_providers/qwen3_local_provider.py
+++ b/tts_providers/qwen3_local_provider.py
@@ -1,0 +1,267 @@
+"""
+Qwen3-TTS Local Provider — GPU inference on residential-laptop via reverse SSH tunnel.
+
+Hits 127.0.0.1:8096 (raw Qwen3-TTS Mesh API) for synthesis and voice creation.
+Checks 127.0.0.1:18791/health for availability — auto-disabled when laptop is off.
+
+Falls back silently to qwen3 (fal.ai) provider when unavailable.
+
+Voice clones stored as .pt files under VOICE_CLONES_DIR/qwen3-local/.
+"""
+
+import io
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+from .base_provider import TTSProvider
+
+logger = logging.getLogger(__name__)
+
+RUNNER_URL = "http://127.0.0.1:18791"
+API_URL    = os.getenv("QWEN_TTS_LOCAL_URL", "http://127.0.0.1:8096")
+
+BUILTIN_VOICES = [
+    "Vivian", "Serena", "Dylan", "Eric",
+    "Ryan", "Aiden", "Uncle_Fu", "Ono_Anna", "Sohee",
+]
+
+# Cache availability so we don't health-check on every request
+_AVAILABLE_CACHE: dict = {"ok": None, "checked_at": 0.0}
+_CACHE_TTL = 30.0  # seconds
+
+
+def _get_auth_token() -> str:
+    return os.getenv("OVUI_BRIDGE_AUTH_TOKEN", "")
+
+
+def _get_clones_dir() -> Path:
+    try:
+        from services.paths import VOICE_CLONES_DIR
+        base = VOICE_CLONES_DIR
+    except ImportError:
+        base = Path(os.getenv("VOICE_CLONES_DIR", "./runtime/voice-clones"))
+    d = base / "qwen3-local"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _is_available() -> bool:
+    now = time.time()
+    if now - _AVAILABLE_CACHE["checked_at"] < _CACHE_TTL and _AVAILABLE_CACHE["ok"] is not None:
+        return _AVAILABLE_CACHE["ok"]
+    try:
+        with httpx.Client(timeout=3.0) as c:
+            r = c.get(f"{API_URL}/health")
+            ok = r.status_code == 200 and r.json().get("status") == "ok"
+    except Exception:
+        ok = False
+    _AVAILABLE_CACHE["ok"] = ok
+    _AVAILABLE_CACHE["checked_at"] = now
+    return ok
+
+
+class Qwen3LocalProvider(TTSProvider):
+    """
+    Qwen3-TTS running on the residential-laptop RTX 3070 GPU.
+    Free, zero API cost. Only available when laptop is on and tunnel is up.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._token = _get_auth_token()
+        self._status = "active" if self._token else "error"
+        self._init_error = None if self._token else "OVUI_BRIDGE_AUTH_TOKEN not set"
+
+    def _auth_headers(self) -> dict:
+        return {"Authorization": f"Bearer {self._token}"}
+
+    # ------------------------------------------------------------------
+    # Voice cloning
+    # ------------------------------------------------------------------
+
+    def clone_voice(self, audio_path: str = None, audio_bytes: bytes = None,
+                    audio_url: str = None, name: str = "",
+                    reference_text: str = "") -> dict:
+        """
+        Clone a voice. Accepts audio_path (local file), audio_bytes, or audio_url.
+        Returns dict with voice_id, name, pt_path, created_at, clone_time_ms.
+        """
+        if not _is_available():
+            raise RuntimeError("qwen3-local unavailable — laptop offline or tunnel down")
+        if not self._token:
+            raise RuntimeError("OVUI_BRIDGE_AUTH_TOKEN not set")
+
+        # Resolve audio bytes
+        if audio_bytes is None:
+            if audio_path:
+                audio_bytes = Path(audio_path).read_bytes()
+            elif audio_url:
+                with httpx.Client(timeout=30.0) as c:
+                    audio_bytes = c.get(audio_url).content
+            else:
+                raise ValueError("One of audio_path, audio_bytes, or audio_url required")
+
+        filename = Path(audio_path).name if audio_path else "reference.wav"
+
+        t = time.time()
+        with httpx.Client(timeout=120.0) as c:
+            resp = c.post(
+                f"{API_URL}/create-voice",
+                headers=self._auth_headers(),
+                files={"audio": (filename, io.BytesIO(audio_bytes))},
+                data={"transcript": reference_text or ""},
+            )
+            resp.raise_for_status()
+
+        pt_bytes = resp.content
+        elapsed_ms = int((time.time() - t) * 1000)
+
+        voice_id = "clone_" + "".join(
+            ch for ch in name.lower().replace(" ", "_") if ch.isalnum() or ch == "_"
+        )[:40]
+        voice_dir = _get_clones_dir() / voice_id
+        voice_dir.mkdir(parents=True, exist_ok=True)
+
+        pt_path = voice_dir / "voice.pt"
+        pt_path.write_bytes(pt_bytes)
+
+        import json
+        meta = {
+            "voice_id": voice_id,
+            "name": name,
+            "reference_text": reference_text,
+            "pt_path": str(pt_path),
+            "pt_size": len(pt_bytes),
+            "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "clone_time_ms": elapsed_ms,
+            "provider": "qwen3-local",
+        }
+        (voice_dir / "metadata.json").write_text(json.dumps(meta, indent=2))
+
+        logger.info(f"[Qwen3Local] Voice cloned: {voice_id} ({len(pt_bytes)}B) in {elapsed_ms}ms")
+        return meta
+
+    def list_cloned_voices(self) -> list:
+        import json
+        voices = []
+        clones_dir = _get_clones_dir()
+        for voice_dir in sorted(clones_dir.iterdir()):
+            meta_path = voice_dir / "metadata.json"
+            if meta_path.exists():
+                try:
+                    meta = json.loads(meta_path.read_text())
+                    meta["has_pt"] = (voice_dir / "voice.pt").exists()
+                    voices.append(meta)
+                except Exception as e:
+                    logger.warning(f"[Qwen3Local] Bad metadata in {voice_dir}: {e}")
+        return voices
+
+    def _get_voice_pt(self, voice_id: str) -> Optional[bytes]:
+        pt_path = _get_clones_dir() / voice_id / "voice.pt"
+        if pt_path.exists():
+            return pt_path.read_bytes()
+        return None
+
+    # ------------------------------------------------------------------
+    # Speech generation
+    # ------------------------------------------------------------------
+
+    def generate_speech(self, text: str, voice: str = "Vivian", **kwargs) -> bytes:
+        if not _is_available():
+            raise RuntimeError("qwen3-local unavailable — laptop offline or tunnel down")
+        if not self._token:
+            raise RuntimeError("OVUI_BRIDGE_AUTH_TOKEN not set")
+
+        self.validate_text(text)
+        language = kwargs.get("language", "auto")
+
+        is_cloned = voice and voice.startswith("clone_")
+
+        if is_cloned:
+            pt_bytes = self._get_voice_pt(voice)
+            if not pt_bytes:
+                raise RuntimeError(f"Cloned voice '{voice}' not found — .pt file missing")
+
+            t = time.time()
+            with httpx.Client(timeout=120.0) as c:
+                resp = c.post(
+                    f"{API_URL}/tts",
+                    headers=self._auth_headers(),
+                    files={"voice_pt": ("voice.pt", io.BytesIO(pt_bytes))},
+                    data={"text": text, "language": language},
+                )
+                resp.raise_for_status()
+        else:
+            # Built-in voice: use tts-raw with no reference audio — not supported
+            # by this API. Fall back: use tts-raw with empty audio placeholder
+            # or raise so caller falls back to fal.ai.
+            raise RuntimeError(
+                f"qwen3-local only supports cloned voices (.pt). "
+                f"Built-in voice '{voice}' requires fal.ai — use qwen3 provider instead."
+            )
+
+        audio_bytes = resp.content
+        elapsed_ms = int((time.time() - t) * 1000)
+        logger.info(f"[Qwen3Local] TTS: {len(audio_bytes)}B in {elapsed_ms}ms voice={voice}")
+        return audio_bytes
+
+    # ------------------------------------------------------------------
+    # Provider interface
+    # ------------------------------------------------------------------
+
+    def health_check(self) -> dict:
+        _AVAILABLE_CACHE["checked_at"] = 0.0  # force re-check
+        t = time.time()
+        ok = _is_available()
+        latency_ms = int((time.time() - t) * 1000)
+        if ok:
+            return {"ok": True, "latency_ms": latency_ms,
+                    "detail": "RTX 3070 GPU — Qwen3-TTS-1.7B ready"}
+        return {"ok": False, "latency_ms": latency_ms,
+                "detail": "Laptop offline or tunnel down"}
+
+    def list_voices(self) -> list:
+        cloned = [v["voice_id"] for v in self.list_cloned_voices()]
+        return cloned
+
+    def get_default_voice(self) -> str:
+        cloned = self.list_cloned_voices()
+        return cloned[0]["voice_id"] if cloned else "clone_default"
+
+    def is_available(self) -> bool:
+        return bool(self._token) and _is_available()
+
+    def get_info(self) -> dict:
+        available = _is_available()
+        cloned = self.list_cloned_voices() if available else []
+        return {
+            "name": "Qwen3-TTS (local GPU)",
+            "provider_id": "qwen3-local",
+            "status": "active" if available else "offline",
+            "description": (
+                "Qwen3-TTS-1.7B on residential RTX 3070 GPU — free, no API cost. "
+                "Cloned voices only. Requires laptop + tunnel to be up."
+            ),
+            "quality": "very-high",
+            "latency": "fast",
+            "cost_per_minute": 0.0,
+            "voices": [v["voice_id"] for v in cloned],
+            "cloned_voices": [
+                {"voice_id": v["voice_id"], "name": v["name"]} for v in cloned
+            ],
+            "features": [
+                "voice-cloning", "multilingual", "local-gpu",
+                "free", "mp3-output", "no-api-key",
+            ],
+            "requires_api_key": False,
+            "gpu": "RTX 3070 (8GB VRAM)",
+            "model": "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+            "tunnel_url": API_URL,
+            "available": available,
+            "error": None if available else "Laptop offline or SSH tunnel down",
+        }


### PR DESCRIPTION
Release **2026.5.4** (from \`2026.4.28-1\`).

## Highlights

**Critical cost-leak fix.** Every song generation since ~Apr 19 was firing 5-30+ paid Suno API calls instead of 1, due to streaming-text re-parse loops. Audit confirmed every \"successful\" song burned 5-8× the credits. PR #294 caps the paid API at exactly 1 call per unique prompt per 60s.

**Critical UX fix.** The voice agent occasionally responded to users with a bare \"NO\" or \"YES\" — both spoken via TTS and shown in the transcript. Two-layer guard in \`routes/conversation.py\` now catches it before the user ever hears it. PR #296.

**New: Office briefing injection.** Voice agents now receive Clerk-driven open follow-ups + open matters when a known person logs in. PR #297.

**Release-blocker fix.** \`server.py\` was importing a JamBot-only \`song_tagger\` proxy unconditionally, so any fresh image build would have crashed at Flask startup. Made the import optional. PR #295.

## Full changelog

### Fixes
- fix(suno): cap paid Suno API at 1 call per unique prompt per 60s window — #294
- fix(conversation): eradicate bare \"NO\"/\"YES\" voice-agent leak — #296
- fix(auth): prevent users from reading or burning other users' usage quotas
- fix: suppress status TTS after interim response; guard playTTS against text mode

### Features
- feat(office): persist clerk_user_id + extend CURRENT_USER with office briefing — #297
- feat: add Qwen3-local TTS provider + fix desktop first-run seeding

### Chore / infrastructure
- chore: bump version to 2026.5.4 — #298
- chore(ovui): bump app.js cache-buster v=24 → v=25 (forces fresh JS load)
- chore(server): make song_tagger import optional + gitignore the file — #295
- chore: hide qwen3-local Voice Studio card when provider is offline

### Dependencies (security/maintenance)
- ci(deps): bump actions/upload-pages-artifact 3 → 5 — #286
- ci(deps): bump aquasecurity/trivy-action 0.35.0 → 0.36.0 — #288
- deps(deps): bump groq 1.1.2 → 1.2.0 — #287
- deps(deps): update python-pptx ≥0.6.23 → ≥1.0.2 — #289
- deps(deps): update openpyxl ≥3.1.0 → ≥3.1.5 — #290

## Post-merge action required

After this lands on \`main\`, the JamBot host must rebuild the OpenVoiceUI image so live containers pick up the permanent fixes (currently they're running an Apr-30 image with hot-patches layered on top — any container restart loses the patches):

\`\`\`bash
bash scripts/jambot-build-images.sh
\`\`\`

Then restart each client's container stack to load the new image. Hot-patches in \`/app/src/app.js\` will be replaced with the baked-in equivalents — no functional change for users.