### PR TITLE
sync(deps): dev → main — PyJWT 2.13.0 (security) + pypdf + pillow-heif

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,7 +3,7 @@
 # Without it, those file types still upload successfully — the AI just can't read their contents.
 #
 # Install: pip install -r requirements-docs.txt
-pypdf>=6.11.0
+pypdf>=6.12.2
 python-docx>=1.2.0
 openpyxl>=3.1.5
 python-pptx>=1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ psutil==7.2.2
 
 # Image processing (icon generation, uploads)
 Pillow>=12.2.0
-pillow-heif>=0.18.0
+pillow-heif>=1.3.0
 PyYAML>=6.0.3
 
 # Speech-to-text (optional — adds ~200MB for onnxruntime + ctranslate2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ PyYAML>=6.0.3
 groq==1.2.0                 # Groq Orpheus TTS (required if using groq provider)
 
 # Auth (Clerk JWT — optional, only if CANVAS_REQUIRE_AUTH=true)
-PyJWT==2.12.1
+PyJWT==2.13.0
 cryptography==48.0.0
 
 # Face recognition (optional — adds ~700MB for TensorFlow)


### PR DESCRIPTION
Brings the 3 reviewed Dependabot bumps from dev into main so main is the complete, current branch (voice fixes already here via #328). PyJWT 2.13.0 = security release (5 vulns incl. JWT alg-bypass); our usage verified compatible. pillow-heif 1.3.0 already running in prod. pypdf is an optional-file floor bump.