### PR TITLE
fix: song download links, inline video playback, hermes manifest sync

### DIFF
--- a/app.py
+++ b/app.py
@@ -107,6 +107,9 @@ def create_app(config_override: dict = None):
             '/src/',       # static JS/CSS (needed to render the login screen)
             '/sounds/',
             '/music/',
+            '/generated_music/',  # AI-generated songs — shareable download links (texted/emailed
+                                  # to recipients with no app login). Non-sensitive (client's own
+                                  # jingles); the /api/music track list is already public anyway.
             '/images/',    # canvas images (individual pages check their own flag)
             '/uploads/',   # uploaded/generated files — served from VPS filesystem (no secrets)
             '/canvas-data/',  # processed-song media (audio stems) + fixtures for the Suno Studio editor — non-sensitive, served like /uploads/ (added 2026-06-25)

--- a/default-pages/bulk-image-uploader.html
+++ b/default-pages/bulk-image-uploader.html
@@ -458,8 +458,22 @@ function render(){
   $('empty').style.display='none';
   $('grid').innerHTML=list.map((f,i)=>{
     const isImg=f.cat==='img';const e=f.ext.toUpperCase();
+    // Inline playable thumbnails: images render <img>, videos render an inline <video> the user
+    // can play right in the feed (muted+preload=metadata so 20+ clips don't all download at once),
+    // audio renders a compact inline <audio> player. event.stopPropagation keeps play/scrub controls
+    // from bubbling up to the card's lightbox onclick — clicking the card elsewhere still opens the lightbox.
+    let thumb;
+    if(isImg){
+      thumb=`<img src="${f.url}" loading="lazy" alt="">`;
+    }else if(f.cat==='vid'){
+      thumb=`<video src="${f.url}" muted playsinline preload="metadata" controls onclick="event.stopPropagation()" style="width:100%;height:100%;object-fit:cover;background:#000"></video>`;
+    }else if(f.cat==='aud'){
+      thumb=`<div class="ct-ic" style="width:100%;padding:0 10px">${IC.aud.replace(/stroke-width="[^"]*"/,'stroke-width="1.4"').replace(/<svg/,`<svg style="stroke:${COLORS.aud}"`)}<audio src="${f.url}" controls preload="none" onclick="event.stopPropagation()" style="width:100%;max-width:130px"></audio></div>`;
+    }else{
+      thumb=`<div class="ct-ic">${IC[f.cat]?.replace(/stroke-width="[^"]*"/,'stroke-width="1.4"').replace(/<svg/,`<svg style="stroke:${COLORS[f.cat]}"`)}<span class="ct-ext bg-${f.cat} c-${f.cat}">${e}</span></div>`;
+    }
     return`<div class="card" onclick="lbOpen(${i},'${filter}','${s.replace(/'/g,"\\'")}')" role="button" tabindex="0" aria-label="${esc(f.name)}">
-      <div class="card-thumb">${isImg?`<img src="${f.url}" loading="lazy" alt="">`:`<div class="ct-ic">${IC[f.cat]?.replace(/stroke-width="[^"]*"/,'stroke-width="1.4"').replace(/<svg/,`<svg style="stroke:${COLORS[f.cat]}"`)}<span class="ct-ext bg-${f.cat} c-${f.cat}">${e}</span></div>`}<div class="card-badge c-${f.cat}">${e}</div></div>
+      <div class="card-thumb">${thumb}<div class="card-badge c-${f.cat}">${e}</div></div>
       <div class="card-info"><div class="card-name">${esc(f.name)}</div><div class="card-meta"><span>${sz(f.size)}</span><span>${ago(f.modified)}</span></div></div></div>`}).join('');
 }
 

--- a/plugins/hermes-agent/plugin.json
+++ b/plugins/hermes-agent/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Self-improving AI agent with auto-generated skills, deep memory search, and autonomous tasks. Adds a standalone Hermes agent mode with full voice support.",
   "author": "Nous Research / OpenVoiceUI",
   "type": "gateway",

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -174,6 +174,17 @@ _VOICE_INSTRUCTIONS = (
     "After generation, the new song appears in [Available tracks:] by its title. "
     "Use [MUSIC_PLAY:song title] to play it — do NOT use exec/shell to find the file. "
 
+    # --- Delivering a download link (voice / SMS / email) ---
+    "SONG DOWNLOAD / DELIVERY: "
+    "When the user asks for a download or a link to a generated song, give them a DIRECT link in this exact form: "
+    "https://DOMAIN/generated_music/FILENAME?download=1  — where FILENAME is the EXACT file name from the "
+    "[Available tracks — Generated:] list (e.g. 'shop-bay-wisdom.mp3'), and DOMAIN is this site's domain. "
+    "The ?download=1 makes the browser SAVE the file instead of just playing it. "
+    "RULES: (1) NEVER invent a URL — generated songs live ONLY at /generated_music/<file>, never /music/<file>. "
+    "(2) NEVER emit a [CANVAS:...] page for a download — there is no download page; use the direct link above. "
+    "(3) For 'the last/latest track I made', use the song shown in [Latest generated song: ...] context — do not guess. "
+    "(4) The same https://DOMAIN/generated_music/FILENAME?download=1 link is what you text or email the user. "
+
     # --- SoundCloud (real playback, no auth) ---
     "SOUNDCLOUD: [SOUNDCLOUD:<full-track-url>] — embeds the track in the music player and plays it. "
     "Always use with a full https://soundcloud.com/<user>/<slug> URL. NEVER invent URLs — get them from "
@@ -1390,6 +1401,22 @@ def _conversation_inner():
                 _parts.append(f'Generated ({len(_gen_names)}): {_cap_list(_gen_names, max_chars=2000)}')
             if _parts:
                 context_parts.append(f'[Available tracks — {" | ".join(_parts)}]')
+        except Exception:
+            pass
+
+        # Authoritative "last track you made" — newest generated song by file
+        # mtime (created_date metadata is date-only and useless for recency).
+        # Gives the agent the exact filename + a ready-to-send download link so
+        # it never guesses or hands out a broken /music/ URL.
+        try:
+            from routes.music import get_latest_generated_track
+            _latest = get_latest_generated_track()
+            if _latest:
+                context_parts.append(
+                    f"[Latest generated song: {_latest['title']!r} "
+                    f"(file: {_latest['filename']}) — "
+                    f"download link: /generated_music/{_latest['filename']}?download=1]"
+                )
         except Exception:
             pass
 

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1662,21 +1662,24 @@ def _conversation_inner():
                         _audio_fmt = 'wav'
 
                     def _tts_error_event(err_str):
+                        # CLIENT-FACING RULE (Mike 2026-06-28): never serialize raw provider
+                        # name, billing reason, or exception text into a client-bound event.
+                        # Classify to a neutral reason CODE only (used for client-side logic /
+                        # devtools log) — the raw string is logged server-side here, never sent.
                         code_match = re.search(r'\[groq:([^\]]+)\]', err_str)
                         err_code = code_match.group(1) if code_match else 'unknown'
-                        REASONS = {
-                            'model_terms_required': ('terms', 'Accept Orpheus terms at console.groq.com'),
-                            'rate_limit_exceeded':  ('rate_limit', 'Groq rate limit hit — try again shortly'),
-                            'insufficient_quota':   ('no_credits', 'Groq account out of credits'),
-                            'invalid_api_key':      ('bad_key', 'Invalid GROQ_API_KEY'),
-                            'unknown':              ('error', err_str),
+                        REASON_CODES = {
+                            'model_terms_required': 'terms',
+                            'rate_limit_exceeded':  'rate_limit',
+                            'insufficient_quota':   'no_credits',
+                            'invalid_api_key':      'bad_key',
+                            'unknown':              'error',
                         }
-                        reason_key, reason_msg = REASONS.get(err_code, ('error', err_str))
+                        reason_key = REASON_CODES.get(err_code, 'error')
+                        logger.warning(f"### TTS error (not sent to client): reason={reason_key} raw={err_str!r}")
                         return json.dumps({
                             'type': 'tts_error',
-                            'provider': tts_provider,
                             'reason': reason_key,
-                            'error': reason_msg,
                         }) + '\n'
 
                     # ── Mid-stream TTS helpers ────────────────────────────
@@ -1825,7 +1828,9 @@ def _conversation_inner():
                                 # Re-arm a consumed recovery prime — this turn
                                 # never completed, so context must carry forward.
                                 restore_recovery_prime(_recovery_prime)
-                                yield json.dumps({'type': 'error', 'error': 'Gateway timeout'}) + '\n'
+                                # CLIENT-FACING RULE (Mike 2026-06-28): neutral code only.
+                                logger.error('### STREAM HARD TIMEOUT (not sent to client): Gateway timeout')
+                                yield json.dumps({'type': 'error', 'code': 'timeout'}) + '\n'
                                 break
                             yield json.dumps({'type': 'heartbeat', 'elapsed': elapsed}) + '\n'
                             continue
@@ -2013,10 +2018,13 @@ def _conversation_inner():
                                 logger.error(f"### GATEWAY ERROR → fallback: {error_msg}")
                                 # Detect rate limit specifically so the UI can surface it
                                 if 'rate limit' in error_msg.lower():
+                                    # CLIENT-FACING RULE (Mike 2026-06-28): never serialize the
+                                    # raw provider name or rate-limit string into a client-bound
+                                    # event. Send a neutral code only; the browser surfaces
+                                    # nothing and the spoken fallback below stays graceful.
                                     yield json.dumps({
                                         'type': 'rate_limit',
-                                        'provider': 'Z.AI',
-                                        'message': error_msg,
+                                        'code': 'throttled',
                                     }) + '\n'
                                     metrics['rate_limited'] = 1
                                 evt['response'] = "One moment, still working on that."
@@ -2598,12 +2606,12 @@ def _conversation_inner():
                                     }) + '\n'
                                     logger.info(f'Served agent-generated audio: {len(file_bytes)} bytes ({audio_format})')
                                 except Exception as fp_err:
+                                    # CLIENT-FACING RULE (Mike 2026-06-28): log the raw
+                                    # exception server-side; send only a neutral reason code.
                                     logger.error(f'Failed to serve agent audio file {file_path}: {fp_err}')
                                     yield json.dumps({
                                         'type': 'tts_error',
-                                        'provider': 'agent',
                                         'reason': 'file_read_error',
-                                        'error': f'Agent generated audio but file could not be read: {fp_err}',
                                     }) + '\n'
                                 log_metrics(metrics)
                                 break
@@ -2702,9 +2710,14 @@ def _conversation_inner():
                             # the session. Re-arm the prime so the NEXT turn
                             # still carries the conversation context.
                             restore_recovery_prime(_recovery_prime)
+                            # CLIENT-FACING RULE (Mike 2026-06-28): never serialize the raw
+                            # gateway/exception text into a client-bound event. Log it
+                            # server-side; send only a neutral code the browser maps to a
+                            # graceful "reconnecting" line.
+                            logger.error(f"### STREAM ERROR (not sent to client): {evt.get('error', 'Unknown error')!r}")
                             yield json.dumps({
                                 'type': 'error',
-                                'error': evt.get('error', 'Unknown error')
+                                'code': 'gateway',
                             }) + '\n'
                             break
 

--- a/routes/music.py
+++ b/routes/music.py
@@ -238,6 +238,37 @@ def get_music_files(playlist="library"):
     return files
 
 
+def get_latest_generated_track():
+    """Return the most-recently-generated track dict (by file mtime), or None.
+
+    'The last track you made' has no other authoritative source — metadata
+    created_date is date-only, and the playlist is sorted alphabetically. File
+    mtime is the only reliable recency signal. Adds 'url' + 'download_url'.
+    """
+    music_extensions = {".mp3", ".wav", ".ogg", ".m4a", ".webm"}
+    try:
+        candidates = [
+            f for f in GENERATED_MUSIC_DIR.iterdir()
+            if f.is_file() and f.suffix.lower() in music_extensions
+        ]
+    except FileNotFoundError:
+        return None
+    if not candidates:
+        return None
+    newest = max(candidates, key=lambda f: f.stat().st_mtime)
+    metadata = load_generated_music_metadata()
+    meta = metadata.get(newest.name, {})
+    return {
+        "filename": newest.name,
+        "title": meta.get("title", newest.stem),
+        "artist": meta.get("artist", "Jam-Bot"),
+        "url": f"/generated_music/{newest.name}",
+        "download_url": f"/generated_music/{newest.name}?download=1",
+        "created_date": meta.get("created_date", ""),
+        "mtime": newest.stat().st_mtime,
+    }
+
+
 def _build_dj_hints(track):
     """Build a DJ hints string from track metadata."""
     title = track.get("title", track["name"])
@@ -275,23 +306,47 @@ _AUDIO_MIME_TYPES = {
 }
 
 
+def _download_name_for(music_dir, music_path, metadata_loader):
+    """Build a friendly download filename from track metadata title, else the stem."""
+    try:
+        meta = (metadata_loader() or {}).get(music_path.name, {})
+        title = (meta.get("title") or "").strip()
+    except Exception:
+        title = ""
+    base = title or music_path.stem
+    # Keep it filesystem/HTTP-header safe
+    safe = re.sub(r"[^\w\- ]+", "", base).strip().replace(" ", "-") or music_path.stem
+    return f"{safe}{music_path.suffix.lower()}"
+
+
 @music_bp.route("/music/<filename>")
 def serve_music_file(filename):
-    """Serve library music files."""
+    """Serve library music files. ?download=1 forces a save-to-disk download."""
     music_path = _safe_path(MUSIC_DIR, filename)
     if music_path is None or not music_path.exists():
         return jsonify({"error": "Track not found"}), 404
     mime_type = _AUDIO_MIME_TYPES.get(music_path.suffix.lower(), "audio/mpeg")
+    if request.args.get("download"):
+        return send_file(
+            music_path, mimetype=mime_type, as_attachment=True,
+            download_name=_download_name_for(MUSIC_DIR, music_path, load_music_metadata),
+        )
     return send_file(music_path, mimetype=mime_type)
 
 
 @music_bp.route("/generated_music/<filename>")
 def serve_generated_music_file(filename):
-    """Serve AI-generated music files."""
+    """Serve AI-generated music files. ?download=1 forces a save-to-disk download."""
     music_path = _safe_path(GENERATED_MUSIC_DIR, filename)
     if music_path is None or not music_path.exists():
         return jsonify({"error": "Generated track not found"}), 404
     mime_type = _AUDIO_MIME_TYPES.get(music_path.suffix.lower(), "audio/mpeg")
+    if request.args.get("download"):
+        return send_file(
+            music_path, mimetype=mime_type, as_attachment=True,
+            download_name=_download_name_for(
+                GENERATED_MUSIC_DIR, music_path, load_generated_music_metadata),
+        )
     return send_file(music_path, mimetype=mime_type)
 
 
@@ -344,6 +399,19 @@ def handle_music():
             "playlist": "external",
             "source": provider,
             "response": f"Now streaming '{title}' from {provider}.",
+        })
+
+    # ── LATEST ────────────────────────────────────────────────────────────
+    # "The last track you made" — authoritative newest-by-mtime generated song.
+    if action == "latest":
+        latest = get_latest_generated_track()
+        if not latest:
+            return jsonify({"action": "latest", "track": None,
+                            "response": "No generated tracks yet."})
+        return jsonify({
+            "action": "latest",
+            "track": latest,
+            "response": f"Latest generated track: '{latest['title']}'.",
         })
 
     # ── SPOTIFY ───────────────────────────────────────────────────────────

--- a/src/app.js
+++ b/src/app.js
@@ -3854,7 +3854,11 @@ connectAiradio();
                         break;
 
                     case 'error':
-                        this.addSystemMessage(`Error: ${data.message || 'Unknown error'}`);
+                        // CLIENT-FACING RULE (Mike 2026-06-28): never dump a raw gateway
+                        // message (e.g. "weekly limit"/"overloaded") into the visible chat.
+                        // Show at most a neutral reconnecting line; raw detail to devtools only.
+                        console.warn('Clawdbot WS error:', data.message || 'Unknown error');
+                        this.addSystemMessage('One moment — reconnecting…');
                         this.callbacks.onError(data.message || 'Unknown error');
                         break;
 
@@ -4552,41 +4556,36 @@ connectAiradio();
                                     this.addSystemMessage('Session reset — next response may be slow.');
                                 }
 
-                                // AI provider rate limited — surface clearly
+                                // AI provider rate limited. CLIENT-FACING RULE (Mike 2026-06-28):
+                                // never name a provider or say "throttled"/"fallback" to the
+                                // client — the reply itself is already graceful. Surface NOTHING
+                                // in the visible chat. Raw detail to console.warn only (devtools).
                                 if (data.type === 'rate_limit') {
-                                    const provider = data.provider || 'AI provider';
-                                    console.warn('[Conversation] Rate limited by', provider, data.message);
-                                    ActionConsole.addEntry('error', `⚠️ ${provider} throttled — using fallback model`);
-                                    this.addSystemMessage(`⚠️ ${provider} is temporarily throttled. Response came from fallback model.`);
+                                    console.warn('[Conversation] Rate limited:', data.provider, data.message);
                                 }
 
-                                // Generic server error — surface prominently
+                                // Generic server error. CLIENT-FACING RULE (Mike 2026-06-28):
+                                // the server now sends a neutral `code` (no raw text). Show a
+                                // single neutral reconnecting line; raw detail (if any) to
+                                // devtools only. Never echo a raw gateway/exception string.
                                 if (data.type === 'error') {
-                                    console.error('Stream error:', data.error);
-                                    ActionConsole.addEntry('error', data.error);
-                                    // Gateway connection errors should be visible to the user
-                                    if (data.error?.includes('connect') || data.error?.includes('Gateway') || data.error?.includes('Failed')) {
-                                        this.addSystemMessage('Agent connection error — retrying...');
-                                        StatusModule.update('thinking', 'RECONNECTING...');
-                                    }
+                                    console.error('Stream error:', data.code || data.error);
+                                    ActionConsole.addEntry('system', 'Reconnecting…');
+                                    this.addSystemMessage('One moment — reconnecting…');
+                                    StatusModule.update('thinking', 'RECONNECTING...');
                                 }
 
-                                // TTS-specific failure — response came through but audio failed
+                                // TTS-specific failure — response came through but audio failed.
+                                // CLIENT-FACING RULE (Mike 2026-06-28): never surface a
+                                // provider/billing/error string in the visible chat. The text
+                                // reply is already on screen and the spoken path already failed
+                                // silently server-side — so we add NO chat line here. Raw detail
+                                // (provider, billing reason) goes to console.error only (browser
+                                // devtools, not a client-visible UI surface). The ActionConsole
+                                // is a user-openable panel, so it gets a neutral line too.
                                 if (data.type === 'tts_error') {
-                                    const reasonMessages = {
-                                        'terms':             `${data.provider} TTS: Terms not accepted — visit console.groq.com to accept`,
-                                        'rate_limit':        `${data.provider} TTS: Rate limit hit — try again in a moment`,
-                                        'no_credits':        `${data.provider} TTS: Out of credits`,
-                                        'bad_key':           `${data.provider} TTS: Invalid API key`,
-                                        'agent_tool_misuse': `Agent tried to use its own TTS tool — reply was dropped. Ask again.`,
-                                        'error':             `${data.provider} TTS failed: ${data.error}`,
-                                    };
-                                    const msg = reasonMessages[data.reason] || `TTS failed: ${data.error}`;
                                     console.error('TTS failed:', data);
-                                    ActionConsole.addEntry('error', msg);
-                                    this.addSystemMessage(`⚠️ ${msg}`);
-                                    FaceModule.setMood('sad');
-                                    setTimeout(() => FaceModule.setMood('neutral'), 3000);
+                                    ActionConsole.addEntry('system', 'Audio unavailable for this reply — text shown above');
                                     // Restart STT so the mic comes back (only if call still active)
                                     if (this._voiceActive && this.stt) {
                                         if (this.stt.resume) {
@@ -5282,7 +5281,10 @@ connectAiradio();
                         console.log(`Clawdbot ${role}:`, text);
                     },
                     onError: (error) => {
-                        UIModule.showError(`Agent error: ${error}`);
+                        // CLIENT-FACING RULE (Mike 2026-06-28): never put a raw agent/gateway
+                        // error into a visible toast. Show a neutral line; raw to devtools only.
+                        console.warn('Agent error:', error);
+                        UIModule.showError('One moment…');
                         FaceModule.setMood('sad');
                         setTimeout(() => FaceModule.setMood('neutral'), 2000);
                     }
@@ -5361,7 +5363,10 @@ connectAiradio();
                                 }
                             },
                             onError: (error) => {
-                                UIModule.showError(error);
+                                // CLIENT-FACING RULE (Mike 2026-06-28): neutral toast only;
+                                // raw error to devtools, never a visible toast.
+                                console.warn('Voice adapter error:', error);
+                                UIModule.showError('One moment…');
                                 FaceModule.setMood('sad');
                                 setTimeout(() => FaceModule.setMood('neutral'), 2000);
                             }
@@ -6997,7 +7002,10 @@ connectAiradio();
                     }
                 },
                 onError: (error) => {
-                    UIModule.showError(error);
+                    // CLIENT-FACING RULE (Mike 2026-06-28): neutral toast only;
+                    // raw error to devtools, never a visible toast.
+                    console.warn('Voice adapter error:', error);
+                    UIModule.showError('One moment…');
                     FaceModule.setMood('sad');
                     setTimeout(() => FaceModule.setMood('neutral'), 2000);
                 }


### PR DESCRIPTION
Remaining fleet-hotfixed commits not yet on main (all already live via container hotfix; this makes them durable for image rebuild):

- fix(music): working song download links (public /generated_music + ?download=1 + latest-by-mtime)
- fix(canvas): inline-playable video (+audio) in bulk-uploader feed
- chore(hermes-agent plugin): manifest-only version bump
- merge-sync with PR #346