### PR TITLE
fix(a11y): add ARIA roles and labels to AppShell modals and buttons

### DIFF
--- a/src/ui/AppShell.js
+++ b/src/ui/AppShell.js
@@ -18,15 +18,15 @@ export function inject() {
 
 const SHELL_HTML = `
     <!-- Canvas Menu Button - Top Left Corner (Desktop) -->
-    <button id="canvas-menu-button" title="Desktop"><svg viewBox="0 0 48 48" width="22" height="22" style="vertical-align:middle;filter:drop-shadow(0 0 2px rgba(0,200,255,0.4))"><circle cx="24" cy="24" r="20" style="fill:var(--green)"/><circle cx="24" cy="24" r="20" fill="url(#globe-g)" opacity="0.7"/><ellipse cx="24" cy="24" rx="10" ry="20" fill="none" stroke="rgba(255,255,255,0.45)" stroke-width="1.5"/><line x1="4" y1="24" x2="44" y2="24" stroke="rgba(255,255,255,0.45)" stroke-width="1.5"/><ellipse cx="24" cy="15" rx="17" ry="5" fill="none" stroke="rgba(255,255,255,0.25)" stroke-width="1"/><ellipse cx="24" cy="33" rx="17" ry="5" fill="none" stroke="rgba(255,255,255,0.25)" stroke-width="1"/><circle cx="24" cy="24" r="20" fill="none" style="stroke:var(--cyan)" stroke-width="1" opacity="0.5"/><defs><radialGradient id="globe-g" cx="35%" cy="35%"><stop offset="0%" stop-color="#3b82f6"/><stop offset="100%" stop-color="#059669"/></radialGradient></defs></svg></button>
+    <button id="canvas-menu-button" title="Desktop" aria-label="Open canvas pages menu"><svg viewBox="0 0 48 48" width="22" height="22" aria-hidden="true" style="vertical-align:middle;filter:drop-shadow(0 0 2px rgba(0,200,255,0.4))"><circle cx="24" cy="24" r="20" style="fill:var(--green)"/><circle cx="24" cy="24" r="20" fill="url(#globe-g)" opacity="0.7"/><ellipse cx="24" cy="24" rx="10" ry="20" fill="none" stroke="rgba(255,255,255,0.45)" stroke-width="1.5"/><line x1="4" y1="24" x2="44" y2="24" stroke="rgba(255,255,255,0.45)" stroke-width="1.5"/><ellipse cx="24" cy="15" rx="17" ry="5" fill="none" stroke="rgba(255,255,255,0.25)" stroke-width="1"/><ellipse cx="24" cy="33" rx="17" ry="5" fill="none" stroke="rgba(255,255,255,0.25)" stroke-width="1"/><circle cx="24" cy="24" r="20" fill="none" style="stroke:var(--cyan)" stroke-width="1" opacity="0.5"/><defs><radialGradient id="globe-g" cx="35%" cy="35%"><stop offset="0%" stop-color="#3b82f6"/><stop offset="100%" stop-color="#059669"/></radialGradient></defs></svg></button>
 
     <!-- Canvas Menu Modal -->
-    <div id="canvas-menu-modal" class="canvas-menu-modal" style="display: none;">
+    <div id="canvas-menu-modal" class="canvas-menu-modal" role="dialog" aria-modal="true" aria-label="Canvas pages" style="display: none;">
         <div class="cmm-backdrop"></div>
         <div class="cmm-content">
             <div class="cmm-header">
                 <input type="text" id="canvas-search" placeholder="Search canvas pages...">
-                <button class="cmm-close" title="Close">×</button>
+                <button class="cmm-close" title="Close" aria-label="Close canvas menu">×</button>
             </div>
             <div class="cmm-quick-actions">
                 <button class="cmm-qa active" data-filter="all" title="Show all pages">All</button>
@@ -44,7 +44,7 @@ const SHELL_HTML = `
     </div>
 
     <!-- Delete Confirmation Modal -->
-    <div id="cmm-confirm-modal" class="cmm-confirm-modal" style="display: none;">
+    <div id="cmm-confirm-modal" class="cmm-confirm-modal" role="alertdialog" aria-modal="true" aria-label="Confirm archive" style="display: none;">
         <div class="cmm-confirm-box">
             <div class="cmm-confirm-icon">🗑️</div>
             <div class="cmm-confirm-title">Archive Canvas Page?</div>


### PR DESCRIPTION
﻿## Summary

- Add `role="dialog"` and `aria-modal="true"` to the canvas menu modal
- Add `role="alertdialog"` and `aria-modal="true"` to the archive confirmation modal
- Add `aria-label` to icon-only buttons (canvas menu button, close button)
- Add `aria-hidden="true"` to decorative SVG icon in the canvas menu button

## Motivation

Addresses accessibility gaps flagged in #237 (ARIA section). Screen readers cannot identify modal dialogs or icon-only buttons without these attributes, making the UI inaccessible to keyboard and assistive technology users.

## Test Plan

- [ ] Screen reader announces "Canvas pages dialog" when modal opens
- [ ] Screen reader announces "Confirm archive" for the delete confirmation
- [ ] Icon-only buttons are announced with their labels
- [ ] No visual regressions
