### PR TITLE
feat(office): /api/auth/me, /api/history, and get_clerk_user_profile()

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -171,6 +171,13 @@ ALLOWED_RPC_METHODS = frozenset({
 # Auth check endpoint
 # ---------------------------------------------------------------------------
 
+@admin_bp.route('/api/auth/me', methods=['GET'])
+def auth_me():
+    """Return the current user's display name from the container environment."""
+    username = os.getenv('JAMBOT_TENANT') or os.getenv('CLIENT_NAME') or 'User'
+    return jsonify({'username': username})
+
+
 @admin_bp.route('/api/auth/check', methods=['GET'])
 def auth_check():
     """

--- a/routes/transcripts.py
+++ b/routes/transcripts.py
@@ -109,6 +109,69 @@ def list_transcripts():
     return jsonify(entries)
 
 
+@transcripts_bp.route('/api/history', methods=['GET'])
+def conversation_history():
+    """Return real conversation turns from this client's transcripts directory.
+
+    Query params:
+      days   — how many days back (default 30)
+      limit  — max turns to return (default 200)
+      date   — filter to a specific date YYYY-MM-DD
+    """
+    days  = min(int(request.args.get('days', 30)), 365)
+    limit = min(int(request.args.get('limit', 200)), 1000)
+    date_filter = request.args.get('date', '')
+
+    from datetime import timedelta as _td
+    cutoff = (datetime.now() - _td(days=days)).strftime('%Y-%m-%d')
+
+    turns = []
+    if not os.path.isdir(TRANSCRIPTS_DIR):
+        return jsonify({'turns': [], 'total': 0})
+
+    for date_dir in sorted(os.listdir(TRANSCRIPTS_DIR), reverse=True):
+        if date_dir < cutoff:
+            break
+        if date_filter and date_dir != date_filter:
+            continue
+        day_path = os.path.join(TRANSCRIPTS_DIR, date_dir)
+        if not os.path.isdir(day_path):
+            continue
+        for fname in sorted(os.listdir(day_path), reverse=True):
+            if not fname.endswith('.json'):
+                continue
+            fpath = os.path.join(day_path, fname)
+            try:
+                with open(fpath, encoding='utf-8') as f:
+                    data = json.load(f)
+                user = (data.get('user') or '').strip()
+                if user == '__session_start__':
+                    continue
+                if not user and not (data.get('assistant') or '').strip():
+                    continue
+                turns.append({
+                    'date':          data.get('date', date_dir),
+                    'time':          data.get('time', '00:00:00'),
+                    'timestamp':     data.get('timestamp', ''),
+                    'user':          user[:300],
+                    'assistant':     (data.get('assistant') or '')[:500],
+                    'tools':         data.get('tools', []),
+                    'session_id':    data.get('session_id', ''),
+                    'session_key':   data.get('session_key', 'main'),
+                    'duration_ms':   data.get('duration_ms'),
+                    'word_count':    data.get('word_count', {}),
+                    'clerk_user_id': data.get('clerk_user_id', ''),
+                })
+                if len(turns) >= limit:
+                    break
+            except Exception:
+                pass
+        if len(turns) >= limit:
+            break
+
+    return jsonify({'turns': turns, 'total': len(turns), 'days': days})
+
+
 @transcripts_bp.route('/api/transcripts/<date_dir>/<filename>', methods=['GET'])
 def get_transcript(date_dir, filename):
     # Resolve and verify path stays within TRANSCRIPTS_DIR

--- a/services/auth.py
+++ b/services/auth.py
@@ -122,6 +122,30 @@ def verify_clerk_token(token: str) -> Optional[str]:
     return None
 
 
+def get_clerk_user_profile(user_id: str) -> dict:
+    """Fetch username/name from Clerk Backend API. Returns {} on failure."""
+    import urllib.request, urllib.error, json as _json
+    secret = os.getenv('CLERK_SECRET_KEY', '')
+    if not secret or not user_id:
+        return {}
+    try:
+        req = urllib.request.Request(
+            f'https://api.clerk.com/v1/users/{user_id}',
+            headers={'Authorization': f'Bearer {secret}'},
+        )
+        with urllib.request.urlopen(req, timeout=4) as r:
+            data = _json.loads(r.read())
+        return {
+            'username':   data.get('username') or '',
+            'first_name': data.get('first_name') or '',
+            'last_name':  data.get('last_name') or '',
+            'email':      (data.get('email_addresses') or [{}])[0].get('email_address', ''),
+            'user_id':    user_id,
+        }
+    except Exception:
+        return {'user_id': user_id}
+
+
 def get_token_from_request() -> Optional[str]:
     """
     Extract Clerk session token from the current Flask request.


### PR DESCRIPTION
## Summary
- Adds `GET /api/auth/me` — returns current tenant username from container env vars
- Adds `GET /api/history` — returns real conversation turns from transcripts dir (configurable days/limit/date params)
- Adds `get_clerk_user_profile()` to `services/auth.py` — fetches user profile from Clerk Backend API

## Context
These endpoints are already deployed in production containers (already in use by `conversations-client.html` canvas pages at adrian + mike tenants). This commit brings git in sync with what's running. Required before the OVUI main checkout reconciliation rebuild.

## Endpoint specs
- `/api/auth/me` — `GET`, returns `{username: str}` from `JAMBOT_TENANT` / `CLIENT_NAME` env
- `/api/history?days=30&limit=200&date=YYYY-MM-DD` — returns `{turns: [...], total: N, days: N}`
- `get_clerk_user_profile(user_id)` — returns `{username, first_name, last_name, email, user_id}` or `{}` on failure