### PR TITLE
chore: bump openclaw 2026.3.24 -> 2026.5.2

### DIFF
--- a/deploy/openclaw/Dockerfile
+++ b/deploy/openclaw/Dockerfile
@@ -16,8 +16,8 @@ ENV PATH=$PNPM_HOME:$PATH
 RUN mkdir -p $PNPM_HOME
 
 # OpenClaw version — pinned to the version tested with this OpenVoiceUI release.
-# Override at build time: docker compose build --build-arg OPENCLAW_VERSION=2026.3.24
-ARG OPENCLAW_VERSION=2026.3.24
+# Override at build time: docker compose build --build-arg OPENCLAW_VERSION=2026.5.2
+ARG OPENCLAW_VERSION=2026.5.2
 RUN pnpm add -g openclaw@${OPENCLAW_VERSION} && pnpm approve-builds -g
 
 # Optional: install a coding CLI so the coding-agent skill is available.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: deploy/openclaw
       args:
-        OPENCLAW_VERSION: ${OPENCLAW_VERSION:-2026.3.24}
+        OPENCLAW_VERSION: ${OPENCLAW_VERSION:-2026.5.2}
         CODING_CLI: ${CODING_CLI:-pi}
     volumes:
       - openclaw-data:/root/.openclaw

--- a/services/gateways/compat.py
+++ b/services/gateways/compat.py
@@ -24,7 +24,7 @@ PROTOCOL_MIN = 3
 PROTOCOL_MAX = 5  # forward-compatible — OpenClaw ignores unsupported maxes
 
 # Version this code was tested against (for warning logs).
-OPENCLAW_TESTED_VERSION = "2026.3.13"
+OPENCLAW_TESTED_VERSION = "2026.5.2"
 OPENCLAW_MIN_VERSION = "2026.3.1"
 
 

--- a/setup-sudo.sh
+++ b/setup-sudo.sh
@@ -14,7 +14,7 @@ EMAIL="your@email.com"           # ← EDIT: for Let's Encrypt notifications
 SERVICE_NAME="openvoiceui"
 RUN_USER="${SUDO_USER:-$(whoami)}"
 WWW_DIR="/var/www/${SERVICE_NAME}"          # canvas pages + any web assets
-OPENCLAW_TESTED_VERSION="2026.3.24"        # pinned: the openclaw version tested with this release
+OPENCLAW_TESTED_VERSION="2026.5.2"        # pinned: the openclaw version tested with this release
 # ────────────────────────────────────────────────────────────────────────────
 
 # Guard: refuse to run with placeholder values


### PR DESCRIPTION
## Summary
Generated by `bash bump-openclaw-version.sh 2026.5.2`. All 4 sync targets updated atomically:

| File | From | To |
|---|---|---|
| `docker-compose.yml` | 2026.3.24 | 2026.5.2 |
| `deploy/openclaw/Dockerfile` | 2026.3.24 | 2026.5.2 |
| `setup-sudo.sh` | 2026.3.24 | 2026.5.2 |
| `services/gateways/compat.py` | 2026.3.13 | 2026.5.2 |

The compat.py jump catches an 11-version drift gap that the bump script started syncing in #304.

## Why
Closes #300 (openclaw bump). The bump is the last gating item for #302 release tracking; #94 (UI state migration) follows after this lands.

## Risk
**LOW** — full upgrade audit + risk matrix lives in [MIKE-AI/docs/jambot/openclaw-upgrade-2026.5.2.md](https://github.com/MCERQUA/MIKE-AI/blob/main/docs/jambot/openclaw-upgrade-2026.5.2.md). Both P0 risks closed pre-bump:

- §3.1 `registerEmbeddedExtensionFactory` removal (v2026.4.24) — ByteRover purge in #303 + MCERQUA/MIKE-AI#4 closed this entirely.
- §3.2 trusted-proxy auth tightening (v2026.3.31) — Flask handshake at `services/gateways/openclaw.py:463` already token-bearing.

## Big wins shipped in the 23-release window
- v2026.5.2 GLM-5 consecutive-turn context preservation (headline win — addresses bare-NO/YES family of bugs we've been hot-patching)
- mDNS/Bonjour Docker probe-loop bug fully fixed (we set `discovery.mdns.mode: "off"` to work around it; the safety net is now layered)
- Anthropic-compat streaming delta fix (silent-agent-turn class)
- `sessions.json` no longer carries `resolvedSkills` array per row (significant disk savings on tenants with many sessions)
- Heartbeat scheduler runaway fix (raises safety floor even with heartbeats off)
- Anthropic beta headers stop leaking to custom MiniMax/Z.AI endpoints

## Companion PR
MCERQUA/MIKE-AI#6 — bumps `jambot/openclaw/Dockerfile` (the JamBot-only image Dockerfile, separate from `deploy/openclaw/Dockerfile` by intent). Both must merge before the image rebuild.

## Post-merge sequence (sandbox-first)
1. `bash /home/mike/MIKE-AI/scripts/jambot-build-images.sh` — rebuild `jambot/openclaw:latest`
2. Force-recreate `openclaw-test-dev` only — sandbox smoke test (§8 of prep doc)
3. 24h soak on test-dev
4. Platform roll across all clients in `docs/jambot/client-registry.md`