### PR TITLE
chore(hermes-agent): pin plugin manifest to Hermes v0.15.2

### DIFF
--- a/plugins/hermes-agent/plugin.json
+++ b/plugins/hermes-agent/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Self-improving AI agent with auto-generated skills, deep memory search, and autonomous tasks. Adds a standalone Hermes agent mode with full voice support.",
   "author": "Nous Research / OpenVoiceUI",
   "type": "gateway",
@@ -9,7 +9,7 @@
   "repository": "https://github.com/MCERQUA/openvoiceui-plugins",
   "provides": "gateway",
   "gateway_class": "HermesGateway",
-  "hermes_version": "0.13.0",
+  "hermes_version": "0.15.2",
   "requires_env": [
     "HERMES_HOST"
   ],


### PR DESCRIPTION
Pins the hermes-agent plugin manifest to the new Hermes runtime.

- `plugin.json`: `hermes_version` 0.13.0 → **0.15.2**, plugin `version` → **1.1.0**

Metadata-only. The actual image tag is pinned in `jambot-provision-service.py` (`jambot/hermes:v0.15.2`); `gateway.py` is gitignored here and needs no change — the OVU↔Hermes protocol (`/v1/chat/completions`, bearer, `X-Hermes-Session-Id/Key`, SSE) is backward-compatible on v0.15, verified against the live test-dev cutover (voice + tool-use working). Distribution manifest aligned in openvoiceui-plugins `137b1fd`.

Context: test-dev cut over to v0.15.2 on 2026-06-03 after a 4-round review. Full record in MIKE-AI `docs/jambot/hermes-v0.15-cutover-checklist.md`.