### PR TITLE
Merge dev → main: pypdf/groq/flask-cors bumps + Resemble TTS hardening

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,7 +3,7 @@
 # Without it, those file types still upload successfully — the AI just can't read their contents.
 #
 # Install: pip install -r requirements-docs.txt
-pypdf>=6.12.2
+pypdf>=6.13.0
 python-docx>=1.2.0
 openpyxl>=3.1.5
 python-pptx>=1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ PyYAML>=6.0.3
 # faster-whisper==1.2.1
 
 # TTS providers
-groq==1.2.0                 # Groq Orpheus TTS (required if using groq provider)
+groq==1.4.0                 # Groq Orpheus TTS (required if using groq provider)
 
 # Auth (Clerk JWT — optional, only if CANVAS_REQUIRE_AUTH=true)
 PyJWT==2.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Python 3.10+ required
 # Core framework
 Flask==3.1.3
-flask-cors==6.0.2
+flask-cors==6.0.4
 flask-limiter==4.1.1
 flask-sock==0.7.0
 

--- a/services/tts.py
+++ b/services/tts.py
@@ -229,8 +229,13 @@ def _generate_with_provider(tts_provider: str, text: str, voice: str) -> bytes:
     # number of individual API calls. Fewer requests = fewer chances for any
     # single one to hit a transient cluster issue.
     if tts_provider == 'resemble':
-        if len(text) > 1500:
-            return generate_tts_chunked(provider, text, voice, max_chars=1500)
+        # Resemble's stream DROPS long requests — a ~900+ char / ~36s generation gets
+        # "RemoteProtocolError: peer closed connection" → after retries that's total
+        # silence. Chunk at 400 chars so every request finishes well under the drop
+        # threshold. The chunker splits on sentence boundaries and tolerates a single
+        # chunk failing as a small gap rather than dropping the whole reply. (2026-06-07)
+        if len(text) > 400:
+            return generate_tts_chunked(provider, text, voice, max_chars=400)
         return provider.generate_speech(text=text, voice=voice)
     # Cloud providers returning MP3 (groq, elevenlabs) handle their own limits
     if audio_format == 'mp3':
@@ -277,11 +282,13 @@ def generate_tts_b64(
 
     # ── Try primary provider ──────────────────────────────────────────────────
     last_err = None
-    # Resemble gets 4 attempts — the custom voice is worth waiting for; a slow
-    # cluster response is better than a wrong voice. HTTP 5xx still bails fast.
+    # Resemble gets 6 attempts — the custom CLONE voice is worth waiting for; retrying a
+    # slow/timed-out cluster response is better than silence and FAR better than a wrong
+    # voice. Paired with STREAM_TIMEOUT=120s so a long reply finishes instead of being cut
+    # off. HTTP 5xx still bails fast (a real outage won't fix on retry).
     # Other cloud providers (groq/elevenlabs) get 2 attempts.
     if tts_provider == 'resemble':
-        max_attempts = 4
+        max_attempts = 6
     elif tts_provider in ('groq', 'qwen3', 'elevenlabs'):
         max_attempts = 2
     else:
@@ -294,9 +301,14 @@ def generate_tts_b64(
         except Exception as e:
             last_err = e
             err_str = str(e)
-            # HTTP status errors (4xx/5xx) are server-confirmed — retrying won't help.
-            # Fail fast and fall back immediately instead of burning N × 8s per attempt.
-            if 'API error 4' in err_str or 'API error 5' in err_str:
+            # 4xx = client error (bad auth/payload) — never retry. 5xx normally means a real
+            # outage, so most providers fast-fail. BUT Resemble's cluster throws INTERMITTENT
+            # 500s (a retry seconds later usually succeeds), so for Resemble we RETRY 5xx
+            # instead of dropping the sentence to silence — its base clone has no equal-voice
+            # fallback, so a missed retry = dead air. (2026-06-07)
+            is_4xx = 'API error 4' in err_str
+            is_5xx = 'API error 5' in err_str
+            if is_4xx or (is_5xx and tts_provider != 'resemble'):
                 logger.warning(f"TTS HTTP error, no retry (provider={tts_provider}): {e} — falling back")
                 break
             if attempt < max_attempts - 1:
@@ -308,6 +320,12 @@ def generate_tts_b64(
 
     # ── Fallback to alternate provider ───────────────────────────────
     fallback_id = _FALLBACK_CHAIN.get(tts_provider)
+    # Custom CLONED voices (Resemble — e.g. bhb's Kyle) must NEVER be substituted with a
+    # different voice. For tenants with RESEMBLE_NO_FALLBACK=1, a brief silence beats a
+    # wrong/switching voice (a slow Resemble sentence goes silent; the next retries the
+    # real clone). Default unchanged (fallback ON) for other tenants. (Mike 2026-06-07, bhb)
+    if tts_provider == 'resemble' and os.getenv('RESEMBLE_NO_FALLBACK', '').strip().lower() in ('1', 'true', 'yes', 'on'):
+        fallback_id = None
     if fallback_id:
         logger.info(f"TTS falling back: {tts_provider} → {fallback_id}")
         try:

--- a/tts_providers/resemble_provider.py
+++ b/tts_providers/resemble_provider.py
@@ -43,7 +43,10 @@ MODELS = {
 DEFAULT_MODEL = "chatterbox-turbo"
 
 # Timeouts
-STREAM_TIMEOUT = 30.0    # Max wait for full streaming response
+STREAM_TIMEOUT = 120.0   # Max wait for full streaming response. Resemble's custom-clone
+                         # base model is slow (~53ms/char → a long ~1500-char chunk needs
+                         # ~80s); 30s used to cut long replies off mid-stream → silence.
+                         # 120s lets a full reply finish so the clone voice always speaks. (2026-06-07)
 CONNECT_TIMEOUT = 10.0   # TCP connect timeout
 API_TIMEOUT = 15.0       # For voice listing / non-synthesis calls
 


### PR DESCRIPTION
Brings to the deploy branch:

**Dependency bumps (Dependabot)**
- `pypdf` >=6.12.2 → >=6.13.0 — **security**: avoids infinite loops in outlines/text extraction (malformed-PDF DoS), plus robustness fixes.
- `groq` 1.2.0 → 1.4.0 — multipart file-array fix + env-header support.
- `flask-cors` 6.0.2 → 6.0.4 — MyPy typing + CI/CD hardening (no functional change).

**Voice fix**
- Resemble TTS hardening for the slow custom-clone cluster (400-char chunking, 120s stream timeout, 6 retries + intermittent-5xx retry, `RESEMBLE_NO_FALLBACK`). Already live in all containers since 2026-06-07; commits it so it survives the next image rebuild.

All four merged into `dev` with green `test` + `security-scan` CI.