### PR TITLE
chore(bump): sync services/gateways/compat.py in bump-openclaw-version.sh

### DIFF
--- a/bump-openclaw-version.sh
+++ b/bump-openclaw-version.sh
@@ -46,10 +46,17 @@ OLD=$(grep "OPENCLAW_TESTED_VERSION=" setup-sudo.sh | grep -o '[0-9]\{4\}\.[0-9]
 sed -i "s/OPENCLAW_TESTED_VERSION=\"[0-9]*\.[0-9]*\.[0-9]*\"/OPENCLAW_TESTED_VERSION=\"${NEW_VERSION}\"/" setup-sudo.sh
 echo "  setup-sudo.sh:               $OLD -> $NEW_VERSION"
 
+# 4. services/gateways/compat.py — Python protocol-compat layer holds its own pin
+# that consumers (server.py, gateway connector) read on every startup. Was missed
+# by this script for months and drifted to 2026.3.13.
+OLD=$(grep 'OPENCLAW_TESTED_VERSION = ' services/gateways/compat.py | grep -o '[0-9]\{4\}\.[0-9]*\.[0-9]*' | head -1)
+sed -i "s/OPENCLAW_TESTED_VERSION = \"[0-9]*\.[0-9]*\.[0-9]*\"/OPENCLAW_TESTED_VERSION = \"${NEW_VERSION}\"/" services/gateways/compat.py
+echo "  services/gateways/compat.py: $OLD -> $NEW_VERSION"
+
 echo ""
-echo "All 3 installer paths updated. Verify with:"
-echo "  grep -r '$NEW_VERSION' docker-compose.yml deploy/openclaw/Dockerfile setup-sudo.sh"
+echo "All 4 installer paths updated. Verify with:"
+echo "  grep -r '$NEW_VERSION' docker-compose.yml deploy/openclaw/Dockerfile setup-sudo.sh services/gateways/compat.py"
 echo ""
 echo "Then commit:"
-echo "  git add docker-compose.yml deploy/openclaw/Dockerfile setup-sudo.sh"
+echo "  git add docker-compose.yml deploy/openclaw/Dockerfile setup-sudo.sh services/gateways/compat.py"
 echo "  git commit -m \"chore: bump openclaw to $NEW_VERSION\""


### PR DESCRIPTION
## Summary
- Adds `services/gateways/compat.py` as the 4th sync target in `bump-openclaw-version.sh`
- Updates the trailing verify + commit hint output to mention the 4 paths
- Drift gap discovered: `OPENCLAW_TESTED_VERSION` in `compat.py` was `"2026.3.13"` while the other three paths were on `"2026.3.24"`. The Python constant is read on every gateway startup and emits a version-mismatch warning when it disagrees with the live server — so this had been quietly noisy for months.

## Why
Pre-work for the openclaw 2026.3.24 → 2026.5.2 bump (issue #300). When we run `bash bump-openclaw-version.sh 2026.5.2` in the bump PR, all 4 paths now move together. Captured in `docs/jambot/openclaw-upgrade-2026.5.2.md` §2 in the MIKE-AI repo.

Targeting `dev` to ride the next release.