### PR TITLE
chore: add jsconfig.json for IDE module resolution

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "checkJs": false,
+    "baseUrl": ".",
+    "paths": {
+      "@core/*": ["src/core/*"],
+      "@ui/*": ["src/ui/*"],
+      "@providers/*": ["src/providers/*"],
+      "@shell/*": ["src/shell/*"],
+      "@features/*": ["src/features/*"],
+      "@adapters/*": ["src/adapters/*"],
+      "@face/*": ["src/face/*"]
+    }
+  },
+  "include": ["src/**/*.js", "cli/**/*.js"],
+  "exclude": ["node_modules", "static", "website", "tests"]
+}


### PR DESCRIPTION
﻿## Summary

Adds a `jsconfig.json` to enable IDE tooling (IntelliSense, go-to-definition, autocomplete) for the ES module frontend code in `src/`.

## What This Does

- Configures `module: "es2022"` and `moduleResolution: "bundler"` matching the browser runtime
- Defines path aliases (`@core/*`, `@ui/*`, `@providers/*`, etc.) for the project's directory structure
- Sets `checkJs: false` — this is editor tooling only, not a type-checking gate
- Includes `src/**/*.js` and `cli/**/*.js`, excludes `node_modules`, `static`, `website`, `tests`

## Why

VS Code and other editors using the TypeScript language server need this file to provide accurate navigation and completions for vanilla JS projects with ES module imports. Without it, editors can't resolve relative paths or provide meaningful autocomplete across the `src/` tree.

## Test Plan

- [ ] Open project in VS Code — no new errors or warnings
- [ ] Ctrl+click on an import like `from '../core/EventBus.js'` navigates to the correct file
- [ ] Autocomplete works for exported symbols from `src/core/`
