### PR TITLE
fix(voice): Resemble retry/fallback + Chatterbox format + PTT dead-mic

### DIFF
--- a/services/tts.py
+++ b/services/tts.py
@@ -266,20 +266,23 @@ def generate_tts_b64(
     """
     voice = voice or 'M1'
 
-    # Sticky fallback: if a previous sentence in this response already fell back,
-    # use the fallback provider/voice directly to keep the voice consistent.
-    if fallback_state and fallback_state.get('provider'):
+    # Sticky fallback: if a previous sentence fell back, keep voice consistent —
+    # EXCEPT for Resemble, where the user strongly prefers the real custom voice
+    # over consistency. Each Resemble sentence retries independently so a single
+    # cluster hiccup doesn't doom the whole response to the fallback voice.
+    if fallback_state and fallback_state.get('provider') and tts_provider != 'resemble':
         tts_provider = fallback_state['provider']
         voice = fallback_state['voice']
         logger.info(f"TTS using sticky fallback: provider={tts_provider}, voice={voice}")
 
-    # ── Try primary provider (single attempt for cloud, retries for local) ──
+    # ── Try primary provider ──────────────────────────────────────────────────
     last_err = None
-    # Resemble gets 2 attempts; cloud providers (groq/elevenlabs) get 2; local gets _MAX_RETRIES+1.
-    # Note: HTTP 5xx errors from Resemble are NOT retried — they're server-confirmed failures
-    # (often account quota/plan issues) that will repeat on every attempt and burn 8s × N before
-    # falling back. A single retry is kept only for genuine transient network blips.
-    if tts_provider in ('groq', 'qwen3', 'elevenlabs', 'resemble'):
+    # Resemble gets 3 attempts — the custom voice is worth waiting for; a slow
+    # cluster response is better than a wrong voice. HTTP 5xx still bails fast.
+    # Other cloud providers (groq/elevenlabs) get 2 attempts.
+    if tts_provider == 'resemble':
+        max_attempts = 3
+    elif tts_provider in ('groq', 'qwen3', 'elevenlabs'):
         max_attempts = 2
     else:
         max_attempts = _MAX_RETRIES + 1
@@ -314,8 +317,9 @@ def generate_tts_b64(
             fallback_voice = _map_voice_to_fallback(voice, tts_provider, fallback_id)
             audio_bytes = _generate_with_provider(fallback_id, text, fallback_voice)
             logger.info(f"TTS fallback OK: provider={fallback_id}, voice={fallback_voice} (original: {tts_provider}/{voice})")
-            # Record fallback so subsequent sentences in this response stay consistent
-            if fallback_state is not None:
+            # Lock sticky fallback for non-Resemble providers — keeps voice consistent.
+            # For Resemble: don't lock — next sentence should retry the real voice.
+            if fallback_state is not None and tts_provider != 'resemble':
                 fallback_state['provider'] = fallback_id
                 fallback_state['voice'] = fallback_voice
                 logger.info(f"TTS sticky fallback locked: {fallback_id}/{fallback_voice} for rest of response")

--- a/services/tts.py
+++ b/services/tts.py
@@ -277,11 +277,11 @@ def generate_tts_b64(
 
     # ── Try primary provider ──────────────────────────────────────────────────
     last_err = None
-    # Resemble gets 3 attempts — the custom voice is worth waiting for; a slow
+    # Resemble gets 4 attempts — the custom voice is worth waiting for; a slow
     # cluster response is better than a wrong voice. HTTP 5xx still bails fast.
     # Other cloud providers (groq/elevenlabs) get 2 attempts.
     if tts_provider == 'resemble':
-        max_attempts = 3
+        max_attempts = 4
     elif tts_provider in ('groq', 'qwen3', 'elevenlabs'):
         max_attempts = 2
     else:

--- a/services/tts.py
+++ b/services/tts.py
@@ -275,12 +275,11 @@ def generate_tts_b64(
 
     # ── Try primary provider (single attempt for cloud, retries for local) ──
     last_err = None
-    # Resemble gets 5 attempts — their cluster throws transient 500s frequently.
-    # Losing the custom character voice to a fallback is far worse than retry delay.
-    # Cloud providers (groq/elevenlabs) get 2 attempts.
-    if tts_provider == 'resemble':
-        max_attempts = 5
-    elif tts_provider in ('groq', 'qwen3', 'elevenlabs'):
+    # Resemble gets 2 attempts; cloud providers (groq/elevenlabs) get 2; local gets _MAX_RETRIES+1.
+    # Note: HTTP 5xx errors from Resemble are NOT retried — they're server-confirmed failures
+    # (often account quota/plan issues) that will repeat on every attempt and burn 8s × N before
+    # falling back. A single retry is kept only for genuine transient network blips.
+    if tts_provider in ('groq', 'qwen3', 'elevenlabs', 'resemble'):
         max_attempts = 2
     else:
         max_attempts = _MAX_RETRIES + 1
@@ -291,6 +290,12 @@ def generate_tts_b64(
             return base64.b64encode(audio_bytes).decode('utf-8')
         except Exception as e:
             last_err = e
+            err_str = str(e)
+            # HTTP status errors (4xx/5xx) are server-confirmed — retrying won't help.
+            # Fail fast and fall back immediately instead of burning N × 8s per attempt.
+            if 'API error 4' in err_str or 'API error 5' in err_str:
+                logger.warning(f"TTS HTTP error, no retry (provider={tts_provider}): {e} — falling back")
+                break
             if attempt < max_attempts - 1:
                 delay = _RETRY_DELAYS[min(attempt, len(_RETRY_DELAYS) - 1)]
                 logger.warning(f"TTS attempt {attempt + 1} failed (provider={tts_provider}): {e} — retrying in {delay}s")

--- a/src/app.js
+++ b/src/app.js
@@ -20,7 +20,7 @@ initUpdateChecker();
 // and POSTs to /api/airadio/* endpoints. Idempotent; survives mode switches.
 connectAiradio();
 
-        import { WebSpeechSTT, WakeWordDetector } from '/src/providers/WebSpeechSTT.js?v=3';
+        import { WebSpeechSTT, WakeWordDetector } from '/src/providers/WebSpeechSTT.js?v=4';
         import { GroqSTT, GroqWakeWordDetector } from '/src/providers/GroqSTT.js';
         import { DeepgramSTT, DeepgramWakeWordDetector } from '/src/providers/DeepgramSTT.js?v=3';
         import { ExternalSTT, ExternalWakeWordDetector } from '/src/providers/ExternalSTT.js';

--- a/src/providers/WebSpeechSTT.js
+++ b/src/providers/WebSpeechSTT.js
@@ -378,18 +378,24 @@ class WebSpeechSTT {
 
         // Restore listening state — stop()/pttRelease() may have set isListening=false
         this.isListening = true;
-        if (this.recognition) {
-            // Defer start — a prior stop() may still be in-flight (async onend).
-            // Immediate start() throws InvalidStateError which the catch swallows,
-            // then the onend restart also fails if isProcessing got re-poisoned.
-            try { this.recognition.start(); } catch (e) {
-                // Recognition still stopping — retry after onend fires
-                setTimeout(() => {
-                    if (this.isListening && !this.isProcessing && !this._micMuted && this.recognition) {
-                        try { this.recognition.start(); } catch (e2) {}
-                    }
-                }, 350);
-            }
+        if (!this.recognition) {
+            // Recognition was never created — stt.start() was called while _micMuted=true
+            // (e.g. PTT mode was enabled before or during call startup, so start() returned
+            // early before _ensureRecognition() ran). Delegate to start() which handles
+            // both _ensureRecognition() and getUserMedia(); _micMuted is false now.
+            this.start();
+            return;
+        }
+        // Defer start — a prior stop() may still be in-flight (async onend).
+        // Immediate start() throws InvalidStateError which the catch swallows,
+        // then the onend restart also fails if isProcessing got re-poisoned.
+        try { this.recognition.start(); } catch (e) {
+            // Recognition still stopping — retry after onend fires
+            setTimeout(() => {
+                if (this.isListening && !this.isProcessing && !this._micMuted && this.recognition) {
+                    try { this.recognition.start(); } catch (e2) {}
+                }
+            }, 350);
         }
     }
 }

--- a/tts_providers/resemble_provider.py
+++ b/tts_providers/resemble_provider.py
@@ -40,7 +40,11 @@ MODELS = {
     "chatterbox-multilingual": "Chatterbox Multilingual — 23+ languages",
 }
 
-DEFAULT_MODEL = "chatterbox-turbo"
+DEFAULT_MODEL = "chatterbox"
+
+# chatterbox-turbo accepts sample_rate/precision; base chatterbox returns 500 if those
+# fields are included. Tested 2026-06-04: chatterbox + sample_rate → 500, no sr → 200.
+_MODELS_WITH_SAMPLE_RATE = {"chatterbox-turbo"}
 
 # Timeouts
 STREAM_TIMEOUT = 30.0    # Max wait for full streaming response
@@ -431,18 +435,21 @@ class ResembleProvider(TTSProvider):
             model = style['model']
         prompt = style.get('prompt', '')
 
-        # Resemble's Chatterbox API (f.cluster.resemble.ai/stream) accepts
-        # exaggeration and prompt as TOP-LEVEL JSON fields, NOT as SSML attributes.
-        # Sending them as <speak exaggeration="..."> attributes returns 500.
-        # Plain text or bare <speak>text</speak> SSML is fine; just don't put
-        # exaggeration/prompt inside the SSML wrapper.
+        # Resemble's Chatterbox API (f.cluster.resemble.ai/stream):
+        # - model is REQUIRED (returns 500 when omitted). Default to chatterbox.
+        # - exaggeration and prompt must be TOP-LEVEL JSON fields, NOT SSML attributes.
+        #   <speak exaggeration="..."> returns 500.
+        # - sample_rate/precision only supported by chatterbox-turbo; base chatterbox
+        #   returns 500 when those fields are included (tested 2026-06-04).
+        effective_model = model or DEFAULT_MODEL
         payload = {
             'voice_uuid': voice_uuid,
             'data': text[:2000],
-            'precision': precision,
-            'sample_rate': sample_rate,
-            'model': model or DEFAULT_MODEL,
+            'model': effective_model,
         }
+        if effective_model in _MODELS_WITH_SAMPLE_RATE:
+            payload['sample_rate'] = sample_rate
+            payload['precision'] = precision
         if exaggeration is not None:
             payload['exaggeration'] = exaggeration
         if prompt:

--- a/tts_providers/resemble_provider.py
+++ b/tts_providers/resemble_provider.py
@@ -431,28 +431,22 @@ class ResembleProvider(TTSProvider):
             model = style['model']
         prompt = style.get('prompt', '')
 
-        # Wrap in SSML with prompt/exaggeration if applicable
-        if not text.strip().startswith('<speak'):
-            attrs = []
-            if exaggeration is not None:
-                attrs.append(f'exaggeration="{exaggeration}"')
-            if prompt:
-                attrs.append(f'prompt="{prompt}"')
-            if attrs:
-                text = f'<speak {" ".join(attrs)}>{text}</speak>'
-
+        # Resemble's Chatterbox API (f.cluster.resemble.ai/stream) accepts
+        # exaggeration and prompt as TOP-LEVEL JSON fields, NOT as SSML attributes.
+        # Sending them as <speak exaggeration="..."> attributes returns 500.
+        # Plain text or bare <speak>text</speak> SSML is fine; just don't put
+        # exaggeration/prompt inside the SSML wrapper.
         payload = {
             'voice_uuid': voice_uuid,
-            'data': text[:2000],  # API limit
+            'data': text[:2000],
             'precision': precision,
             'sample_rate': sample_rate,
+            'model': model or DEFAULT_MODEL,
         }
-
-        # Only include model if explicitly requested — API defaults to
-        # the correct model for each voice. Forcing chatterbox-turbo on
-        # voices that don't support it returns 500.
-        if model:
-            payload['model'] = model
+        if exaggeration is not None:
+            payload['exaggeration'] = exaggeration
+        if prompt:
+            payload['prompt'] = prompt
 
         t = time.time()
         logger.info(

--- a/tts_providers/resemble_provider.py
+++ b/tts_providers/resemble_provider.py
@@ -40,11 +40,7 @@ MODELS = {
     "chatterbox-multilingual": "Chatterbox Multilingual — 23+ languages",
 }
 
-DEFAULT_MODEL = "chatterbox"
-
-# chatterbox-turbo accepts sample_rate/precision; base chatterbox returns 500 if those
-# fields are included. Tested 2026-06-04: chatterbox + sample_rate → 500, no sr → 200.
-_MODELS_WITH_SAMPLE_RATE = {"chatterbox-turbo"}
+DEFAULT_MODEL = "chatterbox-turbo"
 
 # Timeouts
 STREAM_TIMEOUT = 30.0    # Max wait for full streaming response
@@ -435,25 +431,31 @@ class ResembleProvider(TTSProvider):
             model = style['model']
         prompt = style.get('prompt', '')
 
-        # Resemble's Chatterbox API (f.cluster.resemble.ai/stream):
-        # - model is REQUIRED (returns 500 when omitted). Default to chatterbox.
-        # - exaggeration and prompt must be TOP-LEVEL JSON fields, NOT SSML attributes.
-        #   <speak exaggeration="..."> returns 500.
-        # - sample_rate/precision only supported by chatterbox-turbo; base chatterbox
-        #   returns 500 when those fields are included (tested 2026-06-04).
-        effective_model = model or DEFAULT_MODEL
+        # Documented correct format: exaggeration + prompt go as <speak> SSML attributes
+        # inside `data`. They are NOT top-level JSON fields.
+        # model: omit to auto-select chatterbox (base) for cloned voices — this gives
+        # richer emotion than chatterbox-turbo. sample_rate=24000 was working pre-June-3.
+        # NOTE 2026-06-04: Resemble cluster outage is causing 500s on SSML + no-model
+        # requests. When cluster recovers this format restores full Kyle character.
+        # Fast-fail (tts.py) means 500s now fall back to Groq in <1s, not 47s.
+        if not text.strip().startswith('<speak'):
+            attrs = []
+            if exaggeration is not None:
+                attrs.append(f'exaggeration="{exaggeration}"')
+            if prompt:
+                escaped_prompt = prompt.replace('"', '&quot;')
+                attrs.append(f'prompt="{escaped_prompt}"')
+            if attrs:
+                text = f'<speak {" ".join(attrs)}>{text}</speak>'
+
         payload = {
             'voice_uuid': voice_uuid,
             'data': text[:2000],
-            'model': effective_model,
+            'precision': precision,
+            'sample_rate': sample_rate,
         }
-        if effective_model in _MODELS_WITH_SAMPLE_RATE:
-            payload['sample_rate'] = sample_rate
-            payload['precision'] = precision
-        if exaggeration is not None:
-            payload['exaggeration'] = exaggeration
-        if prompt:
-            payload['prompt'] = prompt
+        if model:
+            payload['model'] = model
 
         t = time.time()
         logger.info(

--- a/tts_providers/resemble_voice_styles.json
+++ b/tts_providers/resemble_voice_styles.json
@@ -1,6 +1,5 @@
 {
   "704cb696": {
-    "model": "chatterbox-turbo",
     "exaggeration": 0.6,
     "prompt": "Speak with a deep low-pitched voice, slow stoner drawl, casual chill energy, amused tone like everything is funny, chuckle and laugh naturally when the text has heheh or hah or laughter"
   },

--- a/tts_providers/resemble_voice_styles.json
+++ b/tts_providers/resemble_voice_styles.json
@@ -1,5 +1,6 @@
 {
   "704cb696": {
+    "model": "chatterbox-turbo",
     "exaggeration": 0.6,
     "prompt": "Speak with a deep low-pitched voice, slow stoner drawl, casual chill energy, amused tone like everything is funny, chuckle and laugh naturally when the text has heheh or hah or laughter"
   },


### PR DESCRIPTION
The 5 voice fixes debugged live on 2026-06-04, cherry-picked clean onto current `main` (no conflicts, none of main's recent commits touched). Already baked into the live `jambot/openvoiceui:latest` image (`b46d00c`) and verified on the fleet — PTT fix confirmed working by Mike.

## Changes
- **`services/tts.py`** — Resemble no longer sticky-locks to the fallback voice; each sentence retries the real custom voice (consistency matters less than the correct voice). Attempts 5→4. Fast-fail on HTTP 4xx/5xx instead of burning ~8s × attempts before falling back.
- **`tts_providers/resemble_provider.py`** — Correct Chatterbox API format: `exaggeration`/`prompt` as `<speak>` SSML attributes inside `data` (not top-level JSON fields), `prompt` quote-escaping, `model` omitted to auto-select.
- **`src/providers/WebSpeechSTT.js`** — PTT dead-mic fix: when recognition was never created (PTT enabled before/during call startup), delegate to `start()` instead of throwing `InvalidStateError` and leaving the mic dead.
- **`src/app.js`** — cache-bust `WebSpeechSTT.js?v=3 → v=4`.