### PR TITLE
fix(upload): auto-convert HEIC/HEIF to JPG on ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,6 @@ OpenVoiceUI has a plugin system for community-built extensions. Plugins can incl
 | **Hermes Agent** | Gateway | Self-improving AI agent with auto-generated skills, deep memory search, and autonomous tasks. Adds OpenClaw+Hermes hybrid and Hermes-only modes |
 | **SEO Platform** | Canvas Page | Full SEO dashboard powered by DataForSEO — keyword research, rank tracking, backlink analysis, site audits, AI visibility, and local SEO |
 | **Twenty CRM** | Canvas Page | Connect to a Twenty CRM instance for contact, company, deal, and task management with embedded CRM view and setup wizard |
-| **ByteRover Long-Term Memory** | Context Engine | Persistent long-term memory that curates conversation knowledge every turn into a human-readable markdown knowledge base |
 
 **Build your own.** Face packs, canvas pages, workflow dashboards, gateway adapters ([template](plugins/README.md)), or STT/TTS adapters ([template](src/adapters/_template.js)). See the [plugins repo](https://github.com/MCERQUA/openvoiceui-plugins) for submission guidelines.
 

--- a/bump-openclaw-version.sh
+++ b/bump-openclaw-version.sh
@@ -46,10 +46,17 @@ OLD=$(grep "OPENCLAW_TESTED_VERSION=" setup-sudo.sh | grep -o '[0-9]\{4\}\.[0-9]
 sed -i "s/OPENCLAW_TESTED_VERSION=\"[0-9]*\.[0-9]*\.[0-9]*\"/OPENCLAW_TESTED_VERSION=\"${NEW_VERSION}\"/" setup-sudo.sh
 echo "  setup-sudo.sh:               $OLD -> $NEW_VERSION"
 
+# 4. services/gateways/compat.py — Python protocol-compat layer holds its own pin
+# that consumers (server.py, gateway connector) read on every startup. Was missed
+# by this script for months and drifted to 2026.3.13.
+OLD=$(grep 'OPENCLAW_TESTED_VERSION = ' services/gateways/compat.py | grep -o '[0-9]\{4\}\.[0-9]*\.[0-9]*' | head -1)
+sed -i "s/OPENCLAW_TESTED_VERSION = \"[0-9]*\.[0-9]*\.[0-9]*\"/OPENCLAW_TESTED_VERSION = \"${NEW_VERSION}\"/" services/gateways/compat.py
+echo "  services/gateways/compat.py: $OLD -> $NEW_VERSION"
+
 echo ""
-echo "All 3 installer paths updated. Verify with:"
-echo "  grep -r '$NEW_VERSION' docker-compose.yml deploy/openclaw/Dockerfile setup-sudo.sh"
+echo "All 4 installer paths updated. Verify with:"
+echo "  grep -r '$NEW_VERSION' docker-compose.yml deploy/openclaw/Dockerfile setup-sudo.sh services/gateways/compat.py"
 echo ""
 echo "Then commit:"
-echo "  git add docker-compose.yml deploy/openclaw/Dockerfile setup-sudo.sh"
+echo "  git add docker-compose.yml deploy/openclaw/Dockerfile setup-sudo.sh services/gateways/compat.py"
 echo "  git commit -m \"chore: bump openclaw to $NEW_VERSION\""

--- a/deploy/openclaw/Dockerfile
+++ b/deploy/openclaw/Dockerfile
@@ -16,8 +16,8 @@ ENV PATH=$PNPM_HOME:$PATH
 RUN mkdir -p $PNPM_HOME
 
 # OpenClaw version — pinned to the version tested with this OpenVoiceUI release.
-# Override at build time: docker compose build --build-arg OPENCLAW_VERSION=2026.3.24
-ARG OPENCLAW_VERSION=2026.3.24
+# Override at build time: docker compose build --build-arg OPENCLAW_VERSION=2026.5.2
+ARG OPENCLAW_VERSION=2026.5.2
 RUN pnpm add -g openclaw@${OPENCLAW_VERSION} && pnpm approve-builds -g
 
 # Optional: install a coding CLI so the coding-agent skill is available.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: deploy/openclaw
       args:
-        OPENCLAW_VERSION: ${OPENCLAW_VERSION:-2026.3.24}
+        OPENCLAW_VERSION: ${OPENCLAW_VERSION:-2026.5.2}
         CODING_CLI: ${CODING_CLI:-pi}
     volumes:
       - openclaw-data:/root/.openclaw

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ psutil==7.2.2
 
 # Image processing (icon generation, uploads)
 Pillow>=10.0.0
+pillow-heif>=0.18.0
 PyYAML>=6.0
 
 # Speech-to-text (optional — adds ~200MB for onnxruntime + ctranslate2)

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -468,9 +468,13 @@ def _build_recovery_prime(max_turns: int = 6) -> str | None:
             # usually None) — only the steer/interject routes explicitly
             # write session_id='default'. Include both so the prime
             # reflects the actual recent conversation.
+            # Time-filter: only inject turns from the last 10 minutes so stale
+            # context from previous sessions (hours/days old) can't poison a
+            # fresh recovery. Recovery is immediate so old turns are irrelevant.
             rows = _c.execute(
                 'SELECT role, message FROM conversation_log '
-                "WHERE session_id = 'default' OR session_id IS NULL "
+                "WHERE (session_id = 'default' OR session_id IS NULL) "
+                "AND created_at >= datetime('now', '-10 minutes') "
                 'ORDER BY id DESC LIMIT ?',
                 (max_turns,),
             ).fetchall()
@@ -525,10 +529,9 @@ def _enter_session_recovery():
     agent behaves like a brand-new conversation and users experience
     'context lost' after a recovery.
 
-    IMPORTANT: Uses a STABLE key ('recovery') not a timestamped one.
-    Timestamped keys (recovery-<epoch>) created a new openclaw session
-    every time, piling up zombie sessions that never got cleaned.
-    A stable key reuses the same recovery session each time."""
+    Uses a timestamped key so that if the recovery session ITSELF poisons
+    later, a new recovery-<epoch> session can be spun up cleanly. The
+    last-exited cooldown prevents rapid thrashing."""
     global _session_recovery_key, _recovery_entered_at, _recovery_last_activity_at, _recovery_context_prime
     # Cooldown: prevent re-entering recovery within 10s of a previous SUCCESSFUL
     # exit. Pre-Fix-F this was measured against _recovery_entered_at which
@@ -1432,8 +1435,13 @@ def _conversation_inner():
             # After a double-empty that flipped us to the 'recovery' key,
             # prepend a compressed history summary to the very FIRST request
             # so the fresh openclaw session has memory of the prior turns.
+            # Skip on __session_start__: injecting old context onto a greeting
+            # request causes the agent to pick up stale work instead of greeting.
             _recovery_prime = consume_recovery_prime()
-            if _recovery_prime:
+            if _recovery_prime and user_message == '__session_start__':
+                logger.info('### Suppressing recovery prime on __session_start__ (greeting takes priority)')
+                _recovery_prime = None
+            elif _recovery_prime:
                 logger.info(f'### Injecting session-recovery prime ({len(_recovery_prime)} chars)')
 
             def _run_gateway():

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1249,6 +1249,20 @@ def _conversation_inner():
         except Exception:
             pass
 
+        # Recently FAILED Suno generations — agent must tell user something went wrong
+        try:
+            from routes.suno import failed_songs_queue
+            if failed_songs_queue:
+                _failed = failed_songs_queue[-3:]
+                _failed_lines = []
+                for f in _failed:
+                    label = f.get('brand') or f.get('title') or 'a track'
+                    reason = f.get('reason', 'unknown error')
+                    _failed_lines.append(f'{label!r} — {reason}')
+                context_parts.append(f'[Suno generation FAILED: {"; ".join(_failed_lines)} — apologize to user and offer to try again]')
+        except Exception:
+            pass
+
         # Available canvas pages (agent needs IDs for [CANVAS:page-id])
         try:
             from routes.canvas import load_canvas_manifest
@@ -1269,6 +1283,7 @@ def _conversation_inner():
     _min_sentence_chars = 40  # default — prevents choppy short TTS fragments
     _parallel_sentences = True  # default — fire all TTS in parallel threads
     _inter_sentence_gap_ms = 0  # default — no gap between audio chunks
+    _prof = None  # default — referenced again in __session_start__ greeting branch below
     try:
         from profiles.manager import get_profile_manager
         from routes.profiles import _active_profile_id
@@ -1320,11 +1335,36 @@ def _conversation_inner():
     # Replace the legacy __session_start__ sentinel with a natural-language greeting
     # prompt so the LLM produces a real greeting instead of a system sentinel ("NO").
     # user_message is kept as-is so the sentinel suppression logic still works.
+    #
+    # If the active profile defines a verbatim conversation.greeting, the LLM is
+    # instructed to say it EXACTLY — no improvisation, no "Welcome back, ready
+    # when you are" drift. This makes the on-screen greeting deterministic across
+    # restarts. Profiles without a greeting fall back to the open-ended prompt.
     if user_message == '__session_start__':
         logger.info(f"### CALL_START session={session_id}")
         _face = identified_person or {}
         _face_name = _face.get('name', '') if _face.get('name', '') != 'unknown' else ''
-        if _face_name:
+        _profile_greeting = ''
+        try:
+            if _prof and getattr(_prof, 'conversation', None):
+                _profile_greeting = (getattr(_prof.conversation, 'greeting', '') or '').strip()
+        except Exception:
+            _profile_greeting = ''
+        if _profile_greeting:
+            if _face_name:
+                _gateway_message = (
+                    f'A new voice session has just started. The person in front of the camera '
+                    f'has been identified as {_face_name}. Say EXACTLY this sentence as your '
+                    f'entire response — do not add or remove anything, do not rephrase, do not '
+                    f'append qualifiers: "{_profile_greeting}"'
+                )
+            else:
+                _gateway_message = (
+                    f'A new voice session has just started. Say EXACTLY this sentence as your '
+                    f'entire response — do not add or remove anything, do not rephrase, do not '
+                    f'append qualifiers: "{_profile_greeting}"'
+                )
+        elif _face_name:
             _gateway_message = (
                 f'A new voice session has just started. The person in front of the camera '
                 f'has been identified as {_face_name}. Greet them by name — '

--- a/routes/static_files.py
+++ b/routes/static_files.py
@@ -13,6 +13,7 @@ Registers routes:
 import logging
 import random
 import re
+import subprocess
 from pathlib import Path
 
 from flask import Blueprint, Response, jsonify, request, send_file
@@ -302,7 +303,32 @@ def upload_file():
     UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
     f.save(str(dest))
 
+    # --- HEIC/HEIF → JPG auto-conversion ---
+    # Browsers can't display HEIC natively. Convert on ingest so the file is
+    # immediately usable. ImageMagick + libheif1 are present on the host image.
+    if ext in ('.heic', '.heif'):
+        jpg_name = f"{stem_safe}__{uuid.uuid4().hex[:8]}.jpg"
+        jpg_dest = UPLOADS_DIR / jpg_name
+        try:
+            result = subprocess.run(
+                ['convert', f'{dest}[0]', str(jpg_dest)],
+                capture_output=True, timeout=30
+            )
+            if result.returncode == 0 and jpg_dest.exists():
+                dest.rename(dest.parent / (dest.stem + '.heic.original'))
+                dest = jpg_dest
+                safe_name = jpg_name
+                ext = '.jpg'
+                logger.info(f'### HEIC→JPG conversion ok: {jpg_name}')
+            else:
+                logger.warning(f'### HEIC→JPG conversion failed (rc={result.returncode}): {result.stderr.decode()[:200]}')
+        except Exception as _e:
+            logger.warning(f'### HEIC→JPG conversion error: {_e}')
+
     mime = f.mimetype or mimetypes.guess_type(original_name)[0] or ''
+    # Re-derive mime from converted extension so HEIC→JPG is flagged as image
+    if ext == '.jpg':
+        mime = 'image/jpeg'
     is_image = mime.startswith('image/')
 
     result = {

--- a/routes/static_files.py
+++ b/routes/static_files.py
@@ -13,7 +13,6 @@ Registers routes:
 import logging
 import random
 import re
-import subprocess
 from pathlib import Path
 
 from flask import Blueprint, Response, jsonify, request, send_file
@@ -305,23 +304,21 @@ def upload_file():
 
     # --- HEIC/HEIF → JPG auto-conversion ---
     # Browsers can't display HEIC natively. Convert on ingest so the file is
-    # immediately usable. ImageMagick + libheif1 are present on the host image.
+    # immediately usable. Uses pillow-heif (in requirements.txt).
     if ext in ('.heic', '.heif'):
         jpg_name = f"{stem_safe}__{uuid.uuid4().hex[:8]}.jpg"
         jpg_dest = UPLOADS_DIR / jpg_name
         try:
-            result = subprocess.run(
-                ['convert', f'{dest}[0]', str(jpg_dest)],
-                capture_output=True, timeout=30
-            )
-            if result.returncode == 0 and jpg_dest.exists():
-                dest.rename(dest.parent / (dest.stem + '.heic.original'))
-                dest = jpg_dest
-                safe_name = jpg_name
-                ext = '.jpg'
-                logger.info(f'### HEIC→JPG conversion ok: {jpg_name}')
-            else:
-                logger.warning(f'### HEIC→JPG conversion failed (rc={result.returncode}): {result.stderr.decode()[:200]}')
+            import pillow_heif
+            from PIL import Image as _Image
+            pillow_heif.register_heif_opener()
+            with _Image.open(str(dest)) as _img:
+                _img.convert('RGB').save(str(jpg_dest), 'JPEG', quality=90)
+            dest.rename(dest.parent / (dest.stem + '.heic.original'))
+            dest = jpg_dest
+            safe_name = jpg_name
+            ext = '.jpg'
+            logger.info(f'### HEIC→JPG conversion ok: {jpg_name}')
         except Exception as _e:
             logger.warning(f'### HEIC→JPG conversion error: {_e}')
 

--- a/routes/suno.py
+++ b/routes/suno.py
@@ -59,9 +59,41 @@ SUNO_CALLBACK_URL = (
 
 suno_jobs: dict = {}  # job_id -> {status, prompt, title, style, created_at, task_id, ...}
 completed_songs_queue: list = []  # [{song_id, title, job_id, completed_at, url}, ...]
+failed_songs_queue: list = []     # [{job_id, kind, brand, reason, failed_at}, ...]
 _suno_lock = threading.Lock()
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Jingle style presets — proven 2026-05-05. The recipe is:
+#   customMode: false
+#   instrumental: false
+#   model: V5
+#   prompt: "<brand> vocal logo jingle, <STYLE_DESCRIPTOR>, [Intro"
+# The truncated "[Intro" (no closing bracket) signals "this is just an intro"
+# so Suno renders ~10-15s instead of a full song.
+# ---------------------------------------------------------------------------
+JINGLE_STYLE_PRESETS = {
+    # `keyword` = 1-3 word adjective inserted before "vocal logo jingle" in v4 recipe.
+    # Minimal style signal that adds variety without lengthening the prompt enough
+    # to break the truncated `, [Intro` short-form trigger.
+    'rock':          {'keyword': 'rock'},
+    'country':       {'keyword': 'country'},
+    'cinematic':     {'keyword': 'cinematic trailer'},
+    'gospel':        {'keyword': 'gospel'},
+    'lofi-hiphop':   {'keyword': 'lo-fi hip hop'},
+    'jazz':          {'keyword': 'jazz'},
+    'edm':           {'keyword': 'EDM festival'},
+    'bluegrass':     {'keyword': 'bluegrass'},
+    'synthwave':     {'keyword': '80s synthwave'},
+    'latin':         {'keyword': 'Latin bossa'},
+    'reggae':        {'keyword': 'reggae'},
+    'gritty-blues':  {'keyword': 'delta blues'},
+    'orchestral':    {'keyword': 'epic orchestral'},
+    'punk':          {'keyword': 'punk rock'},
+    'rnb':           {'keyword': 'R&B'},
+}
+_JINGLE_GENDER_WORD = {'m': 'male', 'f': 'female'}
 
 
 def _is_safe_download_url(url: str) -> bool:
@@ -113,10 +145,15 @@ def _save_generated_metadata(metadata: dict) -> None:
 
 
 def _add_song_to_metadata(filename: str, title: str, prompt: str, style: str,
-                          duration: float = 0, song_id: str = '') -> None:
-    """Write a new song entry to generated_metadata.json in the format music.py expects."""
+                          duration: float = 0, song_id: str = '',
+                          kind: str = 'song', extra: dict = None) -> None:
+    """Write a new song entry to generated_metadata.json in the format music.py expects.
+
+    `kind` is 'song' (full track) or 'jingle' (10-15s logo jingle). `extra` is merged
+    into the entry — used by jingles to record brand, style_key, vocal_gender.
+    """
     metadata = _load_generated_metadata()
-    metadata[filename] = {
+    entry = {
         'title': title,
         'artist': 'Clawdbot AI',
         'description': prompt[:200] if prompt else 'AI-generated track',
@@ -129,7 +166,11 @@ def _add_song_to_metadata(filename: str, title: str, prompt: str, style: str,
         'made_by': 'Clawdbot',
         'created_date': datetime.now().strftime('%Y-%m-%d'),
         'suno_id': song_id,
+        'kind': kind,
     }
+    if extra:
+        entry.update(extra)
+    metadata[filename] = entry
     _save_generated_metadata(metadata)
 
 
@@ -218,6 +259,19 @@ def handle_suno():
         elif action == 'generate':
             return _action_generate(_q, body)
 
+        elif action == 'jingle':
+            return _action_jingle(_q, body)
+
+        elif action == 'list_jingles':
+            return _action_list_jingles()
+
+        elif action == 'jingle_styles':
+            return jsonify({
+                'action': 'jingle_styles',
+                'styles': sorted(JINGLE_STYLE_PRESETS.keys()),
+                'previews': {k: v['keyword'] for k, v in JINGLE_STYLE_PRESETS.items()},
+            })
+
         elif action == 'status':
             return _action_status(_q('job_id') or _q('song_id'))
 
@@ -225,7 +279,7 @@ def handle_suno():
             return _action_credits()
 
         else:
-            return jsonify({'action': 'error', 'response': f"Unknown action '{action}'. Use: generate, status, list, credits"})
+            return jsonify({'action': 'error', 'response': f"Unknown action '{action}'. Use: generate, jingle, list_jingles, jingle_styles, status, list, credits"})
 
     except Exception as exc:
         logger.exception('Suno endpoint error')
@@ -294,7 +348,7 @@ def _action_generate(_q, body: dict):
             'prompt': song_prompt,
             'customMode': True,
             'instrumental': instrumental,
-            'model': 'V5',
+            'model': 'V5_5',
             'vocalGender': vocal_gender,
             'negativeTags': 'low quality, mumbling, distorted, off-key',
             'style': style or 'Catchy, Radio-friendly, Professional',
@@ -306,7 +360,7 @@ def _action_generate(_q, body: dict):
             'prompt': song_prompt,
             'customMode': False,
             'instrumental': instrumental,
-            'model': 'V5',
+            'model': 'V5_5',
             'vocalGender': vocal_gender,
         }
 
@@ -351,6 +405,183 @@ def _action_generate(_q, body: dict):
 
     except http_requests.RequestException as exc:
         return jsonify({'action': 'error', 'response': f"Couldn't reach Suno API: {exc}"})
+
+
+def _action_jingle(_q, body: dict):
+    """Generate a 10-15 second vocal-logo jingle of a brand name.
+
+    Uses the proven recipe (2026-05-05): customMode=false, instrumental=false,
+    model=V5, prompt ending in literal `, [Intro` (truncated half-tag) — that
+    suffix tells Suno "this is just an intro" so it stops at ~10-15s instead of
+    rendering a full song.
+
+    Inputs:
+      brand          — required, the brand/company name to be sung
+      style          — preset key (see JINGLE_STYLE_PRESETS) OR freetext descriptor.
+                       Random preset chosen if omitted.
+      vocal_gender   — m | f (default m). Ignored if instrumental=true.
+      instrumental   — true to render the jingle as an instrumental audio-logo.
+    """
+    import random
+    brand = (_q('brand') or body.get('brand', '')).strip()
+    if not brand:
+        return jsonify({'action': 'error', 'response': "Need a brand/company name to sing."})
+
+    style_in = (_q('style') or body.get('style', '')).strip()
+    vocal_gender = (_q('vocal_gender') or body.get('vocal_gender', 'm')).lower()
+    if vocal_gender not in ('m', 'f'):
+        vocal_gender = 'm'
+
+    instrumental_raw = _q('instrumental') or body.get('instrumental', False)
+    if isinstance(instrumental_raw, bool):
+        instrumental = instrumental_raw
+    else:
+        instrumental = str(instrumental_raw).lower() in ('true', '1', 'yes')
+
+    # repeat = how many times the brand is sung (1 = shorter ~8-12s, 2 = ~12-15s, default 2)
+    repeat_raw = _q('repeat') or body.get('repeat', 2)
+    try:
+        repeat = max(1, min(3, int(repeat_raw)))
+    except (TypeError, ValueError):
+        repeat = 2
+
+    # Resolve style: preset key, freetext, random preset, or BARE (no style at all).
+    # `bare` flag forces zero style insertion — produces shortest-possible output.
+    bare_raw = _q('bare') or body.get('bare', False)
+    bare = bool(bare_raw) if isinstance(bare_raw, bool) else str(bare_raw).lower() in ('true', '1', 'yes')
+    style_key = ''
+    if bare:
+        style_in = ''  # force empty so style_keyword resolves to ''
+    elif style_in and style_in.lower() in JINGLE_STYLE_PRESETS:
+        style_key = style_in.lower()
+    elif not style_in:
+        style_key = random.choice(list(JINGLE_STYLE_PRESETS.keys()))
+
+    # Resolve short style keyword (1-3 words). For freetext, use as-is but trim hard.
+    if style_key:
+        style_keyword = JINGLE_STYLE_PRESETS[style_key]['keyword']
+    else:
+        # freetext — strip to first ~3 words to keep the prompt minimal
+        style_keyword = ' '.join(style_in.split()[:3]) if style_in else ''
+    style_descriptor = style_keyword  # for metadata logging
+
+    # Recipe v4 (2026-05-05): minimalist — matches Mike's verified-working pattern from
+    # 2026-05-05 with a single short style keyword inserted before "vocal logo jingle".
+    # The truncated `, [Intro` (no closing bracket) signals "this is just an intro" so
+    # Suno renders 10-15s instead of a full song. Recipe history:
+    #   v1 — multi-clause style descriptor → 30-141s (too long, descriptor inflated output)
+    #   v2 — customMode=true skeleton lyrics → 531 refunded (lyrics too short)
+    #   v3 — customMode=false with inline [Intro]...[End] block → 400 malformed
+    #   v4 — minimal keyword + Mike's exact `, [Intro` truncation
+    negative_tags = 'verse, chorus, full song, long intro, padding, extended outro, lengthy, repeat hook, second verse'
+    # v5 uses model V5 (not V5.5) — V5.5 tends to render fuller/longer outputs;
+    # V5 hits the 10-15s short-form sweet spot more reliably with the truncated
+    # `, [Intro` trick.
+    if instrumental:
+        kw_phrase = f'{style_keyword} ' if style_keyword else ''
+        jingle_prompt = f'{brand} {kw_phrase}instrumental audio logo, [Intro'
+        request_body = {
+            'prompt': jingle_prompt,
+            'customMode': False,
+            'instrumental': True,
+            'model': 'V5',
+            'negativeTags': negative_tags + ', vocals, lyrics, singing',
+        }
+    else:
+        kw_phrase = f'{style_keyword} ' if style_keyword else ''
+        jingle_prompt = f'{brand} {kw_phrase}vocal logo jingle, [Intro'
+        request_body = {
+            'prompt': jingle_prompt,
+            'customMode': False,
+            'instrumental': False,
+            'model': 'V5',
+            'vocalGender': vocal_gender,
+            'negativeTags': negative_tags,
+        }
+
+    if SUNO_CALLBACK_URL:
+        request_body['callBackUrl'] = SUNO_CALLBACK_URL
+
+    logger.info(f'Suno jingle: brand={brand!r} style_key={style_key!r} '
+                f'gender={vocal_gender} instrumental={instrumental} repeat={repeat} '
+                f'prompt={jingle_prompt[:120]!r}')
+
+    try:
+        resp = http_requests.post(
+            f'{SUNO_API_BASE}/api/v1/generate',
+            headers={'Authorization': f'Bearer {SUNO_API_KEY}', 'Content-Type': 'application/json'},
+            json=request_body,
+            timeout=30,
+        )
+        logger.info(f'Suno jingle API response: {resp.status_code} {resp.text[:300]}')
+
+        if resp.status_code != 200:
+            return jsonify({'action': 'error', 'response': f'Suno API HTTP {resp.status_code}: {resp.text[:200]}'})
+
+        data = resp.json()
+        if data.get('code') != 200 or not data.get('data', {}).get('taskId'):
+            return jsonify({'action': 'error', 'response': f"Suno API error: {data.get('msg', 'Unknown error')}"})
+
+        task_id = data['data']['taskId']
+        job_id = str(uuid.uuid4())
+        suno_jobs[job_id] = {
+            'status': 'generating',
+            'prompt': jingle_prompt,
+            'title': f'{brand} Jingle',
+            'style': style_descriptor,
+            'task_id': task_id,
+            'created_at': time.time(),
+            'kind': 'jingle',
+            'brand': brand,
+            'style_key': style_key,
+            'vocal_gender': vocal_gender,
+            'instrumental': instrumental,
+            'repeat': repeat,
+        }
+        return jsonify({
+            'action': 'generating',
+            'job_id': job_id,
+            'task_id': task_id,
+            'kind': 'jingle',
+            'brand': brand,
+            'style_key': style_key,
+            'response': f"Cooking your '{brand}' jingle ({style_key or 'custom'}) — ready in ~45-60s.",
+            'estimated_seconds': 45,
+        })
+
+    except http_requests.RequestException as exc:
+        return jsonify({'action': 'error', 'response': f"Couldn't reach Suno API: {exc}"})
+
+
+def _action_list_jingles():
+    """Return only generations tagged kind=jingle, newest first."""
+    metadata = _load_generated_metadata()
+    jingles = []
+    for f in sorted(GENERATED_MUSIC_DIR.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
+        if f.suffix.lower() not in {'.mp3', '.wav', '.ogg', '.m4a'}:
+            continue
+        meta = metadata.get(f.name, {})
+        if meta.get('kind') != 'jingle':
+            continue
+        jingles.append({
+            'filename': f.name,
+            'title': meta.get('title', f.stem),
+            'brand': meta.get('brand', ''),
+            'style_key': meta.get('style_key', ''),
+            'vocal_gender': meta.get('vocal_gender', ''),
+            'instrumental': meta.get('instrumental', False),
+            'duration_seconds': meta.get('duration_seconds', 0),
+            'created_date': meta.get('created_date', ''),
+            'description': meta.get('description', ''),
+            'url': f'/generated_music/{f.name}',
+            'size_bytes': f.stat().st_size,
+        })
+    return jsonify({
+        'action': 'list_jingles',
+        'count': len(jingles),
+        'jingles': jingles,
+        'response': f'Got {len(jingles)} jingles in the vault.',
+    })
 
 
 def _action_status(job_id: str):
@@ -453,7 +684,20 @@ def _action_status(job_id: str):
                                 logger.warning(f'Suno download failed: {audio_resp.status_code}')
                                 continue
 
-                        # Save metadata
+                        # Save metadata — propagate jingle fields if this was a jingle job
+                        kind = job.get('kind', 'song')
+                        extra = {}
+                        if kind == 'jingle':
+                            extra = {
+                                'brand': job.get('brand', ''),
+                                'style_key': job.get('style_key', ''),
+                                'vocal_gender': job.get('vocal_gender', ''),
+                                'instrumental': job.get('instrumental', False),
+                            }
+                        # Capture lyrics from Suno response if present
+                        song_lyrics = song.get('prompt', '') or song.get('lyrics', '')
+                        if song_lyrics:
+                            extra['lyrics'] = song_lyrics
                         _add_song_to_metadata(
                             filename=filename,
                             title=song_title,
@@ -461,6 +705,8 @@ def _action_status(job_id: str):
                             style=job.get('style', ''),
                             duration=duration,
                             song_id=song_id,
+                            kind=kind,
+                            extra=extra,
                         )
 
                         # Update job
@@ -475,9 +721,11 @@ def _action_status(job_id: str):
                             'filename': filename,
                             'title': song_title,
                             'job_id': job_id,
+                            'kind': kind,
                             'url': f'/generated_music/{filename}',
                             'completed_at': datetime.now().isoformat(),
                             'prompt': job.get('prompt', ''),
+                            'lyrics': song_lyrics,
                         })
 
                         return jsonify({
@@ -500,7 +748,27 @@ def _action_status(job_id: str):
                         'response': f'Still cooking ({gen_status})...',
                     })
                 else:
-                    return jsonify({'action': 'status', 'status': gen_status.lower(), 'response': f'Status: {gen_status}'})
+                    # Anything not in (SUCCESS, PENDING, TEXT_SUCCESS, FIRST_SUCCESS) is a failure
+                    reason = status_data.get('errorMessage') or status_data.get('msg') or gen_status or 'generation failed'
+                    job['status'] = 'failed'
+                    job['error'] = reason
+                    failed_songs_queue.append({
+                        'job_id': job_id,
+                        'task_id': task_id,
+                        'kind': job.get('kind', 'song'),
+                        'brand': job.get('brand', ''),
+                        'title': job.get('title', ''),
+                        'reason': reason,
+                        'failed_at': datetime.now().isoformat(),
+                    })
+                    logger.warning(f'Suno job {job_id} failed: {reason}')
+                    return jsonify({
+                        'action': 'failed',
+                        'status': 'failed',
+                        'job_id': job_id,
+                        'reason': reason,
+                        'response': f"Suno couldn't make the song: {reason}",
+                    })
 
     except Exception as exc:
         logger.warning(f'Suno status poll error: {exc}')
@@ -555,6 +823,30 @@ def suno_callback():
             callback_type = data.get('data', {}).get('callbackType', '')
             task_id = data.get('data', {}).get('taskId', '')
 
+            # Failure callback — surface to user + agent
+            if callback_type == 'error':
+                reason = data.get('data', {}).get('errorMessage') or data.get('msg') or 'Suno reported an error'
+                _job_id = None
+                _job = None
+                for jid, job in suno_jobs.items():
+                    if job.get('task_id') == task_id:
+                        _job_id = jid
+                        _job = job
+                        job['status'] = 'failed'
+                        job['error'] = reason
+                        break
+                failed_songs_queue.append({
+                    'job_id': _job_id or task_id,
+                    'task_id': task_id,
+                    'kind': (_job or {}).get('kind', 'song'),
+                    'brand': (_job or {}).get('brand', ''),
+                    'title': (_job or {}).get('title', ''),
+                    'reason': reason,
+                    'failed_at': datetime.now().isoformat(),
+                })
+                logger.warning(f'Suno callback reported error for task {task_id}: {reason}')
+                return jsonify({'status': 'ok'})
+
             # sunoapi.org sends: "text" (lyrics ready), "first"/"second" (audio ready), "complete"
             # Only process 'complete' to avoid duplicates (first/second are partial deliveries
             # of the same songs that appear again in complete).
@@ -606,6 +898,8 @@ def suno_callback():
                                 prompt = ''
                                 style = ''
                                 job_id = None
+                                kind = 'song'
+                                extra = {}
                                 for jid, job in suno_jobs.items():
                                     if job.get('task_id') == task_id:
                                         job['status'] = 'complete'
@@ -614,18 +908,35 @@ def suno_callback():
                                         prompt = job.get('prompt', '')
                                         style = job.get('style', '')
                                         job_id = jid
+                                        kind = job.get('kind', 'song')
+                                        if kind == 'jingle':
+                                            extra = {
+                                                'brand': job.get('brand', ''),
+                                                'style_key': job.get('style_key', ''),
+                                                'vocal_gender': job.get('vocal_gender', ''),
+                                                'instrumental': job.get('instrumental', False),
+                                            }
                                         break
 
-                                _add_song_to_metadata(filename, song_title, prompt, style, duration, song_id)
+                                # Capture lyrics from Suno response (description-mode jingles
+                                # have Suno-written lyrics; custom-mode songs have provided lyrics)
+                                song_lyrics = song.get('prompt', '') or song.get('lyrics', '')
+                                if song_lyrics:
+                                    extra['lyrics'] = song_lyrics
+
+                                _add_song_to_metadata(filename, song_title, prompt, style,
+                                                      duration, song_id, kind=kind, extra=extra)
 
                                 completed_songs_queue.append({
                                     'song_id': song_id,
                                     'filename': filename,
                                     'title': song_title,
                                     'job_id': job_id or task_id,
+                                    'kind': kind,
                                     'url': f'/generated_music/{filename}',
                                     'completed_at': datetime.now().isoformat(),
                                     'prompt': prompt,
+                                    'lyrics': song_lyrics,
                                 })
                         except Exception as exc:
                             logger.warning(f'Callback download error: {exc}')
@@ -662,6 +973,27 @@ def suno_completed():
     if completed_songs_queue:
         return jsonify({'has_completed': True, 'songs': completed_songs_queue, 'count': len(completed_songs_queue)})
     return jsonify({'has_completed': False, 'songs': [], 'count': 0})
+
+
+@suno_bp.route('/api/suno/failed', methods=['GET', 'POST'])
+def suno_failed():
+    """
+    GET  — Returns failed Suno jobs waiting for notification.
+    POST — Clears specific job (or all) from the failed queue after UI showed it.
+    """
+    global failed_songs_queue
+
+    if request.method == 'POST':
+        job_id = request.args.get('job_id') or (request.get_json(silent=True) or {}).get('job_id')
+        if job_id:
+            failed_songs_queue = [f for f in failed_songs_queue if f.get('job_id') != job_id]
+        else:
+            failed_songs_queue = []
+        return jsonify({'status': 'ok', 'cleared': True})
+
+    if failed_songs_queue:
+        return jsonify({'has_failed': True, 'failures': failed_songs_queue, 'count': len(failed_songs_queue)})
+    return jsonify({'has_failed': False, 'failures': [], 'count': 0})
 
 
 @suno_bp.route('/api/suno/song/<filename>', methods=['DELETE'])

--- a/services/gateways/compat.py
+++ b/services/gateways/compat.py
@@ -24,7 +24,7 @@ PROTOCOL_MIN = 3
 PROTOCOL_MAX = 5  # forward-compatible — OpenClaw ignores unsupported maxes
 
 # Version this code was tested against (for warning logs).
-OPENCLAW_TESTED_VERSION = "2026.3.13"
+OPENCLAW_TESTED_VERSION = "2026.5.2"
 OPENCLAW_MIN_VERSION = "2026.3.1"
 
 

--- a/setup-config.js
+++ b/setup-config.js
@@ -64,7 +64,7 @@ const openclawConfig = {
     },
     list: [{ id: "main", default: true, workspace: "/root/.openclaw/workspace" }],
   },
-  // Plugins configured by individual plugin installers (e.g., ByteRover memory)
+  // Plugins configured by individual plugin installers
 };
 
 fs.mkdirSync("openclaw-data/workspace", { recursive: true });

--- a/setup-sudo.sh
+++ b/setup-sudo.sh
@@ -14,7 +14,7 @@ EMAIL="your@email.com"           # ← EDIT: for Let's Encrypt notifications
 SERVICE_NAME="openvoiceui"
 RUN_USER="${SUDO_USER:-$(whoami)}"
 WWW_DIR="/var/www/${SERVICE_NAME}"          # canvas pages + any web assets
-OPENCLAW_TESTED_VERSION="2026.3.24"        # pinned: the openclaw version tested with this release
+OPENCLAW_TESTED_VERSION="2026.5.2"        # pinned: the openclaw version tested with this release
 # ────────────────────────────────────────────────────────────────────────────
 
 # Guard: refuse to run with placeholder values

--- a/src/app.js
+++ b/src/app.js
@@ -1686,6 +1686,52 @@ connectAiradio();
                 if (this.statusEl) this.statusEl.style.display = 'none';
             },
 
+            async generateJingle(brand, style, gender, instrumental) {
+                // Dedup on the brand+style+gender+instrumental combo
+                const now = Date.now();
+                const dedupKey = `JINGLE|${brand}|${style}|${gender}|${instrumental}`;
+                for (const [k, t] of this._recentPrompts) {
+                    if (now - t > this._DEDUP_WINDOW_MS) this._recentPrompts.delete(k);
+                }
+                if (this._recentPrompts.has(dedupKey)) {
+                    console.warn('[Suno] dedup: dropping repeat jingle for', dedupKey);
+                    return;
+                }
+                this._recentPrompts.set(dedupKey, now);
+
+                console.log('[Suno] Generating jingle:', { brand, style, gender, instrumental });
+                this._showStatus(`🎵 Jingle: cooking "${brand}" (~45-60s)...`);
+
+                try {
+                    const resp = await fetch(`${CONFIG.serverUrl}/api/suno`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            action: 'jingle',
+                            brand: brand,
+                            style: style || '',
+                            vocal_gender: gender || 'm',
+                            instrumental: !!instrumental,
+                        }),
+                    });
+                    const data = await resp.json();
+                    if (data.action === 'generating' && data.job_id) {
+                        this.activeJobId = data.job_id;
+                        this._startPolling(data.job_id);
+                    } else {
+                        const err = data.response || 'unknown error';
+                        ActionConsole?.addEntry('error', `🎵 Jingle failed to start: ${err}`);
+                        this._showStatus(`🎵 Jingle: ${err}`);
+                        setTimeout(() => this._hideStatus(), 5000);
+                    }
+                } catch (err) {
+                    console.error('[Suno] jingle error:', err);
+                    ActionConsole?.addEntry('error', `🎵 Jingle: connection error — ${err.message || err}`);
+                    this._showStatus('🎵 Jingle: connection error');
+                    setTimeout(() => this._hideStatus(), 4000);
+                }
+            },
+
             async generate(prompt) {
                 // Dedup: drop repeat fires of the same prompt within the window
                 const now = Date.now();
@@ -1727,7 +1773,9 @@ connectAiradio();
                         this._showStatus('🎵 Suno: cooking your track (~45s)...');
                         this._startPolling(data.job_id);
                     } else {
-                        this._showStatus(`🎵 Suno: ${data.response || 'Error starting generation'}`);
+                        const err = data.response || 'Error starting generation';
+                        ActionConsole?.addEntry('error', `🎵 Suno failed to start: ${err}`);
+                        this._showStatus(`🎵 Suno: ${err}`);
                         setTimeout(() => this._hideStatus(), 5000);
                     }
                 } catch (err) {
@@ -1754,6 +1802,12 @@ connectAiradio();
                         if (data.action === 'complete' || data.status === 'complete') {
                             this._stopPolling();
                             this._onComplete(data);
+                        } else if (data.action === 'failed' || data.status === 'failed') {
+                            this._stopPolling();
+                            const reason = data.reason || data.response || 'unknown error';
+                            ActionConsole?.addEntry('error', `🎵 Suno generation failed: ${reason}`);
+                            this._showStatus(`🎵 Suno failed: ${reason}`);
+                            setTimeout(() => this._hideStatus(), 8000);
                         } else if (data.status === 'not_found' || data.status === 'no_jobs') {
                             this._stopPolling();
                             this._hideStatus();
@@ -4038,9 +4092,34 @@ connectAiradio();
                         }
                         [...text.matchAll(/\[SUNO_GENERATE:([^\]]+)\]/gi)].forEach(m => {
                             const sunoPrompt = m[1].trim();
+                            const key = `SUNO:${sunoPrompt}`;
+                            if (canvasCommandsProcessed.has(key)) return;
+                            canvasCommandsProcessed.add(key);
                             ActionConsole?.addEntry('system', `🎵 Suno: generating "${sunoPrompt.substring(0, 60)}${sunoPrompt.length > 60 ? '...' : ''}"`);
                             AgentActivityChip?.handleTag('suno', sunoPrompt);
                             window.sunoModule?.generate(sunoPrompt);
+                        });
+                        // [JINGLE_GENERATE:brand|style|gender|instrumental|repeat] — short logo jingle (10-15s)
+                        // Parts: brand (required), style (preset key or freetext), gender (m|f),
+                        //        instrumental (true|false), repeat (1|2|3 — how many times brand is sung)
+                        [...text.matchAll(/\[JINGLE_GENERATE:([^\]]+)\]/gi)].forEach(m => {
+                            const raw = m[1].trim();
+                            const key = `JINGLE:${raw}`;
+                            if (canvasCommandsProcessed.has(key)) return;
+                            canvasCommandsProcessed.add(key);
+                            const parts = raw.split('|').map(s => s.trim());
+                            const brand = parts[0] || '';
+                            const style = parts[1] || '';
+                            const gender = (parts[2] || 'm').toLowerCase();
+                            const instrumental = (parts[3] || '').toLowerCase() === 'true';
+                            const repeat = parseInt(parts[4], 10) || 2;
+                            if (!brand) {
+                                ActionConsole?.addEntry('error', `🎵 Jingle: missing brand name`);
+                                return;
+                            }
+                            ActionConsole?.addEntry('system', `🎵 Jingle: "${brand}" (${style || 'random style'}${instrumental ? ', instrumental' : ', ' + (gender === 'f' ? 'female' : 'male')}${repeat !== 2 ? `, ${repeat}×` : ''})`);
+                            AgentActivityChip?.handleTag('suno', `${brand} jingle`);
+                            window.sunoModule?.generateJingle(brand, style, gender, instrumental, repeat);
                         });
                         // Check for [SPOTIFY:track name|artist] — switches player to Spotify mode
                         const spotifyMatch = text.match(/\[SPOTIFY:([^|\]]+)(?:\|([^\]]+))?\]/i);


### PR DESCRIPTION
## Summary

- HEIC/HEIF files uploaded by users (iPhone photos, Apple devices) are now automatically converted to JPG at upload time
- Returns the `.jpg` URL in the upload response — the agent and UI see a browser-compatible image immediately
- Uses `ImageMagick convert <file>[0]` with the `[0]` frame selector to handle multi-frame HEIC (without it, IM produces `name-0.jpg` / `name-1.jpg` instead of `name.jpg`)
- Original HEIC is renamed to `.heic.original` (not deleted)
- Failure path: logs a warning and returns the original HEIC — upload never fails because of conversion

## Dependencies already on the host image

- `imagemagick` — `/usr/bin/convert`
- `libheif1` + `libheif-plugin-libde265` — HEIC decode support

No new packages required.

## Closes

Mesh ticket `src-008` — IMG_20260318_183133.heic was uploaded but couldn't display in browser.