### PR TITLE
fix+feat: Fable review remediation — P1 bugs, latency, framework-agnostic admin panel

### DIFF
--- a/app.py
+++ b/app.py
@@ -148,29 +148,41 @@ def create_app(config_override: dict = None):
             '/canvas-data/',  # processed-song media (audio stems) + fixtures for the Suno Studio editor — non-sensitive, served like /uploads/ (added 2026-06-25)
             '/static/',    # PWA icons, app icons
             '/pages/',     # canvas pages — served without auth (CANVAS_REQUIRE_AUTH opt-in)
-            '/api/canvas/',  # canvas API — creation, manifest, context (no per-user auth needed)
             '/api/upload',    # file upload — canvas pages lose Clerk JWT on long sessions; files are non-sensitive
             '/api/uploads',   # uploads list — files are already public at /uploads/, listing is fine
-            '/api/profiles',  # read-only profile config — loaded before Clerk init
             '/api/plugins/assets',  # Plugin face scripts/CSS — fetched by index.html before login.
                                     # All other /api/plugins routes (install/uninstall/restart/config)
                                     # are state-changing admin operations and require admin auth below.
             '/api/vault/oauth/callback/',  # OAuth callbacks — redirected from external providers
             '/plugins/',      # Plugin static assets — face scripts, CSS, previews
-            '/api/chat',      # LLM proxy (Groq) — used by canvas pages for inline AI
-            '/api/tts/',      # TTS provider list — loaded before Clerk init
-            '/api/stt/',      # STT endpoints (Deepgram token, Groq, local) — mic audio only, no secrets exposed
             '/api/theme',     # theme config — loaded before Clerk init
-            '/api/music',     # music track list — loaded before Clerk init
-            '/api/faces',     # face list — loaded before Clerk init
-            '/api/custom-faces', # custom face manifest + CRUD — loaded by face picker
             '/faces/custom/', # custom face HTML — loaded in iframe by face-box
-            '/api/icons/',    # icon library + generated icons — static images, no secrets
-            '/api/suno',      # Suno song generation — status polling + song list (no secrets)
             '/registry/',     # Pinokio registry check-in — accessed by Pinokio, not logged-in user
             '/checkpoints/',  # Pinokio snapshot endpoint — called from /registry/checkin page JS
             '/openclaw-ui/',  # OpenClaw Control UI SPA + assets — proxied to internal gateway
         )
+        # Public for READS ONLY (GET/HEAD/OPTIONS). These prefixes serve config
+        # lists the UI loads before Clerk init, but their state-changing methods
+        # (POST/PUT/PATCH/DELETE) must NOT bypass auth — a prefix opened for a
+        # benign read previously exposed every write sibling under it
+        # (SEC-1/2/3/6/9). Write methods fall through to the normal auth path:
+        # the internal agent key already carves out its allowed non-admin paths
+        # (canvas/tts/suno/music writes the openclaw agent depends on), and
+        # everything else requires a Clerk session.
+        _PUBLIC_READ_PREFIXES = (
+            '/api/canvas/',   # GET manifest/context/pages — writes gated (SEC-2/3/8)
+            '/api/tts/',      # GET provider list — clone/default-writes gated (SEC-9)
+            '/api/chat',      # LLM proxy — POST gated so anon can't burn the LLM budget (SEC-6)
+            '/api/music',     # GET track list — upload/delete gated
+            '/api/faces',     # GET face list — enrollment writes gated
+            '/api/custom-faces',  # GET manifest — HTML-face writes gated (SEC-3 stored XSS)
+            '/api/icons/',    # GET icon library — generate/upload gated (SEC-9)
+            '/api/suno',      # GET status/song-list — generation POSTs gated (SEC-9)
+            '/api/profiles',  # GET profile config — activate/save writes gated (SEC-10)
+        )
+        # NOTE: /api/stt/ is intentionally NOT public — the Deepgram token
+        # endpoint returns a live secret (SEC-1). All /api/stt/* now requires a
+        # Clerk session or the agent key.
         _PUBLIC_EXACT = {
             '/',           # main page — hosts the Clerk login gate itself
             '/pi',         # Pi-optimized page — same login gate, different entry point
@@ -227,6 +239,13 @@ def create_app(config_override: dict = None):
             # /src/ is public (login-screen assets) EXCEPT the admin shell itself —
             # /src/admin.html must go through the same admin gate as /admin.
             if path != '/src/admin.html' and any(path.startswith(p) for p in _PUBLIC_PREFIXES):
+                return
+            # Read-only public prefixes: GET/HEAD/OPTIONS bypass auth (config lists
+            # loaded before Clerk init); write methods fall through to the auth
+            # path below (agent key or Clerk session required).
+            if request.method in ('GET', 'HEAD', 'OPTIONS') and any(
+                path.startswith(p) for p in _PUBLIC_READ_PREFIXES
+            ):
                 return
             # Canvas pages and images have their own auth logic (public flag)
             # handled inside canvas_bp — let them through here

--- a/app.py
+++ b/app.py
@@ -111,6 +111,9 @@ def create_app(config_override: dict = None):
         '/api/server-stats',
         '/api/plugins/',    # install/uninstall/restart/config (assets exempted below)
         '/api/plugins',     # bare list endpoint
+        '/api/services/',   # Service Catalog + per-service health (WO-1.2) — reads
+                            # gateway/LLM/TTS/STT descriptors + vault cred status;
+                            # admin-only, never public.
     )
 
     if not _auth_enabled:

--- a/config/ai-providers.json
+++ b/config/ai-providers.json
@@ -1,0 +1,57 @@
+{
+  "_comment": "LLM provider catalog for the admin panel + Service Catalog (WO-1.2). Moved out of the hardcoded routes/admin.py:_AI_PROVIDERS dict so a provider can be added/edited without a code change. services/ai_providers.py loads this file and falls back to the inline default (services.ai_providers._DEFAULT_AI_PROVIDERS) if it is missing or unparseable. Adding a provider here makes it appear in /api/services/catalog and the AI-Models admin tab with no panel edit. LLM ROUTING itself lives in the gateway/framework layer (openclaw.json agents.defaults.model), NOT here — this catalog only describes providers + their credential env keys + selectable models.",
+  "providers": {
+    "zai": {
+      "name": "Z.AI (Account A)",
+      "envKey": "ZAI_API_KEY",
+      "baseUrl": "https://api.z.ai/api/anthropic",
+      "api": "anthropic-messages",
+      "models": [
+        {"id": "glm-5-turbo", "name": "GLM-5 Turbo (Z.AI)", "contextWindow": 204000},
+        {"id": "glm-4.7", "name": "GLM-4.7 (Z.AI)", "contextWindow": 204000}
+      ]
+    },
+    "zai_fb": {
+      "name": "Z.AI (Account B / fallback)",
+      "envKey": "ZAI_FALLBACK_API_KEY",
+      "baseUrl": "https://api.z.ai/api/anthropic",
+      "api": "anthropic-messages",
+      "models": [
+        {"id": "glm-5-turbo", "name": "GLM-5 Turbo (Z.AI B)", "contextWindow": 204000},
+        {"id": "glm-4.7", "name": "GLM-4.7 (Z.AI B)", "contextWindow": 204000}
+      ]
+    },
+    "anthropic": {
+      "name": "Anthropic",
+      "envKey": "ANTHROPIC_API_KEY",
+      "baseUrl": "https://api.anthropic.com",
+      "api": "anthropic-messages",
+      "models": [
+        {"id": "claude-sonnet-5", "name": "Claude Sonnet 5", "contextWindow": 200000},
+        {"id": "claude-opus-4-8", "name": "Claude Opus 4.8", "contextWindow": 200000},
+        {"id": "claude-haiku-4-5-20251001", "name": "Claude Haiku 4.5", "contextWindow": 200000}
+      ]
+    },
+    "openai": {
+      "name": "OpenAI",
+      "envKey": "OPENAI_API_KEY",
+      "baseUrl": "https://api.openai.com/v1",
+      "api": "openai-responses",
+      "models": [
+        {"id": "gpt-4.1", "name": "GPT-4.1", "contextWindow": 1047576},
+        {"id": "gpt-4o", "name": "GPT-4o", "contextWindow": 128000},
+        {"id": "gpt-4o-mini", "name": "GPT-4o Mini", "contextWindow": 128000}
+      ]
+    },
+    "google": {
+      "name": "Google Gemini",
+      "envKey": "GEMINI_API_KEY",
+      "baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+      "api": "google-generative-ai",
+      "models": [
+        {"id": "gemini-2.5-flash", "name": "Gemini 2.5 Flash", "contextWindow": 1048576},
+        {"id": "gemini-2.5-pro", "name": "Gemini 2.5 Pro", "contextWindow": 1048576}
+      ]
+    }
+  }
+}

--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -2,6 +2,19 @@
 # ADR-001: YAML format with env interpolation
 # ADR-003: Abstract base class + registry pattern
 #
+# ── STATUS (2026-07-11, WO-1.3) ────────────────────────────────────────────
+# Only the `stt:` section is LOAD-BEARING. autodiscover() runs at startup
+# (server.py) to register the STT providers so the Service Catalog reads STT
+# ids from the same registry that /api/stt/* uses.
+#
+# The `llm:` section is DEPRECATED — see providers/llm/DEPRECATED.md. LLM
+# routing belongs to the gateway/framework layer (openclaw.json model config via
+# the config.patch RPC / GatewayBase.configure()). The llm modules here have
+# zero production call sites; autodiscover only registers the classes. The
+# provider CATALOG the admin panel renders is config/ai-providers.json, not this
+# file. Kept (not removed) so autodiscover stays stable; do not build on it.
+# The `tts:` section is likewise informational — live TTS uses tts_providers/.
+#
 # ${ENV_VAR} placeholders are resolved at runtime from environment variables.
 # 'modules' lists Python module paths imported during autodiscover() so that
 # each module's register() calls fire automatically.

--- a/config/tts-fallback.json
+++ b/config/tts-fallback.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "TTS fallback policy for the admin panel + runtime (WO-3.1). Moved out of the hardcoded services/tts.py:_FALLBACK_CHAIN / _VOICE_GENDER dicts so the chain + voice-gender map can be edited from the admin 'Voice: TTS' tab without a code change. services/tts_fallback.py loads this file (mtime-cached) and falls back to the inline default (services.tts_fallback._DEFAULT_FALLBACK) if it is missing or unparseable. Runtime reads through the loader so a UI edit takes effect on the NEXT utterance, no restart. 'chain' maps a provider_id -> its single next-hop fallback provider_id (followed transitively, cycle-protected). 'voice_gender' maps a voice_id -> 'M'|'F' so a fallback keeps the same gender voice.",
+  "chain": {
+    "groq": "supertonic",
+    "qwen3": "groq",
+    "qwen3-local": "groq",
+    "resemble": "groq",
+    "elevenlabs": "groq"
+  },
+  "voice_gender": {
+    "autumn": "F", "diana": "F", "hannah": "F",
+    "austin": "M", "daniel": "M", "troy": "M",
+
+    "rachel": "F", "drew": "M", "clyde": "M", "paul": "M",
+    "domi": "F", "bella": "F", "antoni": "M", "elli": "F",
+    "josh": "M", "arnold": "M", "adam": "M", "sam": "M",
+
+    "M1": "M", "M2": "M", "M3": "M", "M4": "M", "M5": "M",
+    "F1": "F", "F2": "F", "F3": "F", "F4": "F", "F5": "F",
+
+    "kyle": "M", "valhalla": "M", "bhb": "M",
+
+    "ethan": "M", "chelsie": "F", "cherry": "F", "serena": "F",
+    "dylan": "M", "jada": "F", "sunny": "F"
+  }
+}

--- a/dev-tasks/hermes-agent-gateway-catalog-contract.patch
+++ b/dev-tasks/hermes-agent-gateway-catalog-contract.patch
@@ -1,0 +1,163 @@
+--- /tmp/claude-1000/-home-mike-MIKE-AI/47617f0a-a5f5-41b1-b645-0e453631c4cf/scratchpad/hermes-gateway-orig.py	2026-07-11 16:52:53.236574287 +0000
++++ plugins/hermes-agent/gateway.py	2026-07-11 16:44:39.912934661 +0000
+@@ -135,6 +135,40 @@
+         )
+ 
+ 
++# ---------------------------------------------------------------------------
++# Cached reachability probe (WO-2.1)
++# ---------------------------------------------------------------------------
++# is_configured() must reflect REAL reachability (not unconditional True), but
++# it is called at register-time and on every list_gateways()/catalog call — so a
++# naked network call each time would be both slow and startup-blocking. We cache
++# the last probe for a short TTL and time the round-trip so check_health() can
++# report latency from the same probe.
++_REACH_CACHE = {"ok": None, "latency_ms": None, "ts": 0.0}
++_REACH_TTL_S = 30.0
++
++
++def _probe_hermes(timeout: float = 2.0, force: bool = False) -> tuple:
++    """Return (reachable: bool, latency_ms: float|None), cached for _REACH_TTL_S.
++
++    A single GET /health round-trip. On any failure returns (False, None).
++    """
++    now = time.time()
++    if not force and _REACH_CACHE["ok"] is not None and (now - _REACH_CACHE["ts"]) < _REACH_TTL_S:
++        return (_REACH_CACHE["ok"], _REACH_CACHE["latency_ms"])
++    t0 = time.time()
++    ok = False
++    latency = None
++    try:
++        resp = requests.get(f"{HERMES_BASE_URL}/health", headers=_hermes_headers(), timeout=timeout)
++        ok = bool(resp.ok)
++        latency = round((time.time() - t0) * 1000, 1)
++    except Exception:
++        ok = False
++        latency = None
++    _REACH_CACHE.update({"ok": ok, "latency_ms": latency, "ts": now})
++    return (ok, latency)
++
++
+ def _hermes_headers(session_id: str = "", session_key: str = "") -> dict:
+     """Build headers for every Hermes API call.
+ 
+@@ -510,6 +544,9 @@
+ 
+     gateway_id = "hermes"
+     persistent = False  # REST per-request, no persistent connection
++    capabilities = frozenset({
++        "streaming", "steer", "sessions", "tool-events", "reset",
++    })
+ 
+     def __init__(self):
+         self._session_history: dict[str, list] = {}
+@@ -531,22 +568,65 @@
+         self._active_runs_lock = threading.Lock()
+ 
+     def is_configured(self) -> bool:
+-        """Check if the Hermes container is reachable."""
+-        # Don't block startup with a health check — just verify env/config
+-        # The actual container may start after OpenVoiceUI
+-        return True
++        """Whether Hermes is actually reachable (WO-2.1).
++
++        Previously returned unconditional True, which made the panel and the
++        catalog claim Hermes was configured even when its container was down.
++        Now reflects a cached reachability probe (30s TTL) so is_configured is
++        honest. The cache means the register-time call and every list_gateways()
++        call is cheap; a container that comes up after OVU is picked up on the
++        next probe within the TTL. On a cold cache we probe once (short timeout).
++        """
++        ok, _lat = _probe_hermes()
++        return ok
+ 
+     def is_healthy(self) -> bool:
+-        """Live health check — ping the Hermes API."""
++        """Live health check — ping the Hermes API (cached)."""
++        ok, _lat = _probe_hermes()
++        return ok
++
++    def check_health(self) -> tuple:
++        """(reachable, latency_ms) from the cached /health probe (WO-2.1)."""
++        return _probe_hermes()
++
++    def get_config_schema(self) -> dict:
++        """Hermes connection + key schema (rendered generically by the panel)."""
++        return {
++            "fields": [
++                {"id": "HERMES_HOST", "type": "text", "label": "Hermes host",
++                 "required": True, "placeholder": "hermes"},
++                {"id": "HERMES_PORT", "type": "text", "label": "Hermes port",
++                 "required": False, "placeholder": "18790"},
++                {"id": "HERMES_API_KEY", "type": "password", "label": "Hermes API key",
++                 "required": False, "credential": "hermes_api_key"},
++            ],
++            "editable": True,
++            "transport": "provisioning-service",
++        }
++
++    def configure(self, partial: dict) -> dict:
++        """Apply a config change via the plugin provisioning service (WO-2.1).
++
++        Routes through services.plugins.update_plugin_config('hermes-agent', …),
++        which PUTs to the provisioning service and restarts the hermes container.
++        Imported lazily to keep the plugin importable outside the app process.
++        """
+         try:
+-            resp = requests.get(
+-                f"{HERMES_BASE_URL}/health",
+-                headers=_hermes_headers(),
+-                timeout=5
+-            )
+-            return resp.ok
+-        except Exception:
+-            return False
++            from services.plugins import update_plugin_config
++        except Exception as exc:
++            return {"status": "error", "detail": f"provisioning path unavailable: {exc}"}
++        result = update_plugin_config("hermes-agent", partial or {})
++        if result.get("ok"):
++            # Invalidate the reachability cache so the next health read is fresh.
++            _probe_hermes(force=True)
++            return {"status": "needs_restart",
++                    "detail": "applied via provisioning service (hermes container restarts)",
++                    "raw": result}
++        return {"status": "error", "detail": result.get("error", "provisioning failed")}
++
++    def restart_scope(self) -> str:
++        tenant = HERMES_TENANT_SESSION_KEY or ""
++        return f"container:hermes-{tenant}" if tenant else "container:hermes"
+ 
+     def stream_to_queue(
+         self,
+@@ -844,20 +924,20 @@
+ 
+     gateway_id = "hermes-bridge"
+     persistent = False
++    capabilities = frozenset({"streaming", "tool-events", "delegation"})
+ 
+     def is_configured(self) -> bool:
+-        return True
++        # Bridge mode: OpenClaw stays primary; the bridge only needs Hermes
++        # reachable to accept a delegated task. Reflect real reachability.
++        ok, _lat = _probe_hermes()
++        return ok
+ 
+     def is_healthy(self) -> bool:
+-        try:
+-            resp = requests.get(
+-                f"{HERMES_BASE_URL}/health",
+-                headers=_hermes_headers(),
+-                timeout=5,
+-            )
+-            return resp.ok
+-        except Exception:
+-            return False
++        ok, _lat = _probe_hermes()
++        return ok
++
++    def check_health(self) -> tuple:
++        return _probe_hermes()
+ 
+     def stream_to_queue(
+         self,

--- a/profiles/schema.json
+++ b/profiles/schema.json
@@ -43,7 +43,8 @@
       "properties": {
         "provider": {
           "type": "string",
-          "enum": ["zai", "clawdbot", "gateway", "openai", "ollama", "anthropic", "hume", "elevenlabs"]
+          "minLength": 1,
+          "description": "LLM/agent provider id. Validation-only (any non-empty string) — the real option list comes from /api/services/catalog, not a fixed enum, so new providers (resemble, qwen3, plugins) never drift out of a hardcoded list. WO-3.3."
         },
         "model":     { "type": "string" },
         "config_id": { "type": "string" },
@@ -90,7 +91,8 @@
       "properties": {
         "tts_provider": {
           "type": "string",
-          "enum": ["supertonic", "groq", "elevenlabs", "hume", "qwen3"]
+          "minLength": 1,
+          "description": "TTS provider id. Validation-only (any non-empty string) — options come from the tts_providers registry via /api/services/catalog, so resemble/qwen3-local/custom providers never drift out of a fixed enum. WO-3.3."
         },
         "voice_id":  { "type": "string" },
         "speed":     { "type": "number", "minimum": 0.5, "maximum": 2.0, "default": 1.0 },
@@ -125,7 +127,8 @@
       "properties": {
         "provider": {
           "type": "string",
-          "enum": ["deepgram", "deepgram-streaming", "deepgram-batch", "groq", "webspeech", "whisper", "hume", "elevenlabs"]
+          "minLength": 1,
+          "description": "STT provider id. Validation-only (any non-empty string) — options come from /api/services/catalog (webspeech/deepgram/groq_whisper/whisper/external), so a new STT provider never drifts out of a fixed enum. WO-3.3."
         },
         "language": { "type": "string", "default": "en-US" },
         "notes":    { "type": "string" },

--- a/providers/llm/DEPRECATED.md
+++ b/providers/llm/DEPRECATED.md
@@ -1,0 +1,36 @@
+# DEPRECATED — providers/llm/
+
+**Status:** Deprecated as of 2026-07-11 (WO-1.3). **Not deleted** (house rule:
+never delete). Do **not** build new features on this package.
+
+## Why
+
+LLM routing in OpenVoiceUI belongs to the **gateway / framework layer**, not to
+an OVU-side LLM provider registry:
+
+- The real LLM choice lives in `openclaw.json` (`agents.defaults.model.primary /
+  fallbacks`), managed by the gateway `config.patch` RPC
+  (`routes/admin.py` → `PUT /api/admin/ai-config`, and now
+  `OpenClawGateway.configure()`).
+- Alternate frameworks (Hermes, future gateways) each own their own model
+  selection through `GatewayBase.get_config_schema()` / `configure()`.
+- The provider **catalog** (what the admin panel renders) is
+  `config/ai-providers.json` (loaded by `services/ai_providers.py`), surfaced
+  via `GET /api/services/catalog`.
+
+`providers/llm/` (`zai_provider.py`, `clawdbot_provider.py`, `base.py`) has
+**zero production call sites**. It is still imported by
+`providers.registry.autodiscover()` (driven by `config/providers.yaml`), which
+only registers the classes — it routes nothing.
+
+## What IS wired
+
+Only the **STT** side of `providers/` is load-bearing:
+- `providers/stt/*` registers webspeech / whisper / external into the registry.
+- `autodiscover()` runs at startup (`server.py`) so the STT Service Catalog
+  reads ids from the same registry that `/api/stt/*` uses.
+
+## If you need to add an LLM
+
+Add it to `config/ai-providers.json` (catalog) and wire the actual routing
+through the active framework's `configure()` — not here.

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -241,8 +241,19 @@ def gateway_status():
     # If ping method not found but handshake worked the error will say so
     err = result.get('error', '')
     err_str = str(err).lower() if err else ''
-    # "missing scope" or "unknown method" = handshake succeeded, just no permission for ping
-    auth_ok = 'missing scope' in err_str or 'method' in err_str or 'unknown' in err_str
+    # The handshake succeeded (auth worked) if the gateway rejected ONLY the
+    # ping method itself — either it is unknown/unsupported, or ping is scope-
+    # restricted. Match those specific shapes, not any error that merely
+    # contains the substring 'method'/'unknown' (which also matches genuine
+    # failures like a malformed request or an "unknown error"). (WS-12)
+    auth_ok = (
+        'missing scope' in err_str
+        or 'method not found' in err_str
+        or 'unknown method' in err_str
+        or 'no such method' in err_str
+        or 'unsupported method' in err_str
+        or 'not allowed' in err_str
+    )
     return jsonify({
         "connected": auth_ok,
         "message": "Handshake OK (ping restricted)" if auth_ok else "Auth failed",
@@ -510,8 +521,13 @@ def install_start():
                     from services.gateways.openclaw import _load_device_identity, _sign_device_connect
                     nonce = challenge.get('payload', {}).get('nonce', '')
                     scopes = ["operator.admin", "operator.read", "operator.write"]
+                    # Identify as the backend gateway-client, not 'cli' — the
+                    # 'cli' label leaked into agent-visible metadata elsewhere
+                    # (fixed in e154d32); this call site was missed. client_id
+                    # is enum-validated (GATEWAY_CLIENT_IDS); signature binds
+                    # client_id|client_mode, so keep both args in lockstep. (WS-12)
                     device_block = _sign_device_connect(
-                        _load_device_identity(), 'cli', 'cli', 'operator', scopes, auth_token, nonce
+                        _load_device_identity(), 'gateway-client', 'backend', 'operator', scopes, auth_token, nonce
                     )
                     connect_id = str(uuid.uuid4())[:8]
                     await ws.send(_json.dumps({
@@ -520,8 +536,8 @@ def install_start():
                         'method': 'connect',
                         'params': build_connect_params(
                             auth_token=auth_token,
-                            client_id='cli',
-                            client_mode='cli',
+                            client_id='gateway-client',
+                            client_mode='backend',
                             platform='linux',
                             user_agent='openvoice-ui-admin/1.0.0',
                             scopes=scopes,

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -679,60 +679,45 @@ _OPENCLAW_CONFIG_RO_FALLBACK = Path('/app/runtime/openclaw-client.json')
 # Active chain is Z.AI account A ('zai') + account B ('zai_fb') — both route to
 # api.z.ai/api/anthropic. MiniMax ('mx'), bigmodel-GLM, and Groq-for-LLM are
 # DROPPED providers and must never be offered here (Groq stays TTS-only).
-_AI_PROVIDERS = {
-    'zai': {
-        'name': 'Z.AI (Account A)',
-        'envKey': 'ZAI_API_KEY',
-        'baseUrl': 'https://api.z.ai/api/anthropic',
-        'api': 'anthropic-messages',
-        'models': [
-            {'id': 'glm-5-turbo', 'name': 'GLM-5 Turbo (Z.AI)', 'contextWindow': 204000},
-            {'id': 'glm-4.7', 'name': 'GLM-4.7 (Z.AI)', 'contextWindow': 204000},
-        ],
-    },
-    'zai_fb': {
-        'name': 'Z.AI (Account B / fallback)',
-        'envKey': 'ZAI_FALLBACK_API_KEY',
-        'baseUrl': 'https://api.z.ai/api/anthropic',
-        'api': 'anthropic-messages',
-        'models': [
-            {'id': 'glm-5-turbo', 'name': 'GLM-5 Turbo (Z.AI B)', 'contextWindow': 204000},
-            {'id': 'glm-4.7', 'name': 'GLM-4.7 (Z.AI B)', 'contextWindow': 204000},
-        ],
-    },
-    'anthropic': {
-        'name': 'Anthropic',
-        'envKey': 'ANTHROPIC_API_KEY',
-        'baseUrl': 'https://api.anthropic.com',
-        'api': 'anthropic-messages',
-        'models': [
-            {'id': 'claude-sonnet-5', 'name': 'Claude Sonnet 5', 'contextWindow': 200000},
-            {'id': 'claude-opus-4-8', 'name': 'Claude Opus 4.8', 'contextWindow': 200000},
-            {'id': 'claude-haiku-4-5-20251001', 'name': 'Claude Haiku 4.5', 'contextWindow': 200000},
-        ],
-    },
-    'openai': {
-        'name': 'OpenAI',
-        'envKey': 'OPENAI_API_KEY',
-        'baseUrl': 'https://api.openai.com/v1',
-        'api': 'openai-responses',
-        'models': [
-            {'id': 'gpt-4.1', 'name': 'GPT-4.1', 'contextWindow': 1047576},
-            {'id': 'gpt-4o', 'name': 'GPT-4o', 'contextWindow': 128000},
-            {'id': 'gpt-4o-mini', 'name': 'GPT-4o Mini', 'contextWindow': 128000},
-        ],
-    },
-    'google': {
-        'name': 'Google Gemini',
-        'envKey': 'GEMINI_API_KEY',
-        'baseUrl': 'https://generativelanguage.googleapis.com/v1beta',
-        'api': 'google-generative-ai',
-        'models': [
-            {'id': 'gemini-2.5-flash', 'name': 'Gemini 2.5 Flash', 'contextWindow': 1048576},
-            {'id': 'gemini-2.5-pro', 'name': 'Gemini 2.5 Pro', 'contextWindow': 1048576},
-        ],
-    },
-}
+# _AI_PROVIDERS moved to config/ai-providers.json (WO-1.2). A module-level
+# property-like accessor keeps every existing `_AI_PROVIDERS[...]` / `.items()`
+# call site working while reading the loadable catalog (mtime-cached, with the
+# historical inline dict as the guaranteed fallback). Assigning at import time is
+# fine because the loader is cheap and cached; the catalog endpoint + this module
+# always call load_ai_providers() fresh where a live edit must be reflected.
+from services.ai_providers import load_ai_providers as _load_ai_providers
+
+
+class _AIProvidersProxy:
+    """Read-only mapping proxy so `_AI_PROVIDERS` reflects config/ai-providers.json
+    on every access without changing the many `_AI_PROVIDERS[pid]` call sites."""
+
+    def _data(self):
+        return _load_ai_providers()
+
+    def __getitem__(self, key):
+        return self._data()[key]
+
+    def __contains__(self, key):
+        return key in self._data()
+
+    def get(self, key, default=None):
+        return self._data().get(key, default)
+
+    def items(self):
+        return self._data().items()
+
+    def keys(self):
+        return self._data().keys()
+
+    def values(self):
+        return self._data().values()
+
+    def __iter__(self):
+        return iter(self._data())
+
+
+_AI_PROVIDERS = _AIProvidersProxy()
 
 
 def _parse_jsonc(text: str) -> dict:
@@ -962,6 +947,28 @@ def update_ai_config():
         if val and ('/' not in val or val.startswith('/') or val.endswith('/')):
             return jsonify({'error': f"{field} must be 'provider/model-id', got: {val}"}), 400
 
+    # WO-2.2 — framework-generic dispatch. If the active profile's gateway is
+    # NOT openclaw, route the model/key change through that framework's
+    # configure() instead of the openclaw config.patch path (a Hermes-primary
+    # tenant used to 502 here because only openclaw has a config RPC).
+    active_gid = _active_gateway_id()
+    if active_gid and active_gid != 'openclaw':
+        from services.gateway_manager import gateway_manager
+        gw = gateway_manager.get(active_gid)
+        if gw is not None:
+            try:
+                result = gw.configure(data)
+            except Exception as exc:
+                logger.error("framework configure(%s) failed: %s", active_gid, exc)
+                return jsonify({'ok': False, 'error': f'{active_gid} configure failed: {exc}'}), 502
+            status = result.get('status')
+            if status in ('applied', 'needs_restart'):
+                return jsonify({'ok': True, 'gateway': active_gid, 'status': status,
+                                'message': result.get('detail', ''),
+                                'changes': result.get('changes', [])})
+            return jsonify({'ok': False, 'gateway': active_gid,
+                            'error': result.get('detail', 'configure failed')}), 502
+
     config, source, base_hash = _get_effective_config()
     if not config:
         return jsonify({'error': 'Cannot read openclaw config — gateway unreachable and no '
@@ -996,3 +1003,81 @@ def update_ai_config():
     except Exception as exc:
         logger.error(f"Failed to write openclaw.json: {exc}")
         return jsonify({'error': 'Write failed — see server logs'}), 500
+
+
+# ---------------------------------------------------------------------------
+# Agent Framework — gateway list + generic configure dispatch (WO-2.2)
+# ---------------------------------------------------------------------------
+
+def _active_gateway_id() -> str | None:
+    """The gateway_id of the active profile (adapter_config.gateway_id).
+
+    Returns 'openclaw' default when unset, None if profiles can't be read.
+    """
+    try:
+        from profiles.manager import get_profile_manager
+        import routes.profiles as _profiles_mod
+        mgr = get_profile_manager()
+        active_id = getattr(_profiles_mod, '_active_profile_id', None)
+        prof = mgr.get_profile(active_id)  # get_profile(None) → default
+        if prof is not None:
+            return (prof.adapter_config or {}).get('gateway_id', 'openclaw')
+    except Exception as exc:
+        logger.debug("active gateway lookup failed: %s", exc)
+    return None
+
+
+def _profiles_by_gateway() -> dict:
+    """Map gateway_id -> list of profile ids that select it (adapter_config)."""
+    out: dict[str, list] = {}
+    try:
+        from profiles.manager import get_profile_manager
+        mgr = get_profile_manager()
+        for p in mgr.list_profiles():
+            # list_profiles() returns dicts (see manager.to summary) — be tolerant.
+            pid = p.get('id') if isinstance(p, dict) else getattr(p, 'id', None)
+            adapter = (p.get('adapter_config') if isinstance(p, dict)
+                       else getattr(p, 'adapter_config', {})) or {}
+            gid = adapter.get('gateway_id', 'openclaw')
+            if pid:
+                out.setdefault(gid, []).append(pid)
+    except Exception as exc:
+        logger.debug("profiles-by-gateway lookup failed: %s", exc)
+    return out
+
+
+@admin_bp.route('/api/admin/gateways', methods=['GET'])
+def admin_gateways():
+    """List every registered gateway with the WO-2.1 rich contract + which
+    profiles select it + the active gateway. Powers the Agent Framework tab."""
+    from services.gateway_manager import gateway_manager
+    gateways = gateway_manager.list_gateways(rich=True)
+    by_gateway = _profiles_by_gateway()
+    for gw in gateways:
+        gw['profiles'] = by_gateway.get(gw['id'], [])
+    return jsonify({
+        'gateways': gateways,
+        'active_gateway': _active_gateway_id(),
+    })
+
+
+@admin_bp.route('/api/admin/gateways/<gateway_id>/configure', methods=['POST'])
+def admin_gateway_configure(gateway_id):
+    """Dispatch a configuration change to a framework's configure() (WO-2.2)."""
+    from services.gateway_manager import gateway_manager
+    gw = gateway_manager.get(gateway_id)
+    if gw is None:
+        return jsonify({'error': f"Gateway '{gateway_id}' not registered"}), 404
+    partial = request.get_json(silent=True) or {}
+    try:
+        result = gw.configure(partial)
+    except Exception as exc:
+        logger.error("gateway configure(%s) error: %s", gateway_id, exc)
+        return jsonify({'ok': False, 'error': 'configure failed — see server logs'}), 502
+    status = result.get('status')
+    if status in ('applied', 'needs_restart'):
+        return jsonify({'ok': True, 'status': status,
+                        'message': result.get('detail', ''),
+                        'changes': result.get('changes', [])})
+    return jsonify({'ok': False, 'status': status or 'error',
+                    'error': result.get('detail', 'configure failed')}), 400

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -1081,3 +1081,99 @@ def admin_gateway_configure(gateway_id):
                         'changes': result.get('changes', [])})
     return jsonify({'ok': False, 'status': status or 'error',
                     'error': result.get('detail', 'configure failed')}), 400
+
+
+# ---------------------------------------------------------------------------
+# TTS fallback policy — chain + voice-gender map (WO-3.1)
+# ---------------------------------------------------------------------------
+# The fallback chain + voice-gender map live in config/tts-fallback.json and are
+# read THROUGH services.tts_fallback at runtime (services/tts.py), so an edit
+# here takes effect on the next utterance with no restart. These endpoints are
+# admin-gated by app.py (they live under /api/admin/).
+
+_TTS_FALLBACK_CONFIG_PATH = _PROJECT_ROOT / 'config' / 'tts-fallback.json'
+
+
+def _registered_tts_ids() -> set:
+    """The set of registered TTS provider ids — the only valid chain members."""
+    try:
+        from tts_providers import list_providers
+        ids = set()
+        for p in list_providers(include_inactive=True, probe=False):
+            pid = p.get('provider_id') or p.get('id')
+            if pid:
+                ids.add(pid)
+        return ids
+    except Exception as exc:
+        logger.warning("could not enumerate TTS providers: %s", exc)
+        return set()
+
+
+@admin_bp.route('/api/admin/tts-fallback', methods=['GET'])
+def get_tts_fallback():
+    """Return the current TTS fallback policy + the valid provider id set.
+
+    Response:
+      {"chain": {...}, "voice_gender": {...}, "provider_ids": [...]}
+    """
+    from services.tts_fallback import load_tts_fallback
+    policy = load_tts_fallback()
+    return jsonify({
+        'chain': policy.get('chain', {}),
+        'voice_gender': policy.get('voice_gender', {}),
+        'provider_ids': sorted(_registered_tts_ids()),
+    })
+
+
+@admin_bp.route('/api/admin/tts-fallback', methods=['PUT'])
+def update_tts_fallback():
+    """Replace the TTS fallback policy (config/tts-fallback.json).
+
+    Body: {"chain": {...}, "voice_gender": {...}}
+    Validates every provider id against the live registry and rejects a chain
+    with a cycle BEFORE writing. Writes in place, then invalidates the loader
+    cache so the change is live on the next utterance.
+    """
+    from services.tts_fallback import validate_fallback_policy, invalidate
+
+    data = request.get_json(silent=True) or {}
+    policy = {
+        'chain': data.get('chain', {}),
+        'voice_gender': data.get('voice_gender', {}),
+    }
+
+    valid_ids = _registered_tts_ids()
+    if not valid_ids:
+        return jsonify({'ok': False, 'error': 'TTS provider registry unavailable — '
+                                              'cannot validate fallback chain'}), 503
+
+    err = validate_fallback_policy(policy, valid_ids)
+    if err:
+        return jsonify({'ok': False, 'error': err}), 400
+
+    # Preserve the _comment header if the existing file has one.
+    out = {}
+    try:
+        existing = json.loads(_TTS_FALLBACK_CONFIG_PATH.read_text())
+        if isinstance(existing, dict) and existing.get('_comment'):
+            out['_comment'] = existing['_comment']
+    except Exception:
+        pass
+    out['chain'] = policy['chain']
+    out['voice_gender'] = policy['voice_gender']
+
+    try:
+        # Atomic write — this is a plain repo/config file (NOT the openclaw.json
+        # single-file bind mount), so tmp+rename is safe and preferred here.
+        tmp = _TTS_FALLBACK_CONFIG_PATH.with_suffix('.json.tmp')
+        tmp.write_text(json.dumps(out, indent=2))
+        tmp.replace(_TTS_FALLBACK_CONFIG_PATH)
+    except Exception as exc:
+        logger.error("Failed to write tts-fallback.json: %s", exc)
+        return jsonify({'ok': False, 'error': 'write failed — see server logs'}), 500
+
+    invalidate()  # drop the mtime cache so the next utterance reads the new policy
+    logger.info("TTS fallback policy updated (%d chain hops, %d voices)",
+                len(policy['chain']), len(policy['voice_gender']))
+    return jsonify({'ok': True, 'chain': policy['chain'],
+                    'voice_gender': policy['voice_gender']})

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -1177,3 +1177,202 @@ def update_tts_fallback():
                 len(policy['chain']), len(policy['voice_gender']))
     return jsonify({'ok': True, 'chain': policy['chain'],
                     'voice_gender': policy['voice_gender']})
+
+
+# ---------------------------------------------------------------------------
+# Update manager panel (WO-4.2) — admin-gated wrappers over
+# services/update_manager.py. All live under /api/admin/ so they inherit the
+# admin gate. The app-level /api/version* endpoints stay untouched (the main-app
+# UpdateBanner still uses them); these are the operator-panel surface with an
+# explicit preview → apply → verify → ROLLBACK flow.
+# ---------------------------------------------------------------------------
+
+def _update_manager():
+    from services.update_manager import UpdateManager
+    return UpdateManager(_PROJECT_ROOT)
+
+
+@admin_bp.route('/api/admin/update/status', methods=['GET'])
+def admin_update_status():
+    """Current version + deployment mode. Cheap — reads version.json/package.json
+    and detects deployment type; no git fetch, no network."""
+    try:
+        mgr = _update_manager()
+        version = {}
+        vf = _PROJECT_ROOT / 'version.json'
+        if vf.exists():
+            try:
+                version = json.loads(vf.read_text())
+            except Exception:
+                version = {}
+        pkg_version = ''
+        pf = _PROJECT_ROOT / 'package.json'
+        if pf.exists():
+            try:
+                pkg_version = json.loads(pf.read_text()).get('version', '')
+            except Exception:
+                pass
+        return jsonify({
+            'commit': version.get('commit', 'unknown'),
+            'branch': version.get('branch', 'unknown'),
+            'date': version.get('date', 'unknown'),
+            'version': pkg_version,
+            'deployment_type': mgr.detect_deployment_type(),
+            'is_git_repo': (_PROJECT_ROOT / '.git').is_dir(),
+        })
+    except Exception as exc:
+        logger.error("admin update status failed: %s", exc)
+        return jsonify({'error': 'Failed to read update status'}), 500
+
+
+@admin_bp.route('/api/admin/update/preview', methods=['GET'])
+def admin_update_preview():
+    """Preview what an update WOULD change (git fetch + diff analysis, no
+    mutation). Also reports which CLI agent / smart path would run + risk."""
+    try:
+        return jsonify(_update_manager().get_update_preview())
+    except Exception as exc:
+        logger.error("admin update preview failed: %s", exc)
+        return jsonify({'error': 'Update preview failed — see server logs'}), 500
+
+
+@admin_bp.route('/api/admin/update/verify', methods=['POST'])
+def admin_update_verify():
+    """Run the post-update health checks (import app, parse routes, pip check).
+    Read-only — safe to run any time to confirm the checkout is healthy."""
+    try:
+        return jsonify(_update_manager().verify())
+    except Exception as exc:
+        logger.error("admin update verify failed: %s", exc)
+        return jsonify({'healthy': False, 'errors': ['verify failed — see server logs']}), 500
+
+
+@admin_bp.route('/api/admin/update/apply', methods=['POST'])
+def admin_update_apply():
+    """Apply the intelligent update (analyse → agent/smart → verify → maybe
+    rollback → schedule restart). Guarded by an explicit {"confirm": true} in the
+    body so a stray GET/click can never trigger a live update."""
+    data = request.get_json(silent=True) or {}
+    if data.get('confirm') is not True:
+        return jsonify({'ok': False,
+                        'error': 'confirmation required: POST {"confirm": true}'}), 400
+    try:
+        result = _update_manager().apply_update()
+        ok = result.get('status') in ('success', 'current')
+        return jsonify({'ok': ok, **result}), (200 if ok else 502)
+    except Exception as exc:
+        logger.error("admin update apply failed: %s", exc)
+        return jsonify({'ok': False, 'error': 'Update apply failed — see server logs'}), 500
+
+
+@admin_bp.route('/api/admin/update/rollback', methods=['POST'])
+def admin_update_rollback():
+    """Roll the checkout back to a prior commit (git reset --hard + restore any
+    .pre-update backups). Requires an explicit {"target_commit": "<sha>"} — the
+    panel captures the pre-update commit from /api/admin/update/status and passes
+    it here."""
+    data = request.get_json(silent=True) or {}
+    target = (data.get('target_commit') or '').strip()
+    if not target:
+        return jsonify({'ok': False, 'error': 'target_commit is required'}), 400
+    # Only allow short/long hex SHAs — never an arbitrary ref/command.
+    if not all(c in '0123456789abcdefABCDEF' for c in target) or not (7 <= len(target) <= 40):
+        return jsonify({'ok': False, 'error': 'target_commit must be a git SHA (7-40 hex chars)'}), 400
+    try:
+        mgr = _update_manager()
+        mgr.rollback(target)
+        return jsonify({'ok': True, 'rolled_back_to': target,
+                        'message': 'Rolled back. Restart the app to load the reverted code.'})
+    except Exception as exc:
+        logger.error("admin update rollback failed: %s", exc)
+        return jsonify({'ok': False, 'error': 'Rollback failed — see server logs'}), 500
+
+
+# ---------------------------------------------------------------------------
+# Marketplace update-diff + one-click update (WO-5.1) — thin wrappers over
+# services/plugins.py. Version-diff each installed plugin vs the catalog/GitHub
+# registry; update reuses the install lifecycle (soft-archive + reinstall).
+# ---------------------------------------------------------------------------
+
+@admin_bp.route('/api/admin/plugins/updates', methods=['GET'])
+def admin_plugins_updates():
+    """Per-installed-plugin version diff vs the catalog/registry (update badges)."""
+    try:
+        from services.plugins import get_plugin_updates
+        rows = get_plugin_updates()
+        return jsonify({'plugins': rows,
+                        'update_count': sum(1 for r in rows if r['update_available'])})
+    except Exception as exc:
+        logger.error("plugin updates check failed: %s", exc)
+        return jsonify({'error': 'Failed to check plugin updates'}), 500
+
+
+@admin_bp.route('/api/admin/plugins/<plugin_id>/update', methods=['POST'])
+def admin_plugin_update(plugin_id):
+    """One-click update: soft-archive the current plugin dir + reinstall the
+    catalog/registry version. Rolls back the archive on failure."""
+    from services.plugins import update_plugin, get_plugin
+    if get_plugin(plugin_id) is None:
+        return jsonify({'ok': False, 'error': f"Plugin '{plugin_id}' is not installed"}), 404
+    data = request.get_json(silent=True) or {}
+    config = data.get('config')
+    try:
+        result = update_plugin(plugin_id, config=config)
+    except Exception as exc:
+        logger.error("plugin update(%s) error: %s", plugin_id, exc)
+        return jsonify({'ok': False, 'error': 'Update failed — see server logs'}), 500
+    if result is None:
+        return jsonify({'ok': False, 'error': 'Plugin not installed'}), 404
+    if result.get('_error'):
+        return jsonify({'ok': False, 'error': result['_error']}), 502
+    return jsonify({'ok': True, 'plugin': result.get('name', plugin_id),
+                    'version': result.get('version'),
+                    'updated_from': result.get('_updated_from'),
+                    'status': result.get('_status'),
+                    'note': 'Restart the app (Plugins tab) to activate the updated plugin.'})
+
+
+# ---------------------------------------------------------------------------
+# Greetings editor helpers (WO-4.3) — the greetings blueprint already exposes
+# GET /api/greetings + POST /api/greetings/add; these admin-gated wrappers add
+# the two edit ops a compact editor needs (queue a one-shot next greeting, and
+# remove a contextual entry). List-entry edits, not file deletes.
+# ---------------------------------------------------------------------------
+
+def _greetings_path():
+    from routes.greetings import GREETINGS_PATH
+    return GREETINGS_PATH
+
+
+@admin_bp.route('/api/admin/greetings/queue', methods=['POST'])
+def admin_greetings_queue():
+    """Queue a one-shot 'next_greeting' used at the next session start."""
+    from routes.greetings import _load, _save
+    data = request.get_json(silent=True) or {}
+    greeting = (data.get('greeting') or '').strip()
+    if not greeting:
+        return jsonify({'ok': False, 'error': 'greeting is required'}), 400
+    if len(greeting) > 300:
+        return jsonify({'ok': False, 'error': 'greeting too long (max 300)'}), 400
+    d = _load()
+    d['next_greeting'] = greeting
+    _save(d)
+    return jsonify({'ok': True, 'queued': greeting})
+
+
+@admin_bp.route('/api/admin/greetings/remove-contextual', methods=['POST'])
+def admin_greetings_remove_contextual():
+    """Remove one contextual greeting by exact text (config-list edit)."""
+    from routes.greetings import _load, _save
+    data = request.get_json(silent=True) or {}
+    text = (data.get('greeting') or '').strip()
+    if not text:
+        return jsonify({'ok': False, 'error': 'greeting is required'}), 400
+    d = _load()
+    contextual = d.get('greetings', {}).get('contextual', [])
+    new_list = [g for g in contextual if g != text]
+    if len(new_list) == len(contextual):
+        return jsonify({'ok': False, 'error': 'greeting not found in contextual list'}), 404
+    d['greetings']['contextual'] = new_list
+    _save(d)
+    return jsonify({'ok': True, 'remaining': len(new_list)})

--- a/routes/canvas.py
+++ b/routes/canvas.py
@@ -19,7 +19,7 @@ import mimetypes
 from pathlib import Path
 
 import requests as http_requests
-from flask import Blueprint, Response, jsonify, redirect, request, send_file
+from flask import Blueprint, Response, g, jsonify, redirect, request, send_file
 
 # 3D asset MIME types — without these, send_file falls back to
 # application/octet-stream which (combined with X-Content-Type-Options:nosniff)
@@ -1195,16 +1195,23 @@ def handle_page_metadata(page_id):
         _agent_api_key = os.getenv('AGENT_API_KEY', '').strip()
         is_agent_request = bool(_agent_api_key and request.headers.get('X-Agent-Key') == _agent_api_key)
 
-        # Guard: locked pages — agent cannot change is_public on locked pages.
-        # Admin (Clerk-authenticated) can still change anything, including unlocking.
-        if 'is_public' in data and page.get('is_locked', False) and is_agent_request:
+        # Admin identity — only a Clerk-authenticated admin may lock/unlock pages
+        # or flip visibility on a locked page. Resolve from g.clerk_user_id (set
+        # by require_auth) — never trust the agent key for these mutations.
+        from services.auth import is_admin_user
+        is_admin = is_admin_user(getattr(g, 'clerk_user_id', None))
+
+        # Guard: locked pages — visibility can only be changed by an admin.
+        # The unauthenticated path is already 401'd by require_auth (SEC-2 fix in
+        # app.py); this guard is defense-in-depth and blocks the agent key too.
+        if 'is_public' in data and page.get('is_locked', False) and not is_admin:
             return jsonify({
                 'error': 'This page is locked. Visibility can only be changed from the admin dashboard.',
                 'is_locked': True,
             }), 403
 
-        # Guard: agent cannot lock/unlock pages — only admin can.
-        if 'is_locked' in data and is_agent_request:
+        # Guard: only an admin may lock/unlock pages (never the agent).
+        if 'is_locked' in data and not is_admin:
             return jsonify({
                 'error': 'Page lock status can only be changed from the admin dashboard.',
             }), 403

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -38,7 +38,7 @@ from routes.music import current_music_state as _music_state
 from services.gateway_manager import gateway_manager
 from services.gateways.compat import is_system_response
 from services.tts import generate_tts_b64 as _tts_generate_b64
-from tts_providers import get_provider, list_providers
+from tts_providers import get_provider, list_providers, invalidate as _tts_invalidate
 
 logger = logging.getLogger(__name__)
 
@@ -1787,6 +1787,27 @@ def _conversation_inner():
                     except Exception:
                         _audio_fmt = 'wav'
 
+                    def _detect_audio_fmt(audio_b64):
+                        """Sniff the real container from the audio header (TTS-11).
+
+                        After a sticky/transitive fallback the actual provider can
+                        switch mp3↔wav mid-response; labeling every chunk with the
+                        PRIMARY provider's format then lies and breaks decoding. Read
+                        the magic bytes so each chunk is labeled with what it actually
+                        is. Falls back to the primary provider's format on any doubt.
+                        """
+                        try:
+                            head = base64.b64decode(audio_b64[:32])
+                        except Exception:
+                            return _audio_fmt
+                        if head[:4] == b'RIFF' and head[8:12] == b'WAVE':
+                            return 'wav'
+                        if head[:3] == b'ID3' or (len(head) >= 2 and head[0] == 0xFF and (head[1] & 0xE0) == 0xE0):
+                            return 'mp3'
+                        if head[:4] == b'OggS':
+                            return 'ogg'
+                        return _audio_fmt
+
                     def _tts_error_event(err_str):
                         # CLIENT-FACING RULE (Mike 2026-06-28): never serialize raw provider
                         # name, billing reason, or exception text into a client-bound event.
@@ -1907,12 +1928,12 @@ def _conversation_inner():
                             _run()  # sequential — block until this sentence is done
                         return done, result
 
-                    def _audio_event(audio_b64, chunk_idx, tts_ms=0):
+                    def _audio_event(audio_b64, chunk_idx, tts_ms=0, fmt=None):
                         """Build an audio SSE event dict with gap config."""
                         evt = {
                             'type': 'audio',
                             'audio': audio_b64,
-                            'audio_format': _audio_fmt,
+                            'audio_format': fmt or _detect_audio_fmt(audio_b64),
                             'chunk': chunk_idx,
                             'total_chunks': None,
                             'timing': {
@@ -2111,9 +2132,12 @@ def _conversation_inner():
                                 if tts_text_interim and tts_text_interim.strip():
                                     _tts_pending.append(_fire_tts(tts_text_interim))
 
-                            # Flush all pending TTS audio immediately
+                            # Flush all pending TTS audio immediately. Bounded per-chunk
+                            # wait (TTS-2) so a hung provider can't stall the interim
+                            # flush; a failed chunk is skipped, not fatal (already if/elif).
+                            _interim_timeout = int(os.getenv('TTS_SENTENCE_TIMEOUT', '20'))
                             for _done_i, _res_i in _tts_pending:
-                                _done_i.wait(timeout=30)
+                                _done_i.wait(timeout=_interim_timeout)
                                 if _res_i.get('error'):
                                     yield _tts_error_event(_res_i['error'])
                                 elif _res_i.get('audio'):
@@ -2804,17 +2828,46 @@ def _conversation_inner():
 
                             t_tts_start = time.time()
                             total_chunks = _chunks_sent + len(_tts_pending)
-                            tts_ok = True
+                            # TTS-2 / TTS-8: a hung provider must NOT head-of-line-block
+                            # the ordered flush, and one chunk's error/timeout must NOT
+                            # discard the already-generated (paid) chunks behind it.
+                            # First pass: wait a bounded per-chunk timeout; deliver ready
+                            # audio, skip errors, and defer any chunk whose provider is
+                            # still hung. Second pass: give the deferred chunks a short
+                            # grace and deliver any that landed (out of order beats
+                            # silence). Never silently drop paid audio — log the rest.
+                            _tts_sentence_timeout = int(os.getenv('TTS_SENTENCE_TIMEOUT', '20'))
+                            _tts_deferred_grace = int(os.getenv('TTS_DEFERRED_GRACE', '10'))
+                            _deferred = []
                             for i, (done_evt, res) in enumerate(_tts_pending):
-                                done_evt.wait(timeout=30)
-                                if res['error']:
+                                if done_evt.wait(timeout=_tts_sentence_timeout):
+                                    if res['error']:
+                                        metrics['tts_success'] = 0
+                                        metrics['tts_error'] = res['error']
+                                        yield _tts_error_event(res['error'])
+                                        continue  # skip only the failed chunk, keep flushing
+                                    if res['audio']:
+                                        yield _audio_event(res['audio'], _chunks_sent + i, tts_ms=int((time.time() - t_tts_start) * 1000))
+                                else:
+                                    logger.warning(
+                                        f"### TTS chunk {i} not ready after "
+                                        f"{_tts_sentence_timeout}s — skipping ahead (provider hung)"
+                                    )
+                                    _deferred.append((i, done_evt, res))
+                            # Second pass — deliver late-completing chunks if they land.
+                            for i, done_evt, res in _deferred:
+                                if done_evt.wait(timeout=_tts_deferred_grace):
+                                    if res['error']:
+                                        yield _tts_error_event(res['error'])
+                                    elif res['audio']:
+                                        logger.info(f"### TTS chunk {i} completed late — delivering")
+                                        yield _audio_event(res['audio'], _chunks_sent + i, tts_ms=int((time.time() - t_tts_start) * 1000))
+                                else:
                                     metrics['tts_success'] = 0
-                                    metrics['tts_error'] = res['error']
-                                    yield _tts_error_event(res['error'])
-                                    tts_ok = False
-                                    break
-                                if res['audio']:
-                                    yield _audio_event(res['audio'], _chunks_sent + i, tts_ms=int((time.time() - t_tts_start) * 1000))
+                                    logger.error(
+                                        f"### TTS chunk {i} never completed within grace — "
+                                        f"audio not delivered (provider hung); paid generation logged, not discarded"
+                                    )
 
                             metrics['tts_generation_ms'] = int((time.time() - t_tts_start) * 1000)
                             metrics['tts_text_len'] = metrics['response_len']
@@ -3269,7 +3322,7 @@ def session_reset():
 def tts_providers_list():
     """List all available TTS providers with metadata."""
     try:
-        providers = list_providers(include_inactive=True)
+        providers = list_providers(include_inactive=True, probe=True)
         config_path = (Path(__file__).parent.parent
                        / 'tts_providers' / 'providers_config.json')
         default_provider = 'supertonic'
@@ -3352,6 +3405,10 @@ def tts_set_default_provider():
         except Exception as e:
             return jsonify({'ok': False, 'error': f'failed to write config: {e}'}), 500
 
+        # Drop the cached config + provider singletons so the next generate
+        # picks up the new default without a restart.
+        _tts_invalidate()
+
         logger.info(
             f'TTS default provider changed: {old_default} → {provider_id}'
         )
@@ -3420,6 +3477,9 @@ def tts_set_default_voice():
             os.replace(tmp_path, config_path)
         except Exception as e:
             return jsonify({'ok': False, 'error': f'failed to write config: {e}'}), 500
+
+        # Drop the cached config so the next read reflects the new voice order.
+        _tts_invalidate()
 
         logger.info(f'TTS default voice for {provider_id} → {voice}')
         return jsonify({
@@ -3693,7 +3753,10 @@ def tts_voices_list():
     """List all available voices across all providers, including cloned voices."""
     try:
         all_voices = {}
-        for provider_info in list_providers(include_inactive=False):
+        # probe=True: this is an explicit UI voice-list request, so instantiate
+        # cached singletons to surface live cloned_voices (a get_info() field the
+        # config catalog doesn't carry).
+        for provider_info in list_providers(include_inactive=False, probe=True):
             pid = provider_info.get('provider_id', provider_info.get('name', 'unknown'))
             voices = provider_info.get('voices', [])
             cloned = provider_info.get('cloned_voices', [])

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -3280,15 +3280,31 @@ def conversation_reset():
 
 
 # ---------------------------------------------------------------------------
-# POST /api/session/reset  — manual session reset from UI actions panel
+# POST /api/session/reset-openclaw  — deep reset that also clears the openclaw
+# session JSONL (ADMIN-BUG-2, 2026-07-11)
 # ---------------------------------------------------------------------------
-
-@conversation_bp.route('/api/session/reset', methods=['POST'])
+# HISTORY / ADMIN-BUG-2: this handler was originally registered on
+# '/api/session/reset', the SAME path as server.py's soft/hard reset handler
+# (server.py `session_reset`). Because conversation_bp is registered before the
+# server.py @app.route is defined, Werkzeug matched THIS blueprint rule first —
+# silently shadowing server.py's mode-aware (soft/hard + pre-warm) handler that
+# SessionControl.js / the admin Health panel actually drive (they POST
+# {"mode": "soft"|"hard"} and read back `mode`). Worse, the openclaw-session-file
+# path below (`/home/node/.openclaw/...`) lives inside the OPENCLAW container, so
+# from the openvoiceui container it never exists — the try/except swallowed the
+# miss and this handler degraded to "bump the key" while blocking the richer one.
+#
+# FIX (additive, no deletion): this route is moved to the explicit, distinct
+# '/api/session/reset-openclaw' path. `/api/session/reset` is now unambiguously
+# served by server.py's canonical soft/hard handler. Both remain reachable; the
+# deep openclaw-file clear is opt-in via the new path.
+@conversation_bp.route('/api/session/reset-openclaw', methods=['POST'])
 def session_reset():
     """Clear the corrupted openclaw session state and return a fresh session key.
-    Called by the Reset button in the UI actions panel.
-    Clears the openclaw session JSONL file so orphaned messages don't cascade,
-    then bumps the voice session key so the next request starts completely fresh."""
+    Deep reset (opt-in): clears the openclaw session JSONL file so orphaned
+    messages don't cascade, then bumps the voice session key so the next request
+    starts completely fresh. The default /api/session/reset (server.py) handles
+    the common soft/hard reset."""
     old_key = get_voice_session_key()
     # Find and clear the openclaw session file for the current session key
     try:

--- a/routes/music.py
+++ b/routes/music.py
@@ -864,7 +864,20 @@ def delete_track(playlist, filename):
     if not track_path.exists():
         return jsonify({"error": "Track not found"}), 404
 
-    track_path.unlink()
+    # Soft-delete: rename to a .deleted sibling instead of hard-removing (NEVER-DELETE
+    # house rule — matches routes/suno.py delete_song + routes/workspace.py). The
+    # .deleted suffix is not in the music-extension whitelist the list endpoints scan,
+    # so archived tracks are excluded automatically. Collision-safe: if a .deleted
+    # target already exists, append a timestamp so no prior archive is clobbered.
+    renamed = track_path.with_suffix(track_path.suffix + ".deleted")
+    if renamed.exists():
+        renamed = track_path.with_suffix(track_path.suffix + f".{int(time.time())}.deleted")
+    try:
+        track_path.rename(renamed)
+        print(f"🎵 Archived track: {safe_filename} -> {renamed.name}")
+    except Exception as e:
+        print(f"Error archiving track {safe_filename}: {e}")
+        return jsonify({"error": str(e)}), 500
 
     # Remove from metadata if present
     metadata = load_meta()

--- a/routes/registry.py
+++ b/routes/registry.py
@@ -47,13 +47,19 @@ def registry_checkin():
     status_icon  = "&#10004;" if is_healthy else "&#9888;"
     status_color = "#4ade80" if is_healthy else "#fbbf24"
 
-    # Pass values to JS safely via JSON encoding
+    # HTML-escape user-controlled params before interpolating into the page
+    # (SEC-4 reflected XSS: `repo` was interpolated raw into the HTML below).
+    import markupsafe
+    repo_safe = markupsafe.escape(repo)
+
+    # Pass values to JS safely via JSON encoding. Escape '<' so a `repo`
+    # containing '</script>' can't break out of the inline script tag.
     js_config = json.dumps({
         'returnUrl': return_url,
         'registry':  registry,
         'appSlug':   app_slug,
         'repo':      repo,
-    })
+    }).replace('<', '\\u003c')
 
     html = f'''<!DOCTYPE html>
 <html lang="en">
@@ -141,7 +147,7 @@ def registry_checkin():
         </div>
         <div class="status-row">
             <span class="label">Repository</span>
-            <span class="value">{repo}</span>
+            <span class="value">{repo_safe}</span>
         </div>
 
         <div id="status-msg">Completing check-in&hellip;</div>

--- a/routes/services.py
+++ b/routes/services.py
@@ -1,0 +1,346 @@
+"""
+Service Catalog API (WO-1.2 / Part C.1).
+
+ADMIN-ONLY. Aggregates every configurable "service" — agent-framework gateway,
+LLM, TTS, STT — into one descriptor shape so the admin panel becomes a renderer
+over the catalog instead of hardcoding providers:
+
+    {
+      "service": "gateway|llm|tts|stt",
+      "id": "hermes",
+      "name": "Hermes Agent",
+      "source": "builtin|plugin:<id>",
+      "capabilities": ["streaming", "steer", ...],
+      "config_schema": {"fields": [...]},
+      "credentials": ["hermes_api_key"],
+      "health": {"healthy": bool, "latency_ms": float|None, "status": "..."},
+      "restart_scope": "none|ovui|container:<name>"
+    }
+
+Endpoints
+  GET /api/services/catalog  — full descriptor list + credential_status map
+  GET /api/services/health   — per-service health (cheap probes only)
+
+SECURITY: both are gated by app.py require_auth() — '/api/services/' is in the
+admin-only prefix set. NO secret values ever appear in the output (credential
+status is has_value booleans + masked hints only). Health probes are cheap
+(gateway socket, TTS singleton flags) — NEVER a vendor API call.
+"""
+
+import logging
+import os
+
+from flask import Blueprint, jsonify
+
+logger = logging.getLogger(__name__)
+
+services_bp = Blueprint('services', __name__)
+
+
+# ---------------------------------------------------------------------------
+# Source + credential mapping helpers
+# ---------------------------------------------------------------------------
+
+_BUILTIN_GATEWAYS = {'openclaw'}
+# gateway_id -> plugin id (for the "source" field)
+_GATEWAY_PLUGIN = {
+    'hermes': 'hermes-agent',
+    'hermes-bridge': 'hermes-agent',
+}
+_GATEWAY_NAMES = {
+    'openclaw': 'OpenClaw',
+    'hermes': 'Hermes Agent',
+    'hermes-bridge': 'Hermes Bridge (delegation)',
+}
+
+# Best-effort env-var credential per TTS provider (no secret values are read —
+# only the NAME of the env var / whether a value is present).
+_TTS_CRED_ENV = {
+    'groq': 'GROQ_API_KEY',
+    'elevenlabs': 'ELEVENLABS_API_KEY',
+    'resemble': 'RESEMBLE_API_KEY',
+    'hume': 'HUME_API_KEY',
+    'qwen3': 'FAL_KEY',
+    'qwen3-local': '',
+    'supertonic': '',
+}
+
+# STT providers derived from the live /api/stt/* handlers (server.py) + the
+# providers.registry STT registrations. webspeech is client-side (browser).
+_STT_STATIC = {
+    'webspeech': {
+        'name': 'Web Speech API', 'source': 'builtin',
+        'creds': [], 'note': 'Browser-native (Chrome/Edge). No server key.',
+    },
+    'deepgram': {
+        'name': 'Deepgram', 'source': 'builtin',
+        'creds': ['DEEPGRAM_API_KEY'], 'note': 'Cloud streaming STT (/api/stt/deepgram).',
+    },
+    'groq_whisper': {
+        'name': 'Groq Whisper', 'source': 'builtin',
+        'creds': ['GROQ_API_KEY'], 'note': 'Groq whisper-large (/api/stt/groq).',
+    },
+    'whisper': {
+        'name': 'Whisper (local)', 'source': 'builtin',
+        'creds': [], 'note': 'faster-whisper on-box (/api/stt/local).',
+    },
+    'external': {
+        'name': 'External STT', 'source': 'builtin',
+        'creds': ['STT_API_URL', 'STT_API_KEY'],
+        'note': 'Bring-your-own Whisper-compatible API (/api/stt/external).',
+    },
+}
+
+
+def _current_username() -> str:
+    domain = os.getenv('DOMAIN', '')
+    if domain and '.jam-bot.com' in domain:
+        return domain.split('.')[0]
+    return os.getenv('VAULT_USERNAME', 'default')
+
+
+def _env_present(name: str) -> bool:
+    return bool(name and os.environ.get(name, '').strip())
+
+
+# ---------------------------------------------------------------------------
+# Per-service descriptor builders
+# ---------------------------------------------------------------------------
+
+def _gateway_descriptors() -> list:
+    """Agent-framework gateways via the WO-2.1 rich contract."""
+    from services.gateway_manager import gateway_manager
+    out = []
+    for gw in gateway_manager.list_gateways(rich=True):
+        gid = gw['id']
+        plugin = _GATEWAY_PLUGIN.get(gid)
+        source = 'builtin' if gid in _BUILTIN_GATEWAYS else (
+            f'plugin:{plugin}' if plugin else f'plugin:{gid}')
+        health = gw.get('health', {})
+        out.append({
+            'service': 'gateway',
+            'id': gid,
+            'name': _GATEWAY_NAMES.get(gid, gid),
+            'source': source,
+            'capabilities': gw.get('capabilities', []),
+            'config_schema': gw.get('config_schema', {'fields': []}),
+            'credentials': gw.get('credentials', []),
+            'health': {
+                'healthy': bool(gw.get('healthy')),
+                'latency_ms': health.get('latency_ms'),
+                'configured': bool(gw.get('configured')),
+            },
+            'restart_scope': gw.get('restart_scope', 'none'),
+            'persistent': gw.get('persistent', False),
+        })
+    return out
+
+
+def _tts_descriptors() -> list:
+    """TTS providers from the tts_providers registry (network-free path)."""
+    from tts_providers import list_providers
+    out = []
+    try:
+        provs = list_providers(include_inactive=True, probe=False)
+    except Exception as exc:
+        logger.warning("TTS catalog build failed: %s", exc)
+        return out
+    for info in provs:
+        pid = info.get('provider_id') or info.get('id') or ''
+        env = _TTS_CRED_ENV.get(pid, '')
+        requires_key = bool(info.get('requires_api_key'))
+        fields = []
+        creds = []
+        if requires_key and env:
+            fields.append({'id': env, 'type': 'password',
+                           'label': f"{info.get('name', pid)} API key",
+                           'required': True, 'credential': env})
+            creds.append(env)
+        out.append({
+            'service': 'tts',
+            'id': pid,
+            'name': info.get('name', pid),
+            'source': 'builtin',
+            'capabilities': ['tts'] + (['clone'] if 'clone' in (info.get('features') or []) else []),
+            'config_schema': {'fields': fields, 'editable': bool(fields)},
+            'credentials': creds,
+            'health': {
+                'healthy': info.get('status', 'active') == 'active',
+                'latency_ms': None,
+                'status': info.get('status', 'active'),
+                'has_key': (_env_present(env) if requires_key else True),
+            },
+            'restart_scope': 'none',
+            'meta': {
+                'cost_per_minute': info.get('cost_per_minute'),
+                'latency': info.get('latency'),
+                'requires_api_key': requires_key,
+            },
+        })
+    return out
+
+
+def _stt_registry_ids() -> set:
+    """STT provider ids known to providers.registry (wired at startup, WO-1.3)."""
+    try:
+        from providers.registry import registry, ProviderType
+        return set(registry.registered_ids(ProviderType.STT))
+    except Exception as exc:
+        logger.debug("STT registry unavailable: %s", exc)
+        return set()
+
+
+def _stt_descriptors() -> list:
+    """STT catalog: live /api/stt/* handlers + providers.registry (WO-1.3)."""
+    registry_ids = _stt_registry_ids()
+    out = []
+    for sid, meta in _STT_STATIC.items():
+        creds = meta['creds']
+        fields = [{'id': c, 'type': ('password' if 'KEY' in c else 'text'),
+                   'label': c, 'required': (c.endswith('_URL')),
+                   'credential': c} for c in creds]
+        # has_key: all referenced env vars present (or none required)
+        has_key = all(_env_present(c) for c in creds) if creds else True
+        in_registry = sid in registry_ids or (
+            sid == 'groq_whisper' and 'groq' in registry_ids)
+        out.append({
+            'service': 'stt',
+            'id': sid,
+            'name': meta['name'],
+            'source': meta['source'],
+            'capabilities': ['stt'],
+            'config_schema': {'fields': fields, 'editable': bool(fields)},
+            'credentials': creds,
+            'health': {
+                'healthy': has_key,
+                'latency_ms': None,
+                'has_key': has_key,
+                'in_registry': in_registry,
+            },
+            'restart_scope': 'none',
+            'meta': {'note': meta['note']},
+        })
+    return out
+
+
+def _llm_descriptors() -> list:
+    """LLM providers from the loadable catalog (config/ai-providers.json)."""
+    from services.ai_providers import load_ai_providers
+    out = []
+    for pid, pinfo in load_ai_providers().items():
+        env = pinfo.get('envKey', '')
+        fields = []
+        creds = []
+        if env:
+            fields.append({'id': env, 'type': 'password',
+                           'label': f"{pinfo.get('name', pid)} API key",
+                           'required': False, 'credential': env})
+            creds.append(env)
+        out.append({
+            'service': 'llm',
+            'id': pid,
+            'name': pinfo.get('name', pid),
+            'source': 'builtin',
+            'capabilities': ['llm'],
+            'config_schema': {'fields': fields, 'editable': bool(fields)},
+            'credentials': creds,
+            'health': {
+                'healthy': _env_present(env) if env else True,
+                'latency_ms': None,
+                'has_key': _env_present(env) if env else True,
+            },
+            # LLM keys apply hot through the gateway config.patch RPC.
+            'restart_scope': 'none',
+            'meta': {
+                'baseUrl': pinfo.get('baseUrl'),
+                'api': pinfo.get('api'),
+                'models': pinfo.get('models', []),
+            },
+        })
+    return out
+
+
+def _credential_status() -> dict:
+    """Vault credential status keyed by cred_id — has_value + name only.
+
+    NO secret values. references keys the descriptors point at so the panel can
+    render a 'set / not set' chip. Best-effort — returns {} if the vault module
+    or client can't be resolved.
+    """
+    try:
+        from services.vault import get_credentials_status
+        rows = get_credentials_status(_current_username())
+    except Exception as exc:
+        logger.debug("credential status unavailable: %s", exc)
+        return {}
+    status = {}
+    for row in rows:
+        status[row.get('id')] = {
+            'name': row.get('name'),
+            'group': row.get('group'),
+            'has_value': bool(row.get('has_value')),
+            'env_var': row.get('env_var', ''),
+        }
+    return status
+
+
+def build_catalog() -> dict:
+    """Assemble the full Service Catalog (all four service types)."""
+    services = []
+    services.extend(_gateway_descriptors())
+    services.extend(_llm_descriptors())
+    services.extend(_tts_descriptors())
+    services.extend(_stt_descriptors())
+    return {
+        'services': services,
+        'credential_status': _credential_status(),
+        'counts': {
+            'gateway': sum(1 for s in services if s['service'] == 'gateway'),
+            'llm': sum(1 for s in services if s['service'] == 'llm'),
+            'tts': sum(1 for s in services if s['service'] == 'tts'),
+            'stt': sum(1 for s in services if s['service'] == 'stt'),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Routes (admin-gated by app.py)
+# ---------------------------------------------------------------------------
+
+@services_bp.route('/api/services/catalog', methods=['GET'])
+def services_catalog():
+    """Full Service Catalog — descriptors for every gateway/llm/tts/stt."""
+    try:
+        return jsonify(build_catalog())
+    except Exception as exc:
+        logger.error("services/catalog failed: %s", exc)
+        return jsonify({'error': 'Failed to build service catalog'}), 500
+
+
+@services_bp.route('/api/services/health', methods=['GET'])
+def services_health():
+    """Per-service health with latency where cheap. No vendor API calls."""
+    try:
+        catalog = build_catalog()
+    except Exception as exc:
+        logger.error("services/health failed: %s", exc)
+        return jsonify({'error': 'Failed to probe service health'}), 500
+
+    health = []
+    for s in catalog['services']:
+        h = s.get('health', {})
+        health.append({
+            'service': s['service'],
+            'id': s['id'],
+            'name': s['name'],
+            'healthy': bool(h.get('healthy')),
+            'latency_ms': h.get('latency_ms'),
+            'detail': {k: v for k, v in h.items()
+                       if k not in ('healthy', 'latency_ms')},
+        })
+    healthy_count = sum(1 for h in health if h['healthy'])
+    return jsonify({
+        'services': health,
+        'summary': {'total': len(health), 'healthy': healthy_count,
+                    'unhealthy': len(health) - healthy_count},
+    })

--- a/routes/suno.py
+++ b/routes/suno.py
@@ -1572,7 +1572,15 @@ def _submit_process_job(endpoint: str, request_body: dict, kind: str,
 def suno_callback():
     """Webhook from sunoapi.org — downloads song and queues frontend notification."""
     try:
-        # Verify HMAC signature when a webhook secret is configured
+        # Verify HMAC signature when a webhook secret is configured.
+        # NOTE: SUNO_WEBHOOK_SECRET is NOT provisioned in the fleet .env template
+        # yet (verified 2026-07-11), so we cannot fail-closed without breaking
+        # every tenant's song delivery. Until the secret is provisioned
+        # fleet-wide, an unsigned callback is accepted but constrained: the
+        # download is SSRF-checked, restricted to https, and hard-capped at
+        # SUNO_MAX_DOWNLOAD_BYTES (50 MB). TODO: add SUNO_WEBHOOK_SECRET to
+        # templates/.env then flip this to a 503 fail-closed.
+        _require_https = not SUNO_WEBHOOK_SECRET
         if SUNO_WEBHOOK_SECRET:
             sig_header = request.headers.get('X-Suno-Signature', '')
             payload = request.get_data()
@@ -1580,6 +1588,12 @@ def suno_callback():
             if not hmac.compare_digest(sig_header, expected):
                 logger.warning('Suno callback rejected: invalid signature')
                 return jsonify({'status': 'forbidden'}), 403
+        else:
+            logger.warning(
+                'Suno callback accepted UNSIGNED — SUNO_WEBHOOK_SECRET not configured. '
+                'Download restricted to https + %d byte cap. Provision the secret '
+                'fleet-wide to fail closed.', SUNO_MAX_DOWNLOAD_BYTES
+            )
 
         data = request.json or {}
         logger.info(f'Suno callback: {json.dumps(data, indent=2)[:500]}')
@@ -1639,6 +1653,10 @@ def suno_callback():
 
                     if audio_url and not save_path.exists():
                         if not _is_safe_download_url(audio_url):
+                            continue
+                        # Unsigned callbacks: only https audio URLs are allowed.
+                        if _require_https and not audio_url.lower().startswith('https://'):
+                            logger.warning('Unsigned Suno callback: rejecting non-https audioUrl')
                             continue
                         try:
                             audio_resp = http_requests.get(audio_url, timeout=60, stream=True)

--- a/routes/vault.py
+++ b/routes/vault.py
@@ -85,11 +85,18 @@ def update_credential(cred_id):
 
     # Handle model selection update
     if cred_id == '_model_selection':
-        set_model_selection(
+        result = set_model_selection(
             username,
             primary=data.get('primary'),
             fallback=data.get('fallback'),
         )
+        # set_model_selection now returns {'ok': bool, 'error': str} — honor a
+        # real write failure instead of always reporting success (ADMIN-BUG-1).
+        if isinstance(result, dict) and not result.get('ok'):
+            return jsonify({
+                'ok': False,
+                'message': result.get('error', 'Model selection update failed'),
+            }), 500
         return jsonify({'ok': True, 'message': 'Model selection updated'})
 
     value = data.get('value')

--- a/server.py
+++ b/server.py
@@ -236,6 +236,23 @@ app.register_blueprint(vault_bp)
 from routes.identity import identity_bp
 app.register_blueprint(identity_bp)
 
+from routes.services import services_bp
+app.register_blueprint(services_bp)
+
+# WO-1.3 — wire the STT provider registry. autodiscover() loads
+# config/providers.yaml and imports the STT provider modules so their
+# registry.register() calls fire; the Service Catalog then reads STT ids from
+# the SAME registry consumed by /api/stt/*. LLM entries in the yaml are
+# DEPRECATED (see providers/llm/DEPRECATED.md) — importing them registers
+# classes with zero call sites, harmless. Failure is non-fatal: the STT catalog
+# falls back to the static handler-derived list.
+try:
+    from providers.registry import registry as _provider_registry
+    _provider_registry.autodiscover()
+    logger.info("Provider registry autodiscover complete (STT wired).")
+except Exception as _e:
+    logger.warning(f"Provider registry autodiscover failed (non-critical): {_e}")
+
 from services.plugins import load_plugins
 load_plugins(app)
 

--- a/server.py
+++ b/server.py
@@ -1605,27 +1605,65 @@ def _tts_bytes(text: str) -> bytes:
 # and calls push_proactive_message() — closing the "I'll let you know when
 # it's done" loop that previously never fired.
 
+# ws -> outbound queue.Queue. flask_sock's ws.send() is NOT thread-safe, so
+# proactive pushes (generated on the gateway daemon thread) must NOT call
+# ws.send() directly while the socket's own bridge loop is also writing
+# (keepalives, TTS) — interleaved frames corrupt the push channel (WS-2).
+# Instead every producer ENQUEUES here; each /ws/clawdbot connection's own
+# writer coroutine is the ONLY thread that touches its ws.send().
 _push_clients_lock = threading.Lock()
-_push_clients: set = set()
+_push_clients: dict = {}          # ws -> queue.Queue
+_push_client_session: dict = {}   # ws -> last sessionKey the browser declared (WS-9)
+_push_receipt_lock = threading.Lock()  # serialize JSONL appends (WS-10)
 
 
 def _register_push_client(ws):
+    """Register a browser socket and return its outbound queue."""
+    q = queue.Queue()
     with _push_clients_lock:
-        _push_clients.add(ws)
-    logger.info(f"Proactive push: client registered ({len(_push_clients)} connected)")
+        _push_clients[ws] = q
+        n = len(_push_clients)
+    logger.info(f"Proactive push: client registered ({n} connected)")
+    return q
 
 
 def _unregister_push_client(ws):
     with _push_clients_lock:
-        _push_clients.discard(ws)
+        q = _push_clients.pop(ws, None)
+        _push_client_session.pop(ws, None)
+    if q is not None:
+        # Wake the socket's writer so it can observe the shutdown and exit.
+        try:
+            q.put_nowait(None)
+        except Exception:
+            pass
+
+
+def _push_queue_for(ws):
+    with _push_clients_lock:
+        return _push_clients.get(ws)
+
+
+def _note_push_client_session(ws, session_key):
+    """Record the sessionKey a browser is working under so proactive pushes
+    can be scoped to the right tab (WS-9)."""
+    if not session_key:
+        return
+    with _push_clients_lock:
+        if ws in _push_clients:
+            _push_client_session[ws] = session_key
 
 
 def push_proactive_message(text: str, session_key: str = None):
-    """Broadcast an agent-initiated message to all connected browsers.
+    """Broadcast an agent-initiated message to connected browsers.
 
     Called from a daemon thread (gateway loop side) — no Flask context.
     The raw text (with [CANVAS:...] etc. action tags intact) is sent so the
     client can dispatch the tags; TTS is generated from the tag-stripped text.
+
+    Delivery is scoped (WS-9): if this frame carries a sessionKey AND a client
+    has declared one, it is delivered only on a match; a client that never
+    declared a sessionKey receives everything (backward compatible).
     """
     spoken = re.sub(r'\[[A-Z_]+(?::[^\]]*)?\]', '', text).strip()
     audio_b64 = None
@@ -1642,35 +1680,44 @@ def push_proactive_message(text: str, session_key: str = None):
         "ts": time.time(),
     })
     with _push_clients_lock:
-        clients = list(_push_clients)
-    if not clients:
+        targets = list(_push_clients.items())
+        sessions = dict(_push_client_session)
+    if not targets:
         logger.warning("Proactive push: no connected browsers — message not delivered "
                        f"(text: {text[:100]})")
         return
     delivered = 0
-    for client in clients:
+    for ws, q in targets:
+        reg_key = sessions.get(ws)
+        if session_key and reg_key and reg_key != session_key:
+            continue  # WS-9: this push belongs to a different session/tab
         try:
-            client.send(frame)
+            q.put_nowait(frame)
             delivered += 1
         except Exception:
-            _unregister_push_client(client)
-    logger.info(f"Proactive push: delivered to {delivered}/{len(clients)} clients")
-    _write_push_receipt(text, session_key, delivered, len(clients))
+            _unregister_push_client(ws)
+    logger.info(f"Proactive push: enqueued to {delivered}/{len(targets)} clients")
+    _write_push_receipt(text, session_key, delivered, len(targets))
 
 
 def _write_push_receipt(text, session_key, delivered, clients):
     """Durable, host-visible receipt of every proactive push (bind-mounted
-    transcripts dir) — drives the JamFlow board signal and survives restarts."""
+    transcripts dir) — drives the JamFlow board signal and survives restarts.
+    Multiple proactive-push threads can append concurrently, so serialize the
+    write under a module lock — interleaved partial lines corrupt the JSONL
+    the JamFlow board reads (WS-10)."""
     try:
         receipt_path = Path("/app/runtime/transcripts/.proactive-push.jsonl")
-        with open(receipt_path, "a") as f:
-            f.write(json.dumps({
-                "ts": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "session_key": session_key,
-                "delivered": delivered,
-                "clients": clients,
-                "text": text[:300],
-            }) + "\n")
+        line = json.dumps({
+            "ts": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "session_key": session_key,
+            "delivered": delivered,
+            "clients": clients,
+            "text": text[:300],
+        }) + "\n"
+        with _push_receipt_lock:
+            with open(receipt_path, "a") as f:
+                f.write(line)
     except Exception as e:
         logger.debug(f"Proactive push receipt write failed: {e}")
 
@@ -1739,12 +1786,27 @@ def clawdbot_websocket(ws):
     # this socket — delivery is independent of the gateway bridge below.
     _register_push_client(ws)
 
+    # Outbound queue for THIS socket. Every frame written to the browser —
+    # gateway relays, keepalives, and proactive pushes — goes through here and
+    # is drained by the single _writer() coroutine below, which is the only
+    # thread that ever calls ws.send() (WS-2).
+    out_q = _push_queue_for(ws)
+
     async def _run():
+        loop = asyncio.get_running_loop()
+
+        def _enqueue(frame):
+            try:
+                out_q.put_nowait(frame)
+            except Exception:
+                pass
+
         try:
             async with websockets.connect(gateway_url) as gw:
                 logger.info(f"WebSocket connected to Gateway at {gateway_url}")
 
-                # Handshake
+                # Handshake — these pre-writer sends are safe: no other thread
+                # writes ws until _writer() starts (push only ENQUEUES).
                 challenge = json.loads(await asyncio.wait_for(gw.recv(), timeout=10.0))
                 logger.debug(f"Gateway challenge: {challenge.get('event')}")
 
@@ -1772,15 +1834,31 @@ def clawdbot_websocket(ws):
                     return
 
                 logger.info("Gateway handshake OK")
-                ws.send(json.dumps({"type": "connected", "message": "Connected to OpenClaw Gateway"}))
+                _enqueue(json.dumps({"type": "connected", "message": "Connected to OpenClaw Gateway"}))
+
+                async def _writer():
+                    """The ONLY writer to ws. Drains the per-client outbound
+                    queue so flask_sock's non-thread-safe send() is never
+                    called from two threads (WS-2)."""
+                    while True:
+                        frame = await loop.run_in_executor(None, out_q.get)
+                        if frame is None:  # shutdown sentinel
+                            break
+                        try:
+                            ws.send(frame)
+                        except Exception:
+                            break
 
                 async def _from_client():
                     while True:
-                        msg = ws.receive()
+                        # run_in_executor so blocking ws.receive() doesn't
+                        # starve _from_gateway() while the socket is idle (WS-3).
+                        msg = await loop.run_in_executor(None, ws.receive)
                         if not msg:
                             break
                         data = json.loads(msg)
                         if data.get("type") == "chat.send":
+                            _note_push_client_session(ws, data.get("sessionKey"))
                             await gw.send(json.dumps({
                                 "type": "req",
                                 "id": f"chat-{uuid.uuid4()}",
@@ -1799,10 +1877,7 @@ def clawdbot_websocket(ws):
                             # Idle is normal — keep both legs alive. The browser
                             # socket doubles as the proactive-push channel, so it
                             # must survive long silences (nginx idle timeouts too).
-                            try:
-                                ws.send(json.dumps({"type": "keepalive", "ts": time.time()}))
-                            except Exception:
-                                return  # browser gone — end the bridge
+                            _enqueue(json.dumps({"type": "keepalive", "ts": time.time()}))
                             continue
                         if data.get("type") != "event":
                             continue
@@ -1813,35 +1888,61 @@ def clawdbot_websocket(ws):
                             content = payload.get("content", "")
                             if content:
                                 try:
-                                    audio_b64 = base64.b64encode(_tts_bytes(content)).decode()
-                                    ws.send(json.dumps({
+                                    # Offload blocking TTS so it doesn't stall
+                                    # keepalives/frames on this loop (WS-5).
+                                    raw = await loop.run_in_executor(None, _tts_bytes, content)
+                                    audio_b64 = base64.b64encode(raw).decode()
+                                    _enqueue(json.dumps({
                                         "type": "assistant_message",
                                         "text": content,
                                         "audio": audio_b64,
                                     }))
                                 except Exception as e:
                                     logger.error(f"TTS failed in WebSocket handler: {e}")
-                                    ws.send(json.dumps({"type": "assistant_message", "text": content}))
+                                    _enqueue(json.dumps({"type": "assistant_message", "text": content}))
 
                         elif event == "agent.stream.delta":
-                            ws.send(json.dumps({
+                            _enqueue(json.dumps({
                                 "type": "text_delta",
                                 "delta": payload.get("delta", ""),
                             }))
 
                         elif event == "agent.stream.end":
-                            ws.send(json.dumps({"type": "stream_end"}))
+                            _enqueue(json.dumps({"type": "stream_end"}))
 
-                await asyncio.gather(_from_client(), _from_gateway())
+                # WS-8: stop as soon as ANY leg ends; cancel the survivors.
+                # An executor-blocked ws.receive()/out_q.get() can't be
+                # cancelled directly — the None sentinel unblocks the writer and
+                # exiting the `async with` (closing gw) + ws.close() unblocks the
+                # rest, so the upstream connection can't leak.
+                tasks = {asyncio.ensure_future(_writer()),
+                         asyncio.ensure_future(_from_client()),
+                         asyncio.ensure_future(_from_gateway())}
+                try:
+                    await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+                finally:
+                    _enqueue(None)  # release the writer's blocking get
+                    for t in tasks:
+                        t.cancel()
+                    try:
+                        ws.close()
+                    except Exception:
+                        pass
 
         except (ConnectionRefusedError, OSError) as e:
             logger.error(f"Cannot reach Gateway at {gateway_url}: {e}")
-            ws.send(json.dumps({"type": "error", "message": "Cannot connect to Gateway"}))
-            ws.close()
+            try:
+                ws.send(json.dumps({"type": "error", "message": "Cannot connect to Gateway"}))
+                ws.close()
+            except Exception:
+                pass
         except Exception as e:
             logger.error(f"WebSocket error: {e}")
-            ws.send(json.dumps({"type": "error", "message": "Connection error"}))
-            ws.close()
+            try:
+                ws.send(json.dumps({"type": "error", "message": "Connection error"}))
+                ws.close()
+            except Exception:
+                pass
 
     try:
         asyncio.run(_run())
@@ -1897,6 +1998,7 @@ def openclaw_ui_websocket(ws):
         return
 
     async def _run():
+        loop = asyncio.get_running_loop()
         try:
             async with websockets.connect(gateway_url, origin="http://localhost:18789") as gw:
                 logger.info(f"OpenClaw UI: connected to Gateway at {gateway_url}")
@@ -1904,7 +2006,9 @@ def openclaw_ui_websocket(ws):
                 async def _from_client():
                     """Relay browser → openclaw, injecting auth token on connect."""
                     while True:
-                        msg = ws.receive()
+                        # run_in_executor so blocking ws.receive() doesn't
+                        # starve _from_gateway() while idle (WS-3).
+                        msg = await loop.run_in_executor(None, ws.receive)
                         if not msg:
                             break
                         try:
@@ -1933,7 +2037,10 @@ def openclaw_ui_websocket(ws):
                         await gw.send(msg)
 
                 async def _from_gateway():
-                    """Relay openclaw → browser (raw, no transformation)."""
+                    """Relay openclaw → browser (raw, no transformation).
+                    This is the ONLY writer to ws in this bridge (the client
+                    leg only relays to the gateway), so no per-client queue is
+                    needed here."""
                     while True:
                         try:
                             msg = await asyncio.wait_for(gw.recv(), timeout=300.0)
@@ -1943,7 +2050,21 @@ def openclaw_ui_websocket(ws):
                             ws.send(json.dumps({"type": "error", "message": "Gateway timeout"}))
                             return
 
-                await asyncio.gather(_from_client(), _from_gateway())
+                # WS-8: end as soon as either leg finishes; cancel the survivor.
+                # The executor-blocked ws.receive() can't be cancelled, but
+                # exiting the `async with` (closing gw) + ws.close() unblocks it,
+                # so the upstream gateway connection can't leak.
+                tasks = {asyncio.ensure_future(_from_client()),
+                         asyncio.ensure_future(_from_gateway())}
+                try:
+                    await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+                finally:
+                    for t in tasks:
+                        t.cancel()
+                    try:
+                        ws.close()
+                    except Exception:
+                        pass
 
         except (ConnectionRefusedError, OSError) as e:
             logger.error(f"OpenClaw UI: cannot reach Gateway at {gateway_url}: {e}")

--- a/server.py
+++ b/server.py
@@ -1016,11 +1016,32 @@ def deepgram_stt_token():
     live transcription API.  The key is passed via the WebSocket sub-protocol
     header so it never appears in URLs or logs.
 
-    NOTE: Deepgram supports scoped / short-lived project keys — if you want
-    tighter security, create a key with only 'usage:write' permission and
-    rotate it.  For now we hand out the configured key since the UI is
-    already authenticated.
+    TODO(scoped-key): Deepgram supports scoped / short-lived project keys via
+    its /v1/projects/{id}/keys grant API. We should mint a temporary key with
+    only 'usage:write' scope + a short TTL per session instead of handing out
+    the long-lived project key. Until that helper exists we return the
+    configured key ONLY to authenticated callers (Clerk session or agent key).
+
+    SECURITY: the raw key must never be returned unauthenticated. The public
+    allowlist no longer exposes /api/stt/* (require_auth gates it), and this
+    in-handler check is defense-in-depth so the key can't leak even if the
+    gate is ever loosened.
     """
+    # Defense-in-depth auth check (only enforced when Clerk auth is configured;
+    # local/self-hosted mode with no Clerk key runs fully open per app.py).
+    _clerk_configured = bool(
+        (os.getenv("CLERK_PUBLISHABLE_KEY") or os.getenv("VITE_CLERK_PUBLISHABLE_KEY", "")).strip()
+    )
+    if _clerk_configured:
+        _agent_key = os.environ.get("AGENT_API_KEY", "").strip()
+        _is_agent = bool(_agent_key) and request.headers.get("X-Agent-Key") == _agent_key
+        if not _is_agent:
+            from services.auth import get_token_from_request, verify_clerk_token
+            _token = get_token_from_request()
+            _user = verify_clerk_token(_token) if _token else None
+            if not _user:
+                return jsonify({"error": "Unauthorized", "code": "auth_required"}), 401
+
     api_key = os.environ.get("DEEPGRAM_API_KEY", "")
     if not api_key:
         return jsonify({"error": "DEEPGRAM_API_KEY not configured"}), 500
@@ -1840,8 +1861,8 @@ def clawdbot_websocket(ws):
 
 @sock.route("/openclaw-ui")
 def openclaw_ui_websocket(ws):
-    """WebSocket proxy for OpenClaw Control UI behind Clerk auth."""
-    from services.auth import verify_clerk_token, get_token_from_request
+    """WebSocket proxy for OpenClaw Control UI behind Clerk ADMIN auth."""
+    from services.auth import verify_clerk_token, get_token_from_request, is_admin_user
     token = get_token_from_request()
     user_id = verify_clerk_token(token) if token else None
     if not user_id:
@@ -1849,7 +1870,22 @@ def openclaw_ui_websocket(ws):
         ws.send(json.dumps({"type": "error", "message": "Unauthorized"}))
         ws.close()
         return
-    logger.info(f"OpenClaw UI WebSocket authenticated: user_id={user_id}")
+    # This proxy injects the OPERATOR-scope gateway token into the handshake, so
+    # it must be admin-only — an allowlisted voice user must NOT get operator RPC
+    # (SEC-5/WS-4). Being in ALLOWED_USER_IDS gates the voice app, not admin ops.
+    if not is_admin_user(user_id):
+        logger.warning(f"OpenClaw UI WebSocket rejected — non-admin user_id={user_id}")
+        ws.send(json.dumps({"type": "error", "message": "Admin access required"}))
+        ws.close()
+        return
+    logger.info(f"OpenClaw UI WebSocket authenticated (admin): user_id={user_id}")
+
+    # Same RPC method allowlist the hardened HTTP admin proxy enforces
+    # (routes/admin.py ALLOWED_RPC_METHODS) — the proxy relays operator-scope
+    # frames, so arbitrary methods (config.patch / chat.send / sessions.*) must
+    # not be reachable here. `connect` is permitted (handshake).
+    from routes.admin import ALLOWED_RPC_METHODS
+    _allowed_ws_methods = set(ALLOWED_RPC_METHODS) | {"connect"}
 
     gateway_url = os.getenv("CLAWDBOT_GATEWAY_URL", "ws://127.0.0.1:18791")
     auth_token = os.getenv("CLAWDBOT_AUTH_TOKEN")
@@ -1873,11 +1909,25 @@ def openclaw_ui_websocket(ws):
                             break
                         try:
                             data = json.loads(msg)
-                            if data.get("type") == "req" and data.get("method") == "connect":
-                                if "params" not in data:
-                                    data["params"] = {}
-                                data["params"]["auth"] = {"token": auth_token}
-                                msg = json.dumps(data)
+                            if data.get("type") == "req":
+                                _method = data.get("method")
+                                # Enforce the RPC method allowlist — reject any
+                                # method the HTTP admin proxy also refuses.
+                                if _method and _method not in _allowed_ws_methods:
+                                    logger.warning(
+                                        f"OpenClaw UI: blocked disallowed RPC method {_method!r}"
+                                    )
+                                    ws.send(json.dumps({
+                                        "type": "res",
+                                        "id": data.get("id"),
+                                        "error": {"message": f"Method not allowed: {_method}"},
+                                    }))
+                                    continue
+                                if _method == "connect":
+                                    if "params" not in data:
+                                        data["params"] = {}
+                                    data["params"]["auth"] = {"token": auth_token}
+                                    msg = json.dumps(data)
                         except (json.JSONDecodeError, TypeError):
                             pass  # Non-JSON frame — relay as-is
                         await gw.send(msg)

--- a/services/ai_providers.py
+++ b/services/ai_providers.py
@@ -1,0 +1,146 @@
+"""
+LLM provider catalog loader (WO-1.2).
+
+The provider catalog used to live as a hardcoded dict (_AI_PROVIDERS) inside
+routes/admin.py. It is now loadable from config/ai-providers.json so a provider
+can be added or edited without a code change — it appears in
+/api/services/catalog and the AI-Models admin tab automatically.
+
+Load order:
+  1. config/ai-providers.json  (if present + parseable)  → file catalog
+  2. _DEFAULT_AI_PROVIDERS      (inline fallback)          → never empty
+
+The inline default is the exact dict that was in routes/admin.py, kept here so
+the app still works if the JSON file is missing on a given deployment.
+
+LLM ROUTING itself belongs to the gateway/framework layer (openclaw.json
+agents.defaults.model, managed by the config.patch RPC). This catalog only
+DESCRIBES providers: their credential env key, base URL, API dialect, and the
+models a user may select.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_PATH = Path(__file__).parent.parent / "config" / "ai-providers.json"
+
+# Inline fallback — identical to the historical routes/admin.py:_AI_PROVIDERS.
+_DEFAULT_AI_PROVIDERS: Dict[str, Dict[str, Any]] = {
+    "zai": {
+        "name": "Z.AI (Account A)",
+        "envKey": "ZAI_API_KEY",
+        "baseUrl": "https://api.z.ai/api/anthropic",
+        "api": "anthropic-messages",
+        "models": [
+            {"id": "glm-5-turbo", "name": "GLM-5 Turbo (Z.AI)", "contextWindow": 204000},
+            {"id": "glm-4.7", "name": "GLM-4.7 (Z.AI)", "contextWindow": 204000},
+        ],
+    },
+    "zai_fb": {
+        "name": "Z.AI (Account B / fallback)",
+        "envKey": "ZAI_FALLBACK_API_KEY",
+        "baseUrl": "https://api.z.ai/api/anthropic",
+        "api": "anthropic-messages",
+        "models": [
+            {"id": "glm-5-turbo", "name": "GLM-5 Turbo (Z.AI B)", "contextWindow": 204000},
+            {"id": "glm-4.7", "name": "GLM-4.7 (Z.AI B)", "contextWindow": 204000},
+        ],
+    },
+    "anthropic": {
+        "name": "Anthropic",
+        "envKey": "ANTHROPIC_API_KEY",
+        "baseUrl": "https://api.anthropic.com",
+        "api": "anthropic-messages",
+        "models": [
+            {"id": "claude-sonnet-5", "name": "Claude Sonnet 5", "contextWindow": 200000},
+            {"id": "claude-opus-4-8", "name": "Claude Opus 4.8", "contextWindow": 200000},
+            {"id": "claude-haiku-4-5-20251001", "name": "Claude Haiku 4.5", "contextWindow": 200000},
+        ],
+    },
+    "openai": {
+        "name": "OpenAI",
+        "envKey": "OPENAI_API_KEY",
+        "baseUrl": "https://api.openai.com/v1",
+        "api": "openai-responses",
+        "models": [
+            {"id": "gpt-4.1", "name": "GPT-4.1", "contextWindow": 1047576},
+            {"id": "gpt-4o", "name": "GPT-4o", "contextWindow": 128000},
+            {"id": "gpt-4o-mini", "name": "GPT-4o Mini", "contextWindow": 128000},
+        ],
+    },
+    "google": {
+        "name": "Google Gemini",
+        "envKey": "GEMINI_API_KEY",
+        "baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+        "api": "google-generative-ai",
+        "models": [
+            {"id": "gemini-2.5-flash", "name": "Gemini 2.5 Flash", "contextWindow": 1048576},
+            {"id": "gemini-2.5-pro", "name": "Gemini 2.5 Pro", "contextWindow": 1048576},
+        ],
+    },
+}
+
+# mtime-cached load so an admin edit to the JSON is picked up without a restart,
+# while the hot path (catalog build) doesn't re-read disk every call.
+_CACHE: Dict[str, Dict[str, Any]] | None = None
+_CACHE_MTIME: float = -1.0
+
+
+def load_ai_providers() -> Dict[str, Dict[str, Any]]:
+    """Return the LLM provider catalog dict {provider_id: descriptor}.
+
+    Reads config/ai-providers.json (mtime-cached). Falls back to the inline
+    _DEFAULT_AI_PROVIDERS on any error so callers never get an empty catalog.
+    """
+    global _CACHE, _CACHE_MTIME
+    try:
+        mtime = _CONFIG_PATH.stat().st_mtime
+    except OSError:
+        return dict(_DEFAULT_AI_PROVIDERS)
+
+    if _CACHE is not None and mtime == _CACHE_MTIME:
+        return _CACHE
+
+    try:
+        raw = json.loads(_CONFIG_PATH.read_text())
+        providers = raw.get("providers") if isinstance(raw, dict) else None
+        if isinstance(providers, dict) and providers:
+            _CACHE = providers
+            _CACHE_MTIME = mtime
+            return _CACHE
+        logger.warning("ai-providers.json has no 'providers' object — using inline default")
+    except Exception as exc:  # malformed JSON, permission, etc.
+        logger.warning("Failed to load ai-providers.json (%s) — using inline default", exc)
+
+    return dict(_DEFAULT_AI_PROVIDERS)
+
+
+def build_llm_config_schema() -> dict:
+    """Build a config_schema.fields[] descriptor for the LLM providers.
+
+    One password field per provider (its API key, tied to a vault credential
+    env key). Used by OpenClawGateway.get_config_schema() and the catalog LLM
+    descriptors so the panel can render a generic key form.
+    """
+    fields = []
+    for pid, pinfo in load_ai_providers().items():
+        env_key = pinfo.get("envKey", "")
+        fields.append({
+            "id": env_key or pid,
+            "type": "password",
+            "label": f"{pinfo.get('name', pid)} API key",
+            "required": False,
+            "credential": env_key,
+            "provider": pid,
+        })
+    return {"fields": fields}
+
+
+__all__ = ["load_ai_providers", "build_llm_config_schema", "_DEFAULT_AI_PROVIDERS"]

--- a/services/auth.py
+++ b/services/auth.py
@@ -44,10 +44,20 @@ _JWKS_CACHE_TTL = 3600  # refresh keys every 60 minutes
 
 # Allowlist of Clerk user IDs permitted to access this deployment.
 # Set ALLOWED_USER_IDS=user_abc123,user_xyz789 in .env
-# If the env var is empty or unset, the check is SKIPPED (open to any valid Clerk user).
-# Always set this in production — agents have full access.
+# FAIL-CLOSED (SEC-11): when Clerk auth is configured but this allowlist is
+# empty, NO users are permitted (previously it failed OPEN — any Clerk account
+# on the instance was allowed). The fleet .env template always populates
+# ALLOWED_USER_IDS (jambot-create-user.sh sets it to the client + admin, or
+# admin-only), so fail-closed is safe here; a tenant with an empty value is
+# misconfigured and must be locked, not opened.
 _raw_allowed = os.getenv('ALLOWED_USER_IDS', '')
 _ALLOWED_USER_IDS: set[str] = {uid.strip() for uid in _raw_allowed.split(',') if uid.strip()}
+_CLERK_CONFIGURED = bool(_raw_clerk_key)
+if _CLERK_CONFIGURED and not _ALLOWED_USER_IDS:
+    logger.error(
+        'SECURITY: ALLOWED_USER_IDS is EMPTY while Clerk auth is configured — '
+        'FAILING CLOSED: no users will be permitted. Set ALLOWED_USER_IDS in .env.'
+    )
 
 # Admin users — server-side authorization for the admin dashboard and privileged
 # APIs (/admin, /api/admin/*, /api/vault/*, /api/workspace/*, /api/plugins/*, ...).
@@ -121,7 +131,14 @@ def verify_clerk_token(token: str) -> Optional[str]:
                 return None
             # Log user_id on every successful auth so it can be captured for ALLOWED_USER_IDS
             logger.info('Clerk auth: user_id=%s', user_id)
-            # Enforce allowlist if configured
+            # Enforce allowlist. FAIL-CLOSED: an empty allowlist while Clerk is
+            # configured permits NO ONE (SEC-11) — a valid token is not enough.
+            if _CLERK_CONFIGURED and not _ALLOWED_USER_IDS:
+                logger.warning(
+                    'Clerk auth: user_id=%s denied — ALLOWED_USER_IDS is empty (fail-closed)',
+                    user_id,
+                )
+                return None
             if _ALLOWED_USER_IDS and user_id not in _ALLOWED_USER_IDS:
                 logger.warning('Clerk auth: user_id=%s not in ALLOWED_USER_IDS — access denied', user_id)
                 return None

--- a/services/gateway_manager.py
+++ b/services/gateway_manager.py
@@ -202,17 +202,51 @@ class GatewayManager:
     # Health / status                                                      #
     # ------------------------------------------------------------------ #
 
-    def list_gateways(self) -> list[dict]:
-        """Return status of all registered gateways (for health endpoint / admin UI)."""
-        return [
-            {
+    def list_gateways(self, rich: bool = False) -> list[dict]:
+        """Return status of all registered gateways (for health endpoint / admin UI).
+
+        rich=False (default) keeps the original cheap shape used by the existing
+        /api/server-stats consumer — no health I/O beyond is_healthy().
+        rich=True adds the WO-2.1 contract fields (capabilities, config_schema,
+        latency, restart_scope, credentials) for the Service Catalog + Agent
+        Framework tab. Rich mode calls check_health() which may do a cheap
+        socket/ping probe.
+        """
+        out = []
+        for gw in self._gateways.values():
+            entry = {
                 'id': gw.gateway_id,
                 'configured': gw.is_configured(),
                 'healthy': gw.is_healthy(),
                 'persistent': gw.persistent,
             }
-            for gw in self._gateways.values()
-        ]
+            if rich:
+                caps = getattr(gw, 'capabilities', frozenset())
+                try:
+                    healthy, latency = gw.check_health()
+                except Exception as exc:
+                    logger.warning("check_health failed for %s: %s", gw.gateway_id, exc)
+                    healthy, latency = gw.is_healthy(), None
+                try:
+                    schema = gw.get_config_schema()
+                except Exception:
+                    schema = {'fields': [], 'editable': False}
+                try:
+                    rscope = gw.restart_scope()
+                except Exception:
+                    rscope = 'none'
+                # Credential ids referenced by the schema (no secret values).
+                creds = [f['credential'] for f in schema.get('fields', [])
+                         if f.get('credential')]
+                entry.update({
+                    'capabilities': sorted(caps),
+                    'config_schema': schema,
+                    'credentials': creds,
+                    'restart_scope': rscope,
+                    'health': {'healthy': healthy, 'latency_ms': latency},
+                })
+            out.append(entry)
+        return out
 
     def is_configured(self) -> bool:
         """True if at least one gateway is configured (backwards compat for health check)."""

--- a/services/gateways/base.py
+++ b/services/gateways/base.py
@@ -46,6 +46,19 @@ class GatewayBase:
     #         zero idle cost; no background thread required.
     persistent: bool = False
 
+    # Capability descriptor (WO-2.1). Machine-readable set of features this
+    # framework supports, so the admin panel can render capability chips and
+    # decide which controls to show. Known tokens (extend as needed):
+    #   'streaming'     — token-by-token streaming responses
+    #   'steer'         — inject a message into an in-flight run
+    #   'sessions'      — per-session conversational memory / history
+    #   'tool-events'   — emits structured tool/action lifecycle events
+    #   'config-rpc'    — supports live config read/patch (get_config_schema+configure applied hot)
+    #   'reset'         — supports reset_session()
+    #   'delegation'    — used for inter-gateway delegation (not a primary brain)
+    # Set on each subclass. Default: streaming only (the one required behaviour).
+    capabilities: set = frozenset({"streaming"})
+
     # ------------------------------------------------------------------ #
     # Required — subclasses must implement these                          #
     # ------------------------------------------------------------------ #
@@ -95,8 +108,72 @@ class GatewayBase:
         Quick synchronous health check. No I/O — just inspect local state.
         Default: same as is_configured().
         Override to check live connection state, last-error timestamp, etc.
+
+        NOTE: this returns a plain bool and is kept that way for backwards
+        compatibility (gateway_manager.list_gateways() and the readiness probe
+        consume it). For a health check that ALSO reports latency, use
+        check_health() below (WO-2.1).
         """
         return self.is_configured()
+
+    # ------------------------------------------------------------------ #
+    # Capability / config / richer-health contracts (WO-2.1)             #
+    # ------------------------------------------------------------------ #
+
+    def check_health(self) -> tuple:
+        """Richer health probe: return (healthy: bool, latency_ms: float|None).
+
+        Kept separate from is_healthy() (which must stay a bare bool for its
+        existing callers). The Service Catalog / Agent Framework tab call this
+        for the health ring + latency. Default: no I/O — mirror is_healthy()
+        with no latency. Override to measure real reachability + round-trip.
+        Implementations MUST be cheap (socket/local ping), never a vendor API
+        call on the catalog path.
+        """
+        return (self.is_healthy(), None)
+
+    def get_config_schema(self) -> dict:
+        """Return a machine-readable config-field schema for this framework.
+
+        Shape (Hermes install_config style — the panel renders it generically):
+            {"fields": [
+                {"id": "HERMES_HOST", "type": "text", "label": "...",
+                 "required": True},
+                {"id": "HERMES_API_KEY", "type": "password", "label": "...",
+                 "credential": "hermes_api_key"},
+            ]}
+
+        Field types: text | password | select | toggle | number.
+        A field may carry "credential": <vault-cred-id> to route its write
+        through the vault instead of a plain config value.
+
+        Default: an empty, display-only schema (no editable fields). Override
+        to expose configurable settings.
+        """
+        return {"fields": [], "editable": False}
+
+    def configure(self, partial: dict) -> dict:
+        """Apply a partial configuration change to this framework.
+
+        Args:
+            partial: subset of fields from get_config_schema() to change.
+
+        Returns a status dict:
+            {"status": "applied",       "detail": "..."}   — live, no restart
+            {"status": "needs_restart", "detail": "..."}   — written, restart X
+            {"status": "error",         "detail": "..."}   — rejected/failed
+
+        Default: not supported (display-only frameworks).
+        """
+        return {"status": "error", "detail": "configure() not supported by this gateway"}
+
+    def restart_scope(self) -> str:
+        """What a configure() change restarts: 'none' | 'ovui' | 'container:<name>'.
+
+        Default 'none' (hot-applied or display-only). Override when a change
+        requires bouncing a sibling container.
+        """
+        return "none"
 
     def shutdown(self) -> None:
         """

--- a/services/gateways/openclaw.py
+++ b/services/gateways/openclaw.py
@@ -1785,6 +1785,9 @@ class OpenClawGateway(GatewayBase):
 
     gateway_id = "openclaw"
     persistent = True
+    capabilities = frozenset({
+        "streaming", "steer", "sessions", "tool-events", "config-rpc", "reset",
+    })
 
     def __init__(self):
         self._router = GatewayRouter()
@@ -1794,6 +1797,91 @@ class OpenClawGateway(GatewayBase):
 
     def is_healthy(self) -> bool:
         return self.is_configured()
+
+    def check_health(self) -> tuple:
+        """Reachability + latency via a cheap TCP connect to the gateway socket.
+
+        No RPC handshake, no vendor API — just prove the gateway port accepts a
+        connection and time it. Falls back to is_configured() truthiness if the
+        URL can't be parsed. (WO-2.1)
+        """
+        if not self.is_configured():
+            return (False, None)
+        import socket as _socket
+        from urllib.parse import urlparse
+        url = os.getenv('CLAWDBOT_GATEWAY_URL', 'ws://127.0.0.1:18791')
+        parsed = urlparse(url)
+        host = parsed.hostname or '127.0.0.1'
+        port = parsed.port or 18791
+        t0 = time.time()
+        try:
+            with _socket.create_connection((host, port), timeout=2.0):
+                pass
+            return (True, round((time.time() - t0) * 1000, 1))
+        except OSError:
+            return (False, None)
+
+    def get_config_schema(self) -> dict:
+        """OpenClaw config schema: primary/fallback model refs + per-provider keys.
+
+        Model refs are 'provider/model-id' strings; provider keys route through
+        the vault credential env (config-rpc applies them hot). Built from the
+        loadable LLM catalog so a new provider shows up with no code change.
+        """
+        from services.ai_providers import build_llm_config_schema
+        fields = [
+            {"id": "primary", "type": "text", "label": "Primary model (provider/model-id)",
+             "required": False, "placeholder": "zai/glm-5-turbo"},
+            {"id": "fallback", "type": "text", "label": "Fallback model (provider/model-id)",
+             "required": False, "placeholder": "zai_fb/glm-5-turbo"},
+        ]
+        fields.extend(build_llm_config_schema().get("fields", []))
+        return {"fields": fields, "editable": True, "transport": "config-rpc"}
+
+    def configure(self, partial: dict) -> dict:
+        """Apply a model/key change via the existing config.patch RPC path.
+
+        Reuses routes.admin's effective-config read + partial builder + RPC
+        (imported lazily to avoid an import cycle) so this is the SAME hardened,
+        schema-validated write the AI-Models tab uses — not a duplicate. (WO-2.1)
+
+        Accepts the same shape as PUT /api/admin/ai-config:
+            {"primary": "...", "fallback": "...", "keys": {"anthropic": "sk-..."}}
+        """
+        try:
+            from routes.admin import (
+                _get_effective_config, _build_ai_config_partial, _run_rpc,
+                _oc_config_writable, _write_oc_config, _deep_merge,
+            )
+        except Exception as exc:
+            return {"status": "error", "detail": f"config path unavailable: {exc}"}
+        import json as _json
+
+        config, source, base_hash = _get_effective_config()
+        if not config:
+            return {"status": "error",
+                    "detail": "gateway unreachable and no readable openclaw.json"}
+        built, changes = _build_ai_config_partial(partial, config)
+        if not built:
+            return {"status": "applied", "detail": "no changes"}
+        if source == "gateway":
+            result = _run_rpc("config.patch",
+                              {"raw": _json.dumps(built), "baseHash": base_hash}, timeout=15.0)
+            if result.get("ok"):
+                return {"status": "applied", "detail": "applied via config.patch",
+                        "changes": changes}
+            return {"status": "error",
+                    "detail": f"gateway rejected change: {result.get('error')}"}
+        if not _oc_config_writable():
+            return {"status": "error",
+                    "detail": "gateway unreachable and openclaw.json not writable"}
+        try:
+            _write_oc_config(_deep_merge(config, built))
+        except Exception as exc:
+            return {"status": "error", "detail": f"write failed: {exc}"}
+        return {"status": "needs_restart",
+                "detail": "wrote openclaw.json directly — restart openclaw to apply",
+                "changes": changes}
 
     def stream_to_queue(self, event_queue, message, session_key,
                         captured_actions=None, **kwargs):

--- a/services/gateways/openclaw.py
+++ b/services/gateways/openclaw.py
@@ -15,6 +15,7 @@ persistent: True (maintains a live WS connection)
 
 import asyncio
 import base64
+import concurrent.futures
 import hashlib
 import json
 import logging
@@ -139,6 +140,31 @@ class _WSClosedError(Exception):
     pass
 
 
+class _ActivityQueue:
+    """Transparent wrapper around the caller's event_queue that timestamps
+    every put() so the outer stream_to_queue() watchdog can tell a genuinely
+    stalled run from one that is merely LONG.
+
+    Each subagent continuation legitimately resets a fresh ~300s inner budget
+    (_stream_events), so a single fixed 320s outer wait fired mid-turn and,
+    worse, did not cancel the coroutine — which kept running and later put a
+    SECOND terminal event on the abandoned queue (WS-7). By tracking the last
+    put() we only time out on true inactivity: deltas AND the periodic
+    heartbeats _stream_events emits both refresh the clock.
+    """
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.last_activity = time.time()
+
+    def put(self, *args, **kwargs):
+        self.last_activity = time.time()
+        return self._inner.put(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
 # ---------------------------------------------------------------------------
 # Subscription — per-request state
 # ---------------------------------------------------------------------------
@@ -231,7 +257,11 @@ class EventDispatcher:
         self._run_to_chat: dict[str, str] = {}
         self._reader_task: asyncio.Task | None = None
         self._send_lock: asyncio.Lock = asyncio.Lock()
-        self._aborted_runs: set[str] = set()  # runIds from aborted runs — never deliver to new subs
+        # runIds from aborted runs — never deliver to new subs. An
+        # insertion-ordered dict (runId → insert ts) so overflow eviction
+        # drops the OLDEST-inserted entries, not lexicographically-smallest
+        # UUIDs (WS-11).
+        self._aborted_runs: dict[str, float] = {}
         # Learned alias→canonical session key map. OVUI subscribes with the
         # SHORT alias it passed to chat.send ('main', 'recovery-<epoch>', …)
         # but gateway events carry the CANONICAL key
@@ -256,6 +286,17 @@ class EventDispatcher:
 
     def set_orphan_hook(self, fn):
         self._orphan_hook = fn
+
+    def _prune_orphan_bookkeeping(self, now):
+        """Drop stale orphan bookkeeping so the dicts don't leak (WS-11).
+        Cooldown timestamps older than 1h are irrelevant; completed debounce
+        tasks are done and safe to forget."""
+        cutoff = now - 3600
+        for k in [k for k, ts in self._orphan_last_fired.items() if ts < cutoff]:
+            self._orphan_last_fired.pop(k, None)
+        for k in [k for k, t in self._orphan_debounce.items()
+                  if t is None or t.done()]:
+            self._orphan_debounce.pop(k, None)
 
     def _alias_for_canonical(self, canonical: str) -> str | None:
         """Best-effort map a canonical sessionKey (or spawnedBy value like
@@ -283,6 +324,7 @@ class EventDispatcher:
         parent = (self._alias_for_canonical(payload.get('spawnedBy', ''))
                   or self._last_sub_alias or 'main')
         now = time.time()
+        self._prune_orphan_bookkeeping(now)
         if now - self._orphan_last_fired.get(parent, 0) < self.ORPHAN_COOLDOWN_S:
             logger.info(f"### ORPHAN SUBAGENT END: cooldown active for {parent} — skipped")
             return
@@ -339,7 +381,7 @@ class EventDispatcher:
             sub.state = Subscription.DONE
             if sub.run_id:
                 self._run_to_chat.pop(sub.run_id, None)
-                self._aborted_runs.discard(sub.run_id)
+                self._aborted_runs.pop(sub.run_id, None)
 
     def start(self, ws):
         """Start the reader loop for a new WS connection."""
@@ -426,12 +468,13 @@ class EventDispatcher:
                 # delivered to new subscriptions (prevents stale replays).
                 canonical_state = match_state(event_state)
                 if canonical_evt == 'chat' and canonical_state == 'aborted' and event_run_id:
-                    self._aborted_runs.add(event_run_id)
+                    self._aborted_runs[event_run_id] = time.time()
                     logger.info(f"### ABORTED run tracked: {event_run_id[:12]}")
-                    # Cap set size to prevent unbounded growth
+                    # Cap size to prevent unbounded growth — evict the
+                    # oldest-inserted half (dict preserves insertion order).
                     if len(self._aborted_runs) > 100:
-                        oldest = sorted(self._aborted_runs)[:50]
-                        self._aborted_runs -= set(oldest)
+                        for _old in list(self._aborted_runs)[:50]:
+                            self._aborted_runs.pop(_old, None)
 
                 if event_run_id:
                     # Direct mapping — deliver to the sub that owns this runId
@@ -444,8 +487,11 @@ class EventDispatcher:
                             if (event_session_key and sub.session_key
                                     and event_session_key != sub.session_key):
                                 self._canonical_keys[sub.session_key] = event_session_key
+                                # Drop the oldest half on overflow (LRU-ish)
+                                # rather than wiping the whole alias map (WS-11).
                                 if len(self._canonical_keys) > 50:
-                                    self._canonical_keys.clear()
+                                    for _old in list(self._canonical_keys)[:25]:
+                                        self._canonical_keys.pop(_old, None)
                             await sub.event_queue.put(data)
                             return
 
@@ -539,7 +585,7 @@ class EventDispatcher:
             return
         if sub.run_id:
             self._run_to_chat.pop(sub.run_id, None)
-            self._aborted_runs.discard(sub.run_id)
+            self._aborted_runs.pop(sub.run_id, None)
         sub.run_id = None
         sub.state = Subscription.QUEUED
 
@@ -692,8 +738,11 @@ class GatewayConnection:
         self._dispatcher.start(ws)
         # Supervise the reader: without this the connection only comes back
         # lazily on the next chat.send, leaving the orphan-completion watcher
-        # deaf after any gateway restart/blip.
-        asyncio.ensure_future(self._supervise_reader())
+        # deaf after any gateway restart/blip. Bind the supervisor to THIS
+        # (ws, reader_task) generation so it can tell a passive drop (its ws is
+        # still current) from a newer connect having taken over (ws replaced).
+        reader_task = self._dispatcher._reader_task
+        asyncio.ensure_future(self._supervise_reader(ws, reader_task))
         if server_version:
             self._server_version = server_version
             logger.info(
@@ -708,27 +757,49 @@ class GatewayConnection:
         else:
             logger.info(f"### Persistent WS connected + handshake done in {t_ms}ms")
 
-    async def _supervise_reader(self):
+    async def _supervise_reader(self, ws, reader_task):
         """Reconnect the persistent WS when the reader loop dies.
 
-        One supervisor is spawned per successful _connect(). When the reader
-        ends (gateway restart, network blip, deliberate disconnect), wait and
-        re-establish so subagent lifecycle broadcasts keep flowing between
-        user messages. Stale supervisors (a newer connect already succeeded)
-        notice _connected and exit.
+        Bound to the specific (ws, reader_task) generation it was spawned for.
+        When that reader ends (gateway restart, network blip, deliberate
+        disconnect), re-establish so subagent lifecycle broadcasts keep
+        flowing between user messages.
+
+        WS-1: on a PASSIVE drop the reader loop returns without clearing
+        _connected/_ws (only _disconnect() does that, and it is never called
+        for a passive drop). The old supervisor then saw the stale
+        _connected==True, concluded "a newer connect took over," and exited
+        WITHOUT reconnecting — leaving the persistent WS dead but reading
+        healthy, so the orphan-completion watcher went deaf until the next
+        user chat.send. The fix compares ws OBJECT IDENTITY: if self._ws is
+        still THIS ws, no newer connect happened — this is a real drop, so we
+        clear the stale state ourselves and reconnect.
         """
-        task = self._dispatcher._reader_task
-        if task is None:
+        if reader_task is None:
             return
         try:
-            await asyncio.wait({task})
+            await asyncio.wait({reader_task})
         except Exception:
             pass
+        # A newer _connect() already installed a different live ws — that
+        # connection owns its own supervisor; this generation is retired.
+        if self._ws is not None and self._ws is not ws:
+            return
+        # This IS the current generation and its reader just died (passive
+        # drop): clear the stale connection state so _ensure_connected() below
+        # actually reconnects instead of short-circuiting on _connected==True.
+        # (A deliberate _disconnect() already set _ws=None/_connected=False —
+        # that path also lands here and simply reconnects, matching prior
+        # behaviour.)
+        if self._ws is ws:
+            self._connected = False
+            self._last_disconnect_time = time.time()
         while True:
-            if self._connected and self._ws is not None:
-                return  # a newer connect (with its own supervisor) took over
+            # Bail if a newer connection came up while we waited/slept.
+            if self._connected and self._ws is not None and self._ws is not ws:
+                return
             await asyncio.sleep(5)
-            if self._connected and self._ws is not None:
+            if self._connected and self._ws is not None and self._ws is not ws:
                 return
             try:
                 logger.info("### WS supervisor: reader died — reconnecting")
@@ -760,12 +831,20 @@ class GatewayConnection:
     async def _ensure_connected(self):
         async with self._ws_lock:
             if self._connected and self._ws is not None:
-                # No pre-send liveness ping: it serialized a full ping/pong
-                # roundtrip (worst case 5s) ahead of EVERY chat.send on the
-                # hot path. A dead socket is caught on send/recv instead —
-                # _do_stream catches _WSClosedError/ConnectionClosed, then
-                # disconnects, reconnects, and re-sends the same message.
-                return
+                # Cheap, NON-blocking liveness check (no ping/pong roundtrip —
+                # that added worst-case 5s ahead of EVERY chat.send on the hot
+                # path). We only inspect the socket's own close state: a client
+                # that already saw the close frame reports a non-None
+                # close_code. If it looks closed, fall through to reconnect
+                # instead of handing a dead ws to the caller (WS-6 — closes the
+                # WS-1 window even faster than waiting for the supervisor). A
+                # socket that is dead but hasn't observed the close yet is
+                # still caught on send/recv by _do_stream, which reconnects and
+                # re-sends the same message.
+                if getattr(self._ws, 'close_code', None) is None:
+                    return
+                logger.info("### _ensure_connected: socket reports closed — reconnecting")
+                self._connected = False
 
             backoff = self.BACKOFF_DELAYS[min(self._backoff_idx, len(self.BACKOFF_DELAYS) - 1)]
             elapsed = time.time() - self._last_disconnect_time
@@ -1590,17 +1669,46 @@ class GatewayConnection:
             traceback.print_exc()
             event_queue.put({'type': 'error', 'error': str(e)})
 
+    # Watchdog: declare an outer timeout only after this many seconds with NO
+    # activity on the event queue (deltas or heartbeats). A live-but-long run
+    # keeps refreshing the clock, so legitimate multi-continuation turns are no
+    # longer killed mid-flight (WS-7).
+    _STREAM_IDLE_LIMIT_S = 320
+    _STREAM_POLL_S = 10
+
     def stream_to_queue(self, event_queue, message, session_key,
                         captured_actions=None, agent_id=None):
         if captured_actions is None:
             captured_actions = []
         self._ensure_started()
+        aq = _ActivityQueue(event_queue)
         future = asyncio.run_coroutine_threadsafe(
-            self._do_stream(event_queue, message, session_key, captured_actions, agent_id=agent_id),
+            self._do_stream(aq, message, session_key, captured_actions, agent_id=agent_id),
             self._loop
         )
         try:
-            future.result(timeout=320)
+            while True:
+                try:
+                    future.result(timeout=self._STREAM_POLL_S)
+                    return  # coroutine completed
+                except concurrent.futures.TimeoutError:
+                    idle = time.time() - aq.last_activity
+                    if idle >= self._STREAM_IDLE_LIMIT_S:
+                        logger.error(
+                            f"### Gateway stream watchdog: no events for "
+                            f"{int(idle)}s — cancelling run (session={session_key})")
+                        # Cancel the coroutine so it can't keep running and
+                        # later double-emit a terminal event on the abandoned
+                        # queue. run_coroutine_threadsafe's future.cancel()
+                        # raises CancelledError inside the task at its next
+                        # await (CancelledError is BaseException, so the
+                        # coroutine's `except Exception` guards don't swallow
+                        # it — it unwinds cleanly).
+                        future.cancel()
+                        event_queue.put({'type': 'error',
+                                         'error': 'Gateway stream timed out (inactivity)'})
+                        return
+                    # Still producing — keep waiting.
         except Exception as e:
             logger.error(f"Gateway stream error: {e}")
             event_queue.put({'type': 'error', 'error': str(e)})

--- a/services/health.py
+++ b/services/health.py
@@ -7,9 +7,11 @@ Readiness (/health/ready) — can it serve requests? (Gateway + TTS loaded)
 """
 
 import os
+import socket
 import time
 from dataclasses import dataclass, field
-from typing import Dict, Optional
+from typing import Dict, List, Optional
+from urllib.parse import urlparse
 
 
 @dataclass
@@ -70,27 +72,94 @@ class HealthChecker:
 # ---------------------------------------------------------------------------
 
 def _check_gateway() -> CheckResult:
-    """Check that the Gateway auth token is configured."""
+    """Check gateway REACHABILITY without making a third-party HTTP call.
+
+    Readiness must be cheap: no WebSocket handshake, no vendor API. We (1)
+    confirm the gateway is configured, then (2) prefer the persistent
+    GatewayConnection's live `_connected` flag if one exists, else fall back to
+    a cheap local TCP connect to the gateway host:port. This makes readiness go
+    503 when the socket is actually down, not merely when env vars are missing.
+    """
     token = os.getenv("CLAWDBOT_AUTH_TOKEN")
     if not token:
         return CheckResult(healthy=False, message="CLAWDBOT_AUTH_TOKEN not set")
     gateway_url = os.getenv("CLAWDBOT_GATEWAY_URL", "")
     if not gateway_url:
         return CheckResult(healthy=False, message="CLAWDBOT_GATEWAY_URL not set")
-    return CheckResult(healthy=True, message="Gateway configured")
+
+    # (1) Prefer the persistent connection's live `_connected` flag if a
+    # GatewayRouter/connection is already established (no handshake, no I/O).
+    try:
+        from services.gateways import openclaw as _oc
+        router = getattr(_oc, "_router", None) or getattr(_oc, "gateway_router", None)
+        conns = getattr(router, "_connections", None) if router is not None else None
+        if isinstance(conns, dict) and conns:
+            if any(getattr(c, "_connected", False) for c in conns.values()):
+                return CheckResult(healthy=True, message="Gateway connected (live)")
+        # No live connection object → fall through to a cheap socket probe rather
+        # than trusting env-var presence alone.
+    except Exception:
+        pass
+
+    # (2) Cheap local TCP reachability probe (no handshake, no vendor call).
+    try:
+        parsed = urlparse(gateway_url)
+        host = parsed.hostname or "127.0.0.1"
+        port = parsed.port or (443 if parsed.scheme in ("wss", "https") else 18789)
+        with socket.create_connection((host, port), timeout=1.5):
+            return CheckResult(healthy=True, message=f"Gateway reachable ({host}:{port})")
+    except Exception as exc:
+        return CheckResult(healthy=False, message=f"Gateway unreachable: {exc}")
+
+
+# Cached TTS provider-id list (module-level, TTL). Readiness must not
+# instantiate providers (which triggers Supertonic health GET / ElevenLabs
+# voices fetch — third-party calls per probe). We only need the registered
+# ids, which are static config, so cache them.
+_TTS_LIST_CACHE: Dict[str, object] = {"ids": None, "fetched_at": 0.0}
+_TTS_LIST_TTL = 300  # 5 minutes
+
+
+def _get_tts_provider_ids() -> List[str]:
+    """Return registered TTS provider ids from the registry WITHOUT instantiating.
+
+    Cached for _TTS_LIST_TTL. Prefers a non-instantiating registry accessor
+    (`available_providers()` / `_PROVIDERS` keys) so no provider __init__ runs.
+    """
+    now = time.time()
+    cached = _TTS_LIST_CACHE.get("ids")
+    if cached is not None and (now - float(_TTS_LIST_CACHE.get("fetched_at", 0))) < _TTS_LIST_TTL:
+        return cached  # type: ignore[return-value]
+
+    ids: List[str] = []
+    try:
+        import tts_providers as _tp
+        # Prefer the raw registry keys — no instantiation, no network.
+        registry = getattr(_tp, "_PROVIDERS", None)
+        if isinstance(registry, dict) and registry:
+            ids = list(registry.keys())
+        else:
+            fn = getattr(_tp, "available_providers", None)
+            if callable(fn):
+                ids = list(fn())
+    except Exception:
+        ids = []
+
+    _TTS_LIST_CACHE["ids"] = ids
+    _TTS_LIST_CACHE["fetched_at"] = now
+    return ids
 
 
 def _check_tts() -> CheckResult:
-    """Check that at least one TTS provider is available."""
+    """Check that at least one TTS provider is REGISTERED (no instantiation)."""
     try:
-        from tts_providers import list_providers
-        providers = list_providers()
-        if not providers:
+        ids = _get_tts_provider_ids()
+        if not ids:
             return CheckResult(healthy=False, message="No TTS providers available")
         return CheckResult(
             healthy=True,
-            message=f"{len(providers)} TTS provider(s) loaded",
-            details={"providers": [str(p) for p in providers]},
+            message=f"{len(ids)} TTS provider(s) registered",
+            details={"providers": ids},
         )
     except ImportError:
         return CheckResult(healthy=False, message="tts_providers module not importable")

--- a/services/plugins.py
+++ b/services/plugins.py
@@ -396,6 +396,118 @@ def uninstall_plugin(plugin_id: str) -> bool:
     return True
 
 
+def _version_tuple(v) -> tuple:
+    """Best-effort semver -> comparable tuple. Non-numeric parts sort low."""
+    parts = []
+    for chunk in str(v or "0").lstrip("vV").split("."):
+        num = "".join(ch for ch in chunk if ch.isdigit())
+        parts.append(int(num) if num else 0)
+    return tuple(parts) or (0,)
+
+
+def get_plugin_updates() -> List[dict]:
+    """Version-diff each INSTALLED plugin against the catalog/registry (WO-5.1).
+
+    Reuses the same local-catalog scan + remote GitHub registry the
+    available-plugins view uses, but keyed on installed ids (which
+    get_available_plugins deliberately excludes). No mutation, network best-effort
+    (remote registry is 5-min cached). Returns one row per installed plugin:
+      {id, name, installed_version, available_version, update_available, source}
+    """
+    # Build id -> available version map from local catalog + remote registry.
+    avail_versions: Dict[str, dict] = {}
+    if PLUGIN_CATALOG_DIR.is_dir():
+        for d in sorted(PLUGIN_CATALOG_DIR.iterdir()):
+            mp = d / "plugin.json"
+            if mp.is_file():
+                try:
+                    m = json.loads(mp.read_text())
+                    pid = m.get("id", d.name)
+                    avail_versions[pid] = {"version": m.get("version", ""), "source": "local"}
+                except Exception:
+                    continue
+    try:
+        for entry in _fetch_remote_registry():
+            pid = entry.get("id", "")
+            if pid and pid not in avail_versions:
+                avail_versions[pid] = {"version": entry.get("version", ""), "source": "remote"}
+    except Exception as e:
+        logger.debug(f"plugin update check: remote registry unavailable: {e}")
+
+    rows = []
+    for p in get_installed_plugins():
+        pid = p.get("id")
+        installed_v = p.get("version", "")
+        av = avail_versions.get(pid)
+        available_v = av["version"] if av else ""
+        update_available = bool(
+            available_v and _version_tuple(available_v) > _version_tuple(installed_v)
+        )
+        rows.append({
+            "id": pid,
+            "name": p.get("name", pid),
+            "installed_version": installed_v,
+            "available_version": available_v,
+            "update_available": update_available,
+            "source": av["source"] if av else "installed",
+        })
+    return rows
+
+
+def update_plugin(plugin_id: str, config: dict = None) -> Optional[dict]:
+    """Update an installed plugin to the catalog/registry version (WO-5.1).
+
+    Soft, additive, NEVER-DELETE compliant: the existing plugin directory is
+    RENAMED to a timestamped '<id>.old-<ts>' sidecar (never rmtree'd), then the
+    normal install path runs to lay down the new version + re-run the post_install
+    lifecycle hook. On any failure the rename is restored so the plugin is never
+    left missing. Returns the new manifest, or {"_error": ...} on failure, or None
+    if the plugin isn't installed.
+    """
+    dest = PLUGIN_DIR / plugin_id
+    if not dest.exists():
+        return None  # not installed — caller should use install_plugin
+
+    from datetime import datetime as _dt
+    ts = _dt.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    sidecar = dest.with_name(f"{plugin_id}.old-{ts}")
+    try:
+        dest.rename(sidecar)
+    except Exception as e:
+        logger.error(f"Plugin update: could not archive current {plugin_id}: {e}")
+        return {"_error": f"could not archive current version: {e}"}
+
+    # Drop the runtime registry entry so install_plugin's dest.exists() gate opens.
+    prev_manifest = _registry.pop(plugin_id, None)
+    try:
+        result = install_plugin(plugin_id, config=config)
+    except Exception as e:
+        result = {"_error": str(e)}
+
+    if not result or (isinstance(result, dict) and result.get("_error")):
+        # Roll back — restore the archived version exactly as it was.
+        if dest.exists():
+            # partial install landed; move it aside so the restore is clean
+            try:
+                dest.rename(dest.with_name(f"{plugin_id}.failed-{ts}"))
+            except Exception:
+                pass
+        try:
+            sidecar.rename(dest)
+            if prev_manifest is not None:
+                _registry[plugin_id] = prev_manifest
+            logger.info(f"Plugin update rolled back: {plugin_id}")
+        except Exception as e:
+            logger.error(f"Plugin update: rollback FAILED for {plugin_id}: {e}")
+        err = (result or {}).get("_error", "plugin not found in catalog/registry") \
+            if isinstance(result, dict) else "update failed"
+        return {"_error": err}
+
+    logger.info(f"Plugin updated: {plugin_id} (previous archived at {sidecar.name})")
+    result["_updated_from"] = prev_manifest.get("version") if prev_manifest else None
+    return result
+
+
 def get_container_status(plugin_id: str) -> Optional[dict]:
     """Check container status for a plugin that requires infrastructure."""
     plugin = _registry.get(plugin_id)

--- a/services/tts.py
+++ b/services/tts.py
@@ -132,43 +132,47 @@ def generate_tts_chunked(provider, text: str, voice: str, max_chars: int = 800) 
     num_channels = None
     bits_per_sample = None
 
+    # TTS-6: parse the WAV format (fmt chunk) from the FIRST SUCCESSFUL RIFF chunk,
+    # not specifically chunk 0. If chunk 0 fails or comes back non-RIFF, we must
+    # still stitch the chunks that DID succeed rather than discarding all of them
+    # (double-billing) or returning only chunk 0 and dropping the rest.
+    non_riff_only = None  # remember a lone non-RIFF payload for the single-chunk case
     for i, chunk in enumerate(chunks):
         if not chunk.strip():
             continue
         try:
             chunk_audio = provider.generate_speech(text=chunk, voice=voice, **extra_kwargs)
-            if i == 0:
-                if chunk_audio[:4] == b'RIFF' and chunk_audio[8:12] == b'WAVE':
-                    pos = 12
-                    while pos < len(chunk_audio) - 8:
-                        chunk_id = chunk_audio[pos:pos + 4]
-                        chunk_size = struct.unpack('<I', chunk_audio[pos + 4:pos + 8])[0]
-                        if chunk_id == b'fmt ':
-                            fmt_data = chunk_audio[pos + 8:pos + 8 + chunk_size]
-                            num_channels = struct.unpack('<H', fmt_data[2:4])[0]
-                            sample_rate = struct.unpack('<I', fmt_data[4:8])[0]
-                            bits_per_sample = struct.unpack('<H', fmt_data[14:16])[0]
-                        elif chunk_id == b'data':
-                            all_audio_data += chunk_audio[pos + 8:pos + 8 + chunk_size]
-                            break
-                        pos += 8 + chunk_size
-                else:
-                    return chunk_audio
-            else:
-                if chunk_audio[:4] == b'RIFF':
-                    pos = 12
-                    while pos < len(chunk_audio) - 8:
-                        chunk_id = chunk_audio[pos:pos + 4]
-                        chunk_size = struct.unpack('<I', chunk_audio[pos + 4:pos + 8])[0]
-                        if chunk_id == b'data':
-                            all_audio_data += chunk_audio[pos + 8:pos + 8 + chunk_size]
-                            break
-                        pos += 8 + chunk_size
-            logger.info(f"  Chunk {i + 1}/{len(chunks)}: {len(chunk)} chars OK")
         except Exception as e:
             logger.error(f"  Chunk {i + 1}/{len(chunks)} FAILED: {e}")
+            continue
+
+        if chunk_audio[:4] == b'RIFF' and chunk_audio[8:12] == b'WAVE':
+            pos = 12
+            while pos < len(chunk_audio) - 8:
+                chunk_id = chunk_audio[pos:pos + 4]
+                chunk_size = struct.unpack('<I', chunk_audio[pos + 4:pos + 8])[0]
+                if chunk_id == b'fmt ' and sample_rate is None:
+                    fmt_data = chunk_audio[pos + 8:pos + 8 + chunk_size]
+                    num_channels = struct.unpack('<H', fmt_data[2:4])[0]
+                    sample_rate = struct.unpack('<I', fmt_data[4:8])[0]
+                    bits_per_sample = struct.unpack('<H', fmt_data[14:16])[0]
+                elif chunk_id == b'data':
+                    all_audio_data += chunk_audio[pos + 8:pos + 8 + chunk_size]
+                    break
+                pos += 8 + chunk_size
+            logger.info(f"  Chunk {i + 1}/{len(chunks)}: {len(chunk)} chars OK")
+        else:
+            # Non-RIFF payload (unexpected for a WAV provider). Don't let it drop the
+            # rest of the reply: if it's the only chunk we have anything from, keep it
+            # as a last resort; otherwise skip it and keep stitching the RIFF chunks.
+            logger.warning(f"  Chunk {i + 1}/{len(chunks)}: non-RIFF audio — skipping in concat")
+            if non_riff_only is None:
+                non_riff_only = chunk_audio
 
     if not all_audio_data or sample_rate is None:
+        if non_riff_only is not None:
+            logger.warning("No RIFF chunks stitched — returning the non-RIFF chunk as-is")
+            return non_riff_only
         logger.warning("All TTS chunks failed, trying truncated text")
         return provider.generate_speech(text=text[:max_chars], voice=voice, **extra_kwargs)
 
@@ -188,10 +192,15 @@ def generate_tts_chunked(provider, text: str, voice: str, max_chars: int = 800) 
 
 # ===== UNIFIED GENERATE FUNCTION =====
 
-# Fallback order when a provider fails (provider_id → fallback_id)
+# Fallback order when a provider fails (provider_id → next fallback_id).
+# The chain is followed TRANSITIVELY with cycle protection (TTS-7): e.g.
+# resemble → groq → supertonic, elevenlabs → groq → supertonic, groq →
+# supertonic. Kept as plain data so a later admin phase can make it
+# config-editable — this dict is the loadable default.
 _FALLBACK_CHAIN = {
     'groq': 'supertonic',
     'qwen3': 'groq',
+    'qwen3-local': 'groq',
     'resemble': 'groq',
     'elevenlabs': 'groq',
 }
@@ -213,6 +222,43 @@ _VOICE_GENDER = {
     'M1': 'M', 'M2': 'M', 'M3': 'M', 'M4': 'M', 'M5': 'M',
     'F1': 'F', 'F2': 'F', 'F3': 'F', 'F4': 'F', 'F5': 'F',
 }
+
+
+# Groq structured error codes (from groq_provider "[groq:<code>]") that are
+# client-side / non-retryable — treat like an HTTP 4xx and fall back immediately.
+_GROQ_4XX_CODES = (
+    'invalid_api_key', 'rate_limit_exceeded', 'model_terms_required',
+    'insufficient_quota', 'permission_denied', 'model_not_found',
+)
+
+
+def _classify_http_error(err_str: str) -> Optional[str]:
+    """Classify a provider error string as '4xx', '5xx', or None.
+
+    Recognizes the distinct shapes each provider raises (TTS-5):
+      - Resemble  : "Resemble API error 4xx/5xx"
+      - Groq      : "[groq:<code>] ..."  (string codes, mapped to 4xx/5xx)
+      - ElevenLabs: "ElevenLabs TTS error 401: ..."
+    A 4xx (bad auth / quota / rate-limit) must NEVER be retried — it won't fix
+    on retry and the retry sleep just delays the fallback.
+    """
+    # Numeric HTTP status embedded by Resemble / ElevenLabs
+    m = re.search(r'(?:API|TTS) error (\d{3})', err_str)
+    if m:
+        code = int(m.group(1))
+        if 400 <= code < 500:
+            return '4xx'
+        if 500 <= code < 600:
+            return '5xx'
+    # Groq structured code
+    gm = re.search(r'\[groq:([^\]]+)\]', err_str)
+    if gm:
+        gcode = gm.group(1)
+        if gcode in _GROQ_4XX_CODES or gcode.startswith('4'):
+            return '4xx'
+        if gcode.startswith('5') or gcode in ('internal_server_error', 'service_unavailable'):
+            return '5xx'
+    return None
 
 
 def _map_voice_to_fallback(voice: str, src_provider: str, dst_provider: str) -> str:
@@ -289,14 +335,13 @@ def generate_tts_b64(
 
     # ── Try primary provider ──────────────────────────────────────────────────
     last_err = None
-    # Resemble gets 6 attempts — the custom CLONE voice is worth waiting for; retrying a
-    # slow/timed-out cluster response is better than silence and FAR better than a wrong
-    # voice. Paired with STREAM_TIMEOUT=120s so a long reply finishes instead of being cut
-    # off. HTTP 5xx still bails fast (a real outage won't fix on retry).
-    # Other cloud providers (groq/elevenlabs) get 2 attempts.
-    if tts_provider == 'resemble':
-        max_attempts = 6
-    elif tts_provider in ('groq', 'qwen3', 'elevenlabs'):
+    # Resemble gets 2 attempts (was 6 — TTS-2). Its custom CLONE voice is worth a
+    # single retry on an intermittent cluster 500, but 6 attempts × a 120s timeout
+    # head-of-line-blocked the ordered flush for MINUTES. Chunking at 400 chars
+    # (see _generate_with_provider) keeps each request short, so 2 attempts against
+    # the now-30s STREAM_TIMEOUT is the sane ceiling. Other cloud providers
+    # (groq/elevenlabs/qwen3) also get 2.
+    if tts_provider in ('resemble', 'groq', 'qwen3', 'qwen3-local', 'elevenlabs'):
         max_attempts = 2
     else:
         max_attempts = _MAX_RETRIES + 1
@@ -308,15 +353,15 @@ def generate_tts_b64(
         except Exception as e:
             last_err = e
             err_str = str(e)
-            # 4xx = client error (bad auth/payload) — never retry. 5xx normally means a real
-            # outage, so most providers fast-fail. BUT Resemble's cluster throws INTERMITTENT
-            # 500s (a retry seconds later usually succeeds), so for Resemble we RETRY 5xx
-            # instead of dropping the sentence to silence — its base clone has no equal-voice
-            # fallback, so a missed retry = dead air. (2026-06-07)
-            is_4xx = 'API error 4' in err_str
-            is_5xx = 'API error 5' in err_str
-            if is_4xx or (is_5xx and tts_provider != 'resemble'):
-                logger.warning(f"TTS HTTP error, no retry (provider={tts_provider}): {e} — falling back")
+            # 4xx = client error (bad auth/payload/quota/rate-limit) — never retry;
+            # it won't fix on retry and the sleep just delays the fallback. 5xx is a
+            # real outage → most providers fast-fail. EXCEPTION: Resemble's cluster
+            # throws INTERMITTENT 500s (a retry seconds later usually succeeds), and
+            # its base clone has no equal-voice fallback, so for Resemble we retry a
+            # 5xx once instead of dropping straight to silence. (2026-06-07)
+            http_class = _classify_http_error(err_str)
+            if http_class == '4xx' or (http_class == '5xx' and tts_provider != 'resemble'):
+                logger.warning(f"TTS HTTP {http_class}, no retry (provider={tts_provider}): {e} — falling back")
                 break
             if attempt < max_attempts - 1:
                 delay = _RETRY_DELAYS[min(attempt, len(_RETRY_DELAYS) - 1)]
@@ -325,24 +370,32 @@ def generate_tts_b64(
             else:
                 logger.warning(f"TTS failed (provider={tts_provider}): {e} — trying fallback")
 
-    # ── Fallback to alternate provider ───────────────────────────────
-    fallback_id = _FALLBACK_CHAIN.get(tts_provider)
-    # Custom CLONED voices (Resemble — e.g. bhb's Kyle) must NEVER be substituted with a
-    # different voice. For tenants with RESEMBLE_NO_FALLBACK=1, a brief silence beats a
-    # wrong/switching voice (a slow Resemble sentence goes silent; the next retries the
-    # real clone). Default unchanged (fallback ON) for other tenants. (Mike 2026-06-07, bhb)
-    if tts_provider == 'resemble' and os.getenv('RESEMBLE_NO_FALLBACK', '').strip().lower() in ('1', 'true', 'yes', 'on'):
-        fallback_id = None
-    if fallback_id:
-        logger.info(f"TTS falling back: {tts_provider} → {fallback_id}")
+    # ── Fallback through the chain (transitive, cycle-protected — TTS-7) ──────
+    # e.g. resemble → groq → supertonic. If groq is also down, we keep walking
+    # to supertonic (free, always-on) instead of going silent.
+    # Custom CLONED voices (Resemble — e.g. bhb's Kyle) must NEVER be substituted
+    # with a different voice. For tenants with RESEMBLE_NO_FALLBACK=1, a brief
+    # silence beats a wrong/switching voice. (Mike 2026-06-07, bhb)
+    resemble_no_fallback = (
+        tts_provider == 'resemble'
+        and os.getenv('RESEMBLE_NO_FALLBACK', '').strip().lower() in ('1', 'true', 'yes', 'on')
+    )
+
+    tried = {tts_provider}
+    current = tts_provider
+    while not resemble_no_fallback:
+        fallback_id = _FALLBACK_CHAIN.get(current)
+        if not fallback_id or fallback_id in tried:
+            break
+        tried.add(fallback_id)
+        logger.info(f"TTS falling back: {current} → {fallback_id}")
         try:
-            fallback_provider = get_provider(fallback_id)
-            # Map the original voice to the closest match on the fallback provider
+            # Map the ORIGINAL voice to the closest match on the fallback provider
             # to minimize jarring voice switches mid-response.
             fallback_voice = _map_voice_to_fallback(voice, tts_provider, fallback_id)
             audio_bytes = _generate_with_provider(fallback_id, text, fallback_voice)
             logger.info(f"TTS fallback OK: provider={fallback_id}, voice={fallback_voice} (original: {tts_provider}/{voice})")
-            # Lock sticky fallback for non-Resemble providers — keeps voice consistent.
+            # Lock sticky fallback for non-Resemble originals — keeps voice consistent.
             # For Resemble: don't lock — next sentence should retry the real voice.
             if fallback_state is not None and tts_provider != 'resemble':
                 fallback_state['provider'] = fallback_id
@@ -350,7 +403,8 @@ def generate_tts_b64(
                 logger.info(f"TTS sticky fallback locked: {fallback_id}/{fallback_voice} for rest of response")
             return base64.b64encode(audio_bytes).decode('utf-8')
         except Exception as fb_err:
-            logger.error(f"TTS fallback also failed (provider={fallback_id}): {fb_err}")
+            logger.error(f"TTS fallback failed (provider={fallback_id}): {fb_err} — continuing down chain")
+            current = fallback_id  # walk to the next hop
 
     logger.error(f"TTS generation failed — all providers exhausted for: '{text[:60]}'")
     return None

--- a/services/tts.py
+++ b/services/tts.py
@@ -195,33 +195,16 @@ def generate_tts_chunked(provider, text: str, voice: str, max_chars: int = 800) 
 # Fallback order when a provider fails (provider_id → next fallback_id).
 # The chain is followed TRANSITIVELY with cycle protection (TTS-7): e.g.
 # resemble → groq → supertonic, elevenlabs → groq → supertonic, groq →
-# supertonic. Kept as plain data so a later admin phase can make it
-# config-editable — this dict is the loadable default.
-_FALLBACK_CHAIN = {
-    'groq': 'supertonic',
-    'qwen3': 'groq',
-    'qwen3-local': 'groq',
-    'resemble': 'groq',
-    'elevenlabs': 'groq',
-}
+# supertonic. The chain + voice-gender map now live in config/tts-fallback.json
+# (WO-3.1) and are read THROUGH services.tts_fallback at call time so an admin
+# edit takes effect on the next utterance with no restart. The inline defaults
+# in services.tts_fallback._DEFAULT_FALLBACK are the guaranteed fallback.
+from services.tts_fallback import (  # noqa: E402
+    get_fallback_chain, get_voice_gender_map,
+)
 
 _MAX_RETRIES = 2
 _RETRY_DELAYS = (0.5, 1.0, 1.5, 2.0)  # seconds between retries
-
-# Voice gender/character mapping across providers — keeps voice consistent on fallback.
-# Maps (source_provider, voice) → (fallback_provider) → fallback_voice.
-_VOICE_GENDER = {
-    # Groq Orpheus voices
-    'autumn': 'F', 'diana': 'F', 'hannah': 'F',
-    'austin': 'M', 'daniel': 'M', 'troy': 'M',
-    # ElevenLabs voices (common ones)
-    'rachel': 'F', 'drew': 'M', 'clyde': 'M', 'paul': 'M',
-    'domi': 'F', 'bella': 'F', 'antoni': 'M', 'elli': 'F',
-    'josh': 'M', 'arnold': 'M', 'adam': 'M', 'sam': 'M',
-    # Supertonic voices
-    'M1': 'M', 'M2': 'M', 'M3': 'M', 'M4': 'M', 'M5': 'M',
-    'F1': 'F', 'F2': 'F', 'F3': 'F', 'F4': 'F', 'F5': 'F',
-}
 
 
 # Groq structured error codes (from groq_provider "[groq:<code>]") that are
@@ -263,7 +246,7 @@ def _classify_http_error(err_str: str) -> Optional[str]:
 
 def _map_voice_to_fallback(voice: str, src_provider: str, dst_provider: str) -> str:
     """Map a voice from one provider to the closest equivalent on another."""
-    gender = _VOICE_GENDER.get(voice, 'M')  # default male if unknown
+    gender = get_voice_gender_map().get(voice, 'M')  # default male if unknown
     if dst_provider == 'supertonic':
         return 'M1' if gender == 'M' else 'F1'
     if dst_provider == 'groq':
@@ -384,7 +367,7 @@ def generate_tts_b64(
     tried = {tts_provider}
     current = tts_provider
     while not resemble_no_fallback:
-        fallback_id = _FALLBACK_CHAIN.get(current)
+        fallback_id = get_fallback_chain().get(current)
         if not fallback_id or fallback_id in tried:
             break
         tried.add(fallback_id)

--- a/services/tts_fallback.py
+++ b/services/tts_fallback.py
@@ -1,0 +1,187 @@
+"""
+TTS fallback-policy loader (WO-3.1).
+
+The TTS fallback chain + voice-gender map used to live as hardcoded dicts
+(_FALLBACK_CHAIN / _VOICE_GENDER) inside services/tts.py. They are now loadable
+from config/tts-fallback.json so the operator can reorder the fallback chain or
+extend voice-gender coverage from the admin 'Voice: TTS' tab without a code
+change — the runtime (services/tts.py) reads THROUGH this loader, so an edit
+takes effect on the next utterance with no restart.
+
+Load order (mirrors services/ai_providers.py exactly):
+  1. config/tts-fallback.json  (if present + parseable)  → file policy
+  2. _DEFAULT_FALLBACK          (inline fallback)          → never empty
+
+Shape:
+  {
+    "chain": { "<provider_id>": "<next_provider_id>", ... },
+    "voice_gender": { "<voice_id>": "M"|"F", ... }
+  }
+"chain" maps each provider to its SINGLE next-hop fallback; services/tts.py
+walks it transitively with cycle protection. "voice_gender" keeps a fallback on
+the same-gender voice.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_PATH = Path(__file__).parent.parent / "config" / "tts-fallback.json"
+
+# Inline fallback — the historical services/tts.py dicts, with voice_gender
+# coverage extended for qwen3/resemble/custom voices where determinable (TTS-12).
+_DEFAULT_FALLBACK: Dict[str, Any] = {
+    "chain": {
+        "groq": "supertonic",
+        "qwen3": "groq",
+        "qwen3-local": "groq",
+        "resemble": "groq",
+        "elevenlabs": "groq",
+    },
+    "voice_gender": {
+        # Groq Orpheus voices
+        "autumn": "F", "diana": "F", "hannah": "F",
+        "austin": "M", "daniel": "M", "troy": "M",
+        # ElevenLabs voices (common ones)
+        "rachel": "F", "drew": "M", "clyde": "M", "paul": "M",
+        "domi": "F", "bella": "F", "antoni": "M", "elli": "F",
+        "josh": "M", "arnold": "M", "adam": "M", "sam": "M",
+        # Supertonic voices
+        "M1": "M", "M2": "M", "M3": "M", "M4": "M", "M5": "M",
+        "F1": "F", "F2": "F", "F3": "F", "F4": "F", "F5": "F",
+        # Resemble custom clones (bhb Kyle Valhalla + friends) — TTS-12 partial
+        "kyle": "M", "valhalla": "M", "bhb": "M",
+        # Qwen3 preset voices (Fal.ai) — TTS-12 partial
+        "ethan": "M", "chelsie": "F", "cherry": "F", "serena": "F",
+        "dylan": "M", "jada": "F", "sunny": "F",
+    },
+}
+
+# mtime-cached load so an admin edit to the JSON is picked up without a restart,
+# while the hot path (each utterance) doesn't re-read disk every call.
+_CACHE: Dict[str, Any] | None = None
+_CACHE_MTIME: float = -1.0
+
+
+def load_tts_fallback() -> Dict[str, Any]:
+    """Return the TTS fallback policy {'chain': {...}, 'voice_gender': {...}}.
+
+    Reads config/tts-fallback.json (mtime-cached). Falls back to the inline
+    _DEFAULT_FALLBACK on any error so callers never get an empty policy.
+    """
+    global _CACHE, _CACHE_MTIME
+    try:
+        mtime = _CONFIG_PATH.stat().st_mtime
+    except OSError:
+        return {k: dict(v) for k, v in _DEFAULT_FALLBACK.items()}
+
+    if _CACHE is not None and mtime == _CACHE_MTIME:
+        return _CACHE
+
+    try:
+        raw = json.loads(_CONFIG_PATH.read_text())
+        if isinstance(raw, dict):
+            chain = raw.get("chain")
+            vg = raw.get("voice_gender")
+            if isinstance(chain, dict) and isinstance(vg, dict):
+                _CACHE = {"chain": chain, "voice_gender": vg}
+                _CACHE_MTIME = mtime
+                return _CACHE
+        logger.warning("tts-fallback.json missing chain/voice_gender — using inline default")
+    except Exception as exc:  # malformed JSON, permission, etc.
+        logger.warning("Failed to load tts-fallback.json (%s) — using inline default", exc)
+
+    return {k: dict(v) for k, v in _DEFAULT_FALLBACK.items()}
+
+
+def get_fallback_chain() -> Dict[str, str]:
+    """The provider_id -> next-hop provider_id fallback map (live)."""
+    return load_tts_fallback().get("chain", {})
+
+
+def get_voice_gender_map() -> Dict[str, str]:
+    """The voice_id -> 'M'|'F' map (live)."""
+    return load_tts_fallback().get("voice_gender", {})
+
+
+def invalidate() -> None:
+    """Drop the mtime cache so the next read re-loads from disk immediately."""
+    global _CACHE, _CACHE_MTIME
+    _CACHE = None
+    _CACHE_MTIME = -1.0
+
+
+def find_cycle(chain: Dict[str, str]) -> list | None:
+    """Return the first cycle found in the chain as a list of ids, else None.
+
+    The chain is single-successor, so a cycle is any node from which walking
+    `next` revisits a node already on the current path.
+    """
+    for start in chain:
+        seen = []
+        node = start
+        while node in chain:
+            if node in seen:
+                return seen[seen.index(node):] + [node]
+            seen.append(node)
+            node = chain[node]
+    return None
+
+
+def validate_fallback_policy(policy: Dict[str, Any], valid_ids: set) -> str | None:
+    """Validate a candidate fallback policy before it is written.
+
+    Checks:
+      - shape: 'chain' + 'voice_gender' are dicts
+      - every provider id referenced in the chain (source AND destination) is a
+        registered TTS provider
+      - the chain has no cycle (would loop the transitive walk)
+      - voice_gender values are 'M' or 'F'
+
+    Returns an error string on the first problem, or None if the policy is OK.
+    """
+    if not isinstance(policy, dict):
+        return "policy must be an object"
+    chain = policy.get("chain")
+    vg = policy.get("voice_gender")
+    if not isinstance(chain, dict):
+        return "chain must be an object of provider_id -> next_provider_id"
+    if not isinstance(vg, dict):
+        return "voice_gender must be an object of voice_id -> 'M'|'F'"
+
+    for src, dst in chain.items():
+        if not isinstance(dst, str):
+            return f"chain['{src}'] must be a provider id string"
+        if src not in valid_ids:
+            return f"unknown provider in chain (source): {src}"
+        if dst not in valid_ids:
+            return f"unknown provider in chain (destination): {dst}"
+        if src == dst:
+            return f"provider '{src}' cannot fall back to itself"
+
+    cycle = find_cycle(chain)
+    if cycle:
+        return "fallback chain has a cycle: " + " -> ".join(cycle)
+
+    for voice, gender in vg.items():
+        if gender not in ("M", "F"):
+            return f"voice_gender['{voice}'] must be 'M' or 'F', got: {gender}"
+
+    return None
+
+
+__all__ = [
+    "load_tts_fallback",
+    "get_fallback_chain",
+    "get_voice_gender_map",
+    "invalidate",
+    "find_cycle",
+    "validate_fallback_policy",
+    "_DEFAULT_FALLBACK",
+]

--- a/services/vault.py
+++ b/services/vault.py
@@ -1618,7 +1618,7 @@ def set_model_selection(username: str, primary: str = None, fallback: str = None
     if not _safe_exists(config_path):
         config_path = _OPENCLAW_CONFIG_PATH
     if not _safe_exists(config_path):
-        return
+        return {'ok': False, 'error': 'openclaw.json not found — cannot set model selection'}
 
     try:
         config = _parse_jsonc(config_path.read_text())
@@ -1627,10 +1627,10 @@ def set_model_selection(username: str, primary: str = None, fallback: str = None
             f"Cannot read {config_path} to set model selection ({exc}); "
             f"skipping. Phase 2 will store model selection in the vault."
         )
-        return
+        return {'ok': False, 'error': f'Cannot read openclaw.json ({exc})'}
     except Exception as exc:
         logger.error(f"Failed to parse {config_path}: {exc}")
-        return
+        return {'ok': False, 'error': f'Failed to parse openclaw.json ({exc})'}
 
     defaults = config.setdefault('agents', {}).setdefault('defaults', {})
     model_cfg = defaults.setdefault('model', {})
@@ -1650,7 +1650,12 @@ def set_model_selection(username: str, primary: str = None, fallback: str = None
         # on template-shaped tenants — tmp+rename breaks the mount.
         _write_json_inplace(config_path, config)
     except (PermissionError, OSError) as exc:
+        # Report the failure honestly instead of returning success — a silent
+        # no-op here is exactly the "model saved but nothing changed" bug
+        # (ADMIN-BUG-1). Callers surface this to the admin.
         logger.warning(
             f"Cannot write {config_path} ({exc}); model selection update "
-            f"skipped. Phase 2 will fix this properly."
+            f"failed. Use PUT /api/admin/ai-config (gateway config.patch) instead."
         )
+        return {'ok': False, 'error': f'Cannot write openclaw.json ({exc})'}
+    return {'ok': True}

--- a/src/admin.html
+++ b/src/admin.html
@@ -2078,13 +2078,28 @@ const Connections={
     const primary=$('vault-primary')?.value||'';
     const fallback=$('vault-fallback')?.value||'';
     try{
-      const r=await fetch('/api/vault/credentials/_model_selection',{
+      // WO-0.1: write through the hardened gateway config.patch path
+      // (PUT /api/admin/ai-config), NOT /api/vault/credentials/_model_selection.
+      // The old vault path did a direct openclaw.json write that silently
+      // returned success on a PermissionError (ADMIN-BUG-1) — "saved" but no
+      // change. This path is schema-validated and hot-applied by openclaw.
+      const r=await fetch('/api/admin/ai-config',{
         method:'PUT',headers:{'Content-Type':'application/json'},
         body:JSON.stringify({primary,fallback})
       });
       const d=await r.json();
-      if(d.ok) toast('Model selection saved','green');
-      else toast(d.error||'Failed','red');
+      if(!r.ok||!d.ok){ toast(d.error||d.message||('Failed ('+r.status+')'),'red'); return; }
+      // Confirm the applied value via a follow-up read rather than trusting the
+      // write response — surfaces any silent divergence honestly.
+      try{
+        const c=await fetch('/api/admin/ai-config');
+        const cd=await c.json();
+        if(cd&&cd.primary===primary){
+          toast('Model saved: '+cd.primary+(cd.fallback?' → '+cd.fallback:''),'green');
+        }else{
+          toast('Saved, but applied primary is '+((cd&&cd.primary)||'unknown')+' — verify','red');
+        }
+      }catch(_){ toast('Model selection saved','green'); }
     }catch(e){toast(e.message,'red')}
   },
   async test(id){

--- a/src/admin.html
+++ b/src/admin.html
@@ -373,6 +373,7 @@ select{cursor:pointer}
   </div>
   <div class="nav-section">
     <div class="nav-label">Config</div>
+    <div class="nav-item" id="nav-framework" onclick="show('framework')"><span class="nav-icon">&#x1F9E0;</span><span class="nav-text">Agent Framework</span></div>
     <div class="nav-item" id="nav-providers" onclick="show('providers')"><span class="nav-icon">&#x26A1;</span><span class="nav-text">Provider Config</span></div>
     <div class="nav-item" id="nav-connections" onclick="show('connections')"><span class="nav-icon">&#x1F517;</span><span class="nav-text">Connections</span></div>
     <div class="nav-item" id="nav-platform-setup" onclick="show('platform-setup')"><span class="nav-icon">&#x2699;</span><span class="nav-text">Platform Setup</span></div>
@@ -513,6 +514,15 @@ select{cursor:pointer}
         <span id="test-sum" style="font-size:12px;color:var(--dim)"></span>
       </div>
       <div style="display:flex;flex-direction:column;gap:6px" id="test-list"><div class="empty"><div class="empty-icon">&#x1F9EA;</div>Click Run All Tests to begin</div></div>
+    </div>
+  </div>
+
+  <!-- AGENT FRAMEWORK (WO-2.2) -->
+  <div class="panel" id="panel-framework">
+    <div class="panel-inner">
+      <div class="ph"><div class="ph-title">Agent Framework</div><div class="ph-sub">The backend agent brain per profile. Each card is a registered gateway &mdash; health, capabilities, live config, and which profiles use it.</div></div>
+      <div class="ph-row"><button class="btn btn-o" onclick="Framework.load()">&#8634; Refresh</button><span id="fw-active" style="font-size:12px;color:var(--dim);align-self:center;margin-left:8px"></span></div>
+      <div class="g2" id="fw-grid" style="align-items:start;gap:16px"><div class="loading"><div class="spin"></div>Loading...</div></div>
     </div>
   </div>
 
@@ -686,6 +696,7 @@ const loaders = {
   workspace:()=>Workspace.load(),
   music:()=>Music.load(),
   clients:()=>Clients.load(),
+  framework:()=>Framework.load(),
   providers:()=>Providers.load(),
   connections:()=>Connections.load(),
   'platform-setup':()=>PlatformSetup.load(),
@@ -1747,6 +1758,131 @@ const Tests={
 };
 
 // Providers
+// Agent Framework — cards per registered gateway (WO-2.2)
+const Framework={
+  gateways:[], active:null, health:{}, profiles:[],
+  async load(){
+    const g=$('fw-grid');
+    g.innerHTML='<div class="loading"><div class="spin"></div>Loading...</div>';
+    try{
+      const[gwR,hR,pR]=await Promise.all([
+        fetch('/api/admin/gateways'),
+        fetch('/api/services/health').catch(()=>null),
+        fetch('/api/profiles').catch(()=>null)
+      ]);
+      const gwd=await gwR.json();
+      this.gateways=gwd.gateways||[];
+      this.active=gwd.active_gateway;
+      this.health={};
+      if(hR&&hR.ok){const hd=await hR.json();(hd.services||[]).filter(s=>s.service==='gateway').forEach(s=>{this.health[s.id]=s})}
+      if(pR&&pR.ok){const pd=await pR.json();this.profiles=pd.profiles||[]}
+      $('fw-active').innerHTML=this.active?'Active gateway (current profile): <span style="color:var(--green)">'+esc(this.active)+'</span>':'';
+      this.render();
+    }catch(e){g.innerHTML='<div class="empty"><div class="empty-icon">&#x26A0;&#xFE0F;</div>'+esc(e.message)+'</div>'}
+  },
+  render(){
+    const g=$('fw-grid');
+    if(!this.gateways.length){g.innerHTML='<div class="empty">No gateways registered</div>';return}
+    g.innerHTML=this.gateways.map(gw=>{
+      const h=this.health[gw.id]||{healthy:gw.healthy,latency_ms:(gw.health||{}).latency_ms};
+      const healthy=h.healthy;
+      const ring='<span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:'+(healthy?'var(--green)':gw.configured?'var(--yellow,#e3b341)':'var(--red)')+';box-shadow:0 0 6px '+(healthy?'var(--green)':'transparent')+'"></span>';
+      const lat=(h.latency_ms!=null)?' <span style="color:var(--dim);font-size:11px">'+h.latency_ms+'ms</span>':'';
+      const caps=(gw.capabilities||[]).map(c=>'<span class="badge b-blue" style="font-size:10px">'+esc(c)+'</span>').join(' ');
+      const src=gw.source==='builtin'?'<span class="badge b-gray">builtin</span>':'<span class="badge b-gray">'+esc(gw.source)+'</span>';
+      const schema=gw.config_schema||{fields:[]};
+      const canConfig=schema.editable&&(schema.fields||[]).length;
+      const cfgBtn=canConfig?'<button class="btn btn-o btn-sm" onclick="Framework.toggleConfig(\''+esc(gw.id)+'\')">Configure</button>':'';
+      const usedBy=(gw.profiles||[]).length?'<div style="font-size:11px;color:var(--dim);margin-top:6px">Used by: '+gw.profiles.map(p=>esc(p)).join(', ')+'</div>':'';
+      const rscope=gw.restart_scope&&gw.restart_scope!=='none'?'<span class="badge b-yellow" style="font-size:10px" title="A config change restarts this">restarts: '+esc(gw.restart_scope)+'</span>':'';
+      // Per-profile "use for profile X" selector
+      const profOpts=this.profiles.map(p=>'<option value="'+esc(p.id)+'">'+esc(p.name||p.id)+'</option>').join('');
+      const useSel=this.profiles.length?
+        '<div style="display:flex;gap:6px;align-items:center;margin-top:10px;flex-wrap:wrap">'+
+          '<span style="font-size:11px;color:var(--dim)">Set as gateway for:</span>'+
+          '<select id="fw-prof-'+esc(gw.id)+'" style="background:var(--panel3);border:1px solid var(--border);border-radius:6px;padding:5px 9px;color:var(--text);font-size:12px">'+profOpts+'</select>'+
+          '<button class="btn btn-p btn-sm" onclick="Framework.assign(\''+esc(gw.id)+'\')">Apply</button>'+
+        '</div>':'';
+      return '<div class="box" style="padding:14px">'+
+        '<div style="display:flex;align-items:center;justify-content:space-between;gap:8px">'+
+          '<div style="display:flex;align-items:center;gap:8px">'+ring+'<span style="font-weight:600;color:var(--bright)">'+esc(gw.name||gw.id)+'</span>'+lat+'</div>'+
+          '<div style="display:flex;gap:6px;align-items:center">'+src+cfgBtn+'</div>'+
+        '</div>'+
+        '<div style="font-size:11px;color:var(--dim);margin-top:3px">'+esc(gw.id)+(gw.persistent?' &middot; persistent':' &middot; on-demand')+(gw.configured?'':' &middot; <span style="color:var(--red)">not configured</span>')+'</div>'+
+        '<div style="margin-top:8px;display:flex;gap:5px;flex-wrap:wrap">'+caps+' '+rscope+'</div>'+
+        usedBy+useSel+
+        '<div id="fw-config-'+esc(gw.id)+'" style="display:none;margin-top:12px;border-top:1px solid var(--border2);padding-top:12px"></div>'+
+      '</div>';
+    }).join('');
+  },
+  toggleConfig(id){
+    const panel=$('fw-config-'+id);
+    if(!panel)return;
+    if(panel.style.display!=='none'){panel.style.display='none';return}
+    panel.style.display='';
+    const gw=this.gateways.find(g=>g.id===id);
+    if(!gw){panel.innerHTML='';return}
+    const fields=(gw.config_schema||{}).fields||[];
+    const renderField=(f)=>{
+      const fid='fwc-'+id+'-'+f.id;
+      if(f.type==='password'){
+        return '<div style="margin-bottom:10px">'+
+          '<label style="display:block;font-size:12px;font-weight:500;color:var(--text);margin-bottom:4px">'+esc(f.label||f.id)+(f.required?' *':'')+'</label>'+
+          '<input type="password" id="'+fid+'" placeholder="'+esc(f.placeholder||'')+'" autocomplete="off" style="width:100%;background:var(--panel3);border:1px solid var(--border);border-radius:6px;padding:7px 11px;color:var(--text);font-family:var(--mono);font-size:13px">'+
+        '</div>';
+      }
+      if(f.type==='toggle'){
+        return '<div style="margin-bottom:10px"><label style="display:flex;align-items:center;gap:8px;cursor:pointer"><input type="checkbox" id="'+fid+'"'+(f.default?' checked':'')+' style="width:16px;height:16px;accent-color:var(--blue)"><span style="font-size:12px;color:var(--text)">'+esc(f.label||f.id)+'</span></label></div>';
+      }
+      // text / number / default
+      return '<div style="margin-bottom:10px">'+
+        '<label style="display:block;font-size:12px;font-weight:500;color:var(--text);margin-bottom:4px">'+esc(f.label||f.id)+(f.required?' *':'')+'</label>'+
+        '<input type="text" id="'+fid+'" placeholder="'+esc(f.placeholder||'')+'" style="width:100%;background:var(--panel3);border:1px solid var(--border);border-radius:6px;padding:7px 11px;color:var(--text);font-size:13px">'+
+      '</div>';
+    };
+    panel.innerHTML=fields.map(renderField).join('')+
+      '<div style="display:flex;gap:8px;align-items:center;margin-top:8px">'+
+        '<button class="btn btn-g btn-sm" onclick="Framework.saveConfig(\''+esc(id)+'\')">Apply Config</button>'+
+        '<span id="fwc-status-'+esc(id)+'" style="font-size:12px;color:var(--dim)"></span>'+
+      '</div>'+
+      '<div style="font-size:10px;color:var(--dim);margin-top:6px">Empty fields are ignored. Keys route through the vault; model refs use the framework config API.</div>';
+  },
+  async saveConfig(id){
+    const gw=this.gateways.find(g=>g.id===id);if(!gw)return;
+    const fields=(gw.config_schema||{}).fields||[];
+    const payload={};const keys={};
+    fields.forEach(f=>{
+      const el=$('fwc-'+id+'-'+f.id);if(!el)return;
+      let v=el.type==='checkbox'?el.checked:el.value.trim();
+      if(el.type!=='checkbox'&&!v)return;
+      // Model refs (primary/fallback) go top-level; credential fields go under keys{provider}
+      if(f.credential){ keys[f.provider||f.id]=v; }
+      else { payload[f.id]=v; }
+    });
+    if(Object.keys(keys).length)payload.keys=keys;
+    if(!Object.keys(payload).length){toast('Nothing to apply','yellow');return}
+    const st=$('fwc-status-'+id);if(st)st.textContent='Applying...';
+    try{
+      const r=await fetch('/api/admin/gateways/'+encodeURIComponent(id)+'/configure',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+      const d=await r.json();
+      if(d.ok){
+        const msg=(d.status==='needs_restart'?'Applied (needs restart)':'Applied')+(d.message?' — '+d.message:'');
+        if(st)st.textContent=msg;toast(msg,'green');
+      }else{if(st)st.textContent=d.error||'Failed';toast(d.error||'Configure failed','red')}
+    }catch(e){if(st)st.textContent=e.message;toast(e.message,'red')}
+  },
+  async assign(gatewayId){
+    const sel=$('fw-prof-'+gatewayId);if(!sel)return;
+    const profileId=sel.value;if(!profileId)return;
+    try{
+      const r=await fetch('/api/profiles/'+encodeURIComponent(profileId),{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({adapter_config:{gateway_id:gatewayId}})});
+      const d=await r.json();
+      if(d.id||d.name){toast(profileId+' → '+gatewayId+' (refresh voice app to apply)','green');this.load();}
+      else toast(d.error||'Assign failed','red');
+    }catch(e){toast(e.message,'red')}
+  }
+};
+
 const Providers={
   sel:{llm:null,tts:null,stt:null},
   profileId:null,

--- a/src/admin.html
+++ b/src/admin.html
@@ -375,6 +375,8 @@ select{cursor:pointer}
     <div class="nav-label">Config</div>
     <div class="nav-item" id="nav-framework" onclick="show('framework')"><span class="nav-icon">&#x1F9E0;</span><span class="nav-text">Agent Framework</span></div>
     <div class="nav-item" id="nav-providers" onclick="show('providers')"><span class="nav-icon">&#x26A1;</span><span class="nav-text">Provider Config</span></div>
+    <div class="nav-item" id="nav-tts" onclick="show('tts')"><span class="nav-icon">&#x1F5E3;</span><span class="nav-text">Voice: TTS</span></div>
+    <div class="nav-item" id="nav-stt" onclick="show('stt')"><span class="nav-icon">&#x1F3A4;</span><span class="nav-text">Voice: STT &amp; Wake</span></div>
     <div class="nav-item" id="nav-connections" onclick="show('connections')"><span class="nav-icon">&#x1F517;</span><span class="nav-text">Connections</span></div>
     <div class="nav-item" id="nav-platform-setup" onclick="show('platform-setup')"><span class="nav-icon">&#x2699;</span><span class="nav-text">Platform Setup</span></div>
   </div>
@@ -537,6 +539,24 @@ select{cursor:pointer}
   </div>
 
 
+  <!-- VOICE: TTS (WO-3.1) -->
+  <div class="panel" id="panel-tts">
+    <div class="panel-inner">
+      <div class="ph"><div class="ph-title">Voice &mdash; Text to Speech</div><div class="ph-sub">Provider &amp; voice for the active agent, the cross-provider fallback chain, and a per-provider test-speak. Providers are sourced live from the TTS registry &mdash; adding one never needs a panel edit.</div></div>
+      <div class="ph-row"><button class="btn btn-o" onclick="TTS.load()">&#8634; Refresh</button><span id="tts-active" style="font-size:12px;color:var(--dim);align-self:center;margin-left:8px"></span></div>
+      <div id="tts-content"><div class="loading"><div class="spin"></div>Loading...</div></div>
+    </div>
+  </div>
+
+  <!-- VOICE: STT & WAKE (WO-3.2) -->
+  <div class="panel" id="panel-stt">
+    <div class="panel-inner">
+      <div class="ph"><div class="ph-title">Voice &mdash; Speech to Text &amp; Wake</div><div class="ph-sub">STT provider for the active agent, wake-word phrases, and a live per-provider connection test. Providers are sourced from the Service Catalog.</div></div>
+      <div class="ph-row"><button class="btn btn-o" onclick="STT.load()">&#8634; Refresh</button><span id="stt-active" style="font-size:12px;color:var(--dim);align-self:center;margin-left:8px"></span></div>
+      <div id="stt-content"><div class="loading"><div class="spin"></div>Loading...</div></div>
+    </div>
+  </div>
+
   <!-- CONNECTIONS (replaces AI CONFIG) -->
   <div class="panel" id="panel-connections">
     <div class="panel-inner">
@@ -698,6 +718,8 @@ const loaders = {
   clients:()=>Clients.load(),
   framework:()=>Framework.load(),
   providers:()=>Providers.load(),
+  tts:()=>TTS.load(),
+  stt:()=>STT.load(),
   connections:()=>Connections.load(),
   'platform-setup':()=>PlatformSetup.load(),
   system:()=>System.load(),
@@ -774,6 +796,7 @@ const Builder = {
   profiles:[], currentId:null, activeId:null, _voice:null, activeTab:'general',
 
   async load(){
+    await Catalog.get();  // WO-3.3 — preload the Service Catalog for the editor dropdowns
     const r=await fetch('/api/profiles').catch(()=>null);
     if(!r){$('builder-agent-list').innerHTML='<div style="padding:14px;color:var(--red)">Error loading profiles</div>';return}
     const d=await r.json();
@@ -861,6 +884,21 @@ const Builder = {
     sel.innerHTML=filtered.map(v=>'<option value="'+esc(v)+'">'+esc(v)+'</option>').join('');
   },
 
+  // WO-3.3 — build <option>s from the Service Catalog with a static fallback.
+  // leadOpts = pseudo-providers (e.g. the OpenClaw 'gateway') pinned on top that
+  // the catalog doesn't list. If the catalog is unavailable, staticHtml is used
+  // verbatim so the editor never loses its provider list.
+  _catOpts(type,sel,staticHtml,leadOpts){
+    const list=Catalog.list(type);
+    if(!list.length)return staticHtml;
+    const ids=(leadOpts||[]).map(o=>o.id).concat(list.map(s=>s.id));
+    let html=(leadOpts||[]).map(o=>'<option value="'+esc(o.id)+'"'+(o.id===sel?' selected':'')+'>'+esc(o.label)+'</option>').join('');
+    html+=list.map(s=>'<option value="'+esc(s.id)+'"'+(s.id===sel?' selected':'')+'>'+esc(s.name||s.id)+'</option>').join('');
+    // Preserve a saved value the catalog doesn't know about (e.g. 'zai/glm-5.1').
+    if(sel&&ids.indexOf(sel)===-1)html='<option value="'+esc(sel)+'" selected>'+esc(sel)+' (current)</option>'+html;
+    return html;
+  },
+
   renderEditor(id,p){
     const defaultVoices=['M1','M2','M3','M4','M5','F1','F2','F3','F4','F5'];
     const selVoice=this._voice||p.voice?.voice_id||'M1';
@@ -893,24 +931,26 @@ const Builder = {
       '</div>'+
       '<div class="g2" style="margin-bottom:14px">'+
         '<div class="fg"><label class="fl">LLM / Agent System</label><select id="be-llm">'+
-          '<option value="gateway"'+(llmProv==='gateway'?' selected':'')+'>OpenClaw Gateway (default)</option>'+
-          '<option value="zai"'+(llmProv==='zai'?' selected':'')+'>Z.AI GLM-5-turbo</option>'+
-          '<option value="zai/glm-5.1"'+((llmProv==='zai/glm-5.1')?' selected':'')+'>Z.AI GLM-5.1</option>'+
-          '<option value="zai/glm-5-turbo"'+((llmProv==='zai/glm-5-turbo')?' selected':'')+'>Z.AI GLM-5-turbo (direct)</option>'+
-          '<option value="groq"'+(llmProv==='groq'?' selected':'')+'>Groq (Llama / Qwen)</option>'+
-
-          '<option value="gemini"'+(llmProv==='gemini'?' selected':'')+'>Google Gemini</option>'+
-          '<option value="hume_evi"'+(llmProv==='hume_evi'?' selected':'')+'>Hume EVI</option>'+
-          '<option value="elevenlabs"'+(llmProv==='elevenlabs'?' selected':'')+'>ElevenLabs AI</option>'+
-          '<option value="openai"'+(llmProv==='openai'?' selected':'')+'>OpenAI</option>'+
+          this._catOpts('llm',llmProv,
+            '<option value="gateway"'+(llmProv==='gateway'?' selected':'')+'>OpenClaw Gateway (default)</option>'+
+            '<option value="zai"'+(llmProv==='zai'?' selected':'')+'>Z.AI GLM-5-turbo</option>'+
+            '<option value="zai/glm-5.1"'+((llmProv==='zai/glm-5.1')?' selected':'')+'>Z.AI GLM-5.1</option>'+
+            '<option value="zai/glm-5-turbo"'+((llmProv==='zai/glm-5-turbo')?' selected':'')+'>Z.AI GLM-5-turbo (direct)</option>'+
+            '<option value="groq"'+(llmProv==='groq'?' selected':'')+'>Groq (Llama / Qwen)</option>'+
+            '<option value="gemini"'+(llmProv==='gemini'?' selected':'')+'>Google Gemini</option>'+
+            '<option value="hume_evi"'+(llmProv==='hume_evi'?' selected':'')+'>Hume EVI</option>'+
+            '<option value="elevenlabs"'+(llmProv==='elevenlabs'?' selected':'')+'>ElevenLabs AI</option>'+
+            '<option value="openai"'+(llmProv==='openai'?' selected':'')+'>OpenAI</option>',
+            [{id:'gateway',label:'OpenClaw Gateway (default)'}])+
         '</select></div>'+
         '<div class="fg"><label class="fl">TTS Provider</label><select id="be-tts" onchange="Builder._renderVoiceGrid(this.value,null)">'+
-          '<option value="supertonic"'+(ttsProv==='supertonic'?' selected':'')+'>Supertonic (Free &middot; Local)</option>'+
-          '<option value="groq"'+(ttsProv==='groq'?' selected':'')+'>Groq Orpheus (Fast &middot; Cloud)</option>'+
-          '<option value="resemble"'+(ttsProv==='resemble'?' selected':'')+'>Resemble AI (Premium &middot; Cloud)</option>'+
-          '<option value="qwen3"'+(ttsProv==='qwen3'?' selected':'')+'>Qwen3 Voice Clone (Cloud)</option>'+
-          '<option value="hume"'+(ttsProv==='hume'?' selected':'')+'>Hume EVI</option>'+
-          '<option value="elevenlabs"'+(ttsProv==='elevenlabs'?' selected':'')+'>ElevenLabs</option>'+
+          this._catOpts('tts',ttsProv,
+            '<option value="supertonic"'+(ttsProv==='supertonic'?' selected':'')+'>Supertonic (Free &middot; Local)</option>'+
+            '<option value="groq"'+(ttsProv==='groq'?' selected':'')+'>Groq Orpheus (Fast &middot; Cloud)</option>'+
+            '<option value="resemble"'+(ttsProv==='resemble'?' selected':'')+'>Resemble AI (Premium &middot; Cloud)</option>'+
+            '<option value="qwen3"'+(ttsProv==='qwen3'?' selected':'')+'>Qwen3 Voice Clone (Cloud)</option>'+
+            '<option value="hume"'+(ttsProv==='hume'?' selected':'')+'>Hume EVI</option>'+
+            '<option value="elevenlabs"'+(ttsProv==='elevenlabs'?' selected':'')+'>ElevenLabs</option>')+
         '</select></div>'+
       '</div>'+
       '<div class="fg"><label class="fl">Voice</label>'+
@@ -1758,6 +1798,22 @@ const Tests={
 };
 
 // Providers
+// Service Catalog helper (WO-3.3) — single fetch, cached, graceful fallback.
+// The admin panel becomes a renderer over /api/services/catalog instead of
+// hardcoding provider lists. Callers pass a static fallback so a failed fetch
+// (or an old backend without the endpoint) still shows sensible options.
+const Catalog={
+  _data:null,
+  async get(force){
+    if(this._data&&!force)return this._data;
+    try{const r=await fetch('/api/services/catalog');if(r.ok){this._data=await r.json();return this._data}}catch(e){}
+    return this._data||{services:[],credential_status:{}};
+  },
+  // Return [{id,name,...descriptor}] for a service type, or [] if unavailable.
+  list(type,data){return ((data||this._data||{}).services||[]).filter(s=>s.service===type)},
+  cred(id,data){return ((data||this._data||{}).credential_status||{})[id]||null}
+};
+
 // Agent Framework — cards per registered gateway (WO-2.2)
 const Framework={
   gateways:[], active:null, health:{}, profiles:[],
@@ -1923,7 +1979,42 @@ const Providers={
         stt:d.stt?.provider||'webspeech'
       };
     }catch(e){this.sel={llm:'gateway',tts:'supertonic',stt:'webspeech'}}
+    // WO-3.3 — source provider options from the Service Catalog (with the
+    // hardcoded lists as a graceful fallback if the catalog is unavailable).
+    await this._buildFromCatalog();
     this.render();
+  },
+  // Merge catalog descriptors over the static lists: keep the nice static
+  // detail text where an id matches, add any provider the catalog reports that
+  // the static list is missing (so resemble/qwen3/plugins never drift out).
+  async _buildFromCatalog(){
+    // Capture the hardcoded lists ONCE so re-loads always fall back cleanly
+    // (this.PROV gets reassigned from the catalog below).
+    if(!this._static)this._static={llm:this.PROV.llm,tts:this.PROV.tts,stt:this.PROV.stt};
+    const STATIC=this._static;
+    try{
+      const c=await Catalog.get();
+      const merge=(type,extraKeep)=>{
+        const desc=Catalog.list(type,c);
+        if(!desc.length)return STATIC[type];
+        const byId={};STATIC[type].forEach(p=>byId[p.id]=p);
+        return desc.map(s=>{
+          const st=byId[s.id];
+          let detail=st?st.detail:'';
+          if(!detail){const m=s.meta||{};detail=(m.latency?m.latency+' latency. ':'')+(m.note||m.api||s.source||'');}
+          return {id:s.id,name:s.name||(st&&st.name)||s.id,detail:detail||'—'};
+        });
+      };
+      // LLM options in the profile also include the gateway pseudo-provider,
+      // which the catalog doesn't list — keep it pinned at the top.
+      const llm=merge('llm');
+      const hasGateway=llm.some(p=>p.id==='gateway');
+      this.PROV={
+        llm:hasGateway?llm:[STATIC.llm.find(p=>p.id==='gateway')].concat(llm),
+        tts:merge('tts'),
+        stt:merge('stt')
+      };
+    }catch(e){/* keep static PROV */}
   },
   render(){
     const mkCol=(type,label,items)=>
@@ -1972,9 +2063,322 @@ const Providers={
     const results=[];
     try{const d=await(await fetch('/api/admin/gateway/status')).json();results.push('LLM: '+(d.ok||d.healthy||d.connected?'OK':'FAIL'))}catch{results.push('LLM: error')}
     try{const d=await(await fetch('/health/ready')).json();results.push('TTS: '+(d.details?.tts?.healthy?'OK':'FAIL'))}catch{results.push('TTS: error')}
-    results.push('STT: OK (browser)');
+    // ADMIN-BUG-4 — honest STT check. WebSpeech is a browser API (nothing to
+    // probe server-side); cloud providers are checked by real key presence
+    // (labeled as such — not a live vendor ping).
+    const stt=this.sel.stt;
+    if(stt==='webspeech'){results.push('STT: browser API (can’t test server-side)')}
+    else if(stt==='whisper'){results.push('STT(whisper): local, no key')}
+    else{
+      try{
+        const c=await Catalog.get(true);
+        const d=Catalog.list('stt',c).find(s=>s.id===stt);
+        const hasKey=d&&d.health&&d.health.has_key;
+        results.push('STT('+stt+'): '+(hasKey?'key present':'no key')+' (key check only)');
+      }catch{results.push('STT('+stt+'): error')}
+    }
     $('prov-status').textContent=results.join(' | ');
     toast(results.join(' | '),'blue');
+  }
+};
+
+
+// Voice: TTS (WO-3.1) — provider/voice override, fallback-chain editor, test-speak
+const TTS={
+  profileId:null, providers:[], voicesByProv:{}, sel:{provider:'supertonic',voice:''},
+  fallback:{chain:{},voice_gender:{},provider_ids:[]}, credStatus:{},
+  async load(){
+    const el=$('tts-content');
+    el.innerHTML='<div class="loading"><div class="spin"></div>Loading...</div>';
+    try{
+      const[cat,provR,profR,fbR]=await Promise.all([
+        Catalog.get(true),
+        fetch('/api/tts/providers').then(r=>r.ok?r.json():{providers:[]}).catch(()=>({providers:[]})),
+        fetch('/api/profiles/active').then(r=>r.ok?r.json():null).catch(()=>null),
+        fetch('/api/admin/tts-fallback').then(r=>r.ok?r.json():null).catch(()=>null)
+      ]);
+      this.credStatus=(cat&&cat.credential_status)||{};
+      // Prefer the live registry (voices, status); fall back to catalog tts ids.
+      let provs=(provR&&provR.providers)||[];
+      if(!provs.length){provs=Catalog.list('tts',cat).map(s=>({provider_id:s.id,name:s.name,voices:[],status:s.health&&s.health.healthy?'active':'inactive'}))}
+      this.providers=provs;
+      this.voicesByProv={};
+      provs.forEach(p=>{
+        const id=p.provider_id||p.id;
+        const vs=(p.voices||[]).map(v=>{
+          if(typeof v==='string')return {id:v,label:v};
+          return {id:v.id||v.voice_id||v.name||'',label:v.name||v.id||v.voice_id||''};
+        }).filter(v=>v.id);
+        this.voicesByProv[id]=vs;
+      });
+      if(profR){
+        this.profileId=profR.id;
+        this.sel.provider=profR.voice?.tts_provider||provR.default_provider||'supertonic';
+        this.sel.voice=profR.voice?.voice_id||'';
+        $('tts-active').innerHTML='Active profile: <span style="color:var(--green)">'+esc(profR.id)+'</span>';
+      }
+      if(fbR){this.fallback={chain:fbR.chain||{},voice_gender:fbR.voice_gender||{},provider_ids:fbR.provider_ids||[]}}
+      this.render();
+    }catch(e){el.innerHTML='<div class="empty"><div class="empty-icon">&#x26A0;&#xFE0F;</div>'+esc(e.message)+'</div>'}
+  },
+  _voiceOpts(pid,selected){
+    const vs=this.voicesByProv[pid]||[];
+    if(!vs.length)return '<option value="">(provider default)</option>';
+    return '<option value="">(provider default)</option>'+vs.map(v=>'<option value="'+esc(v.id)+'"'+(v.id===selected?' selected':'')+'>'+esc(v.label)+'</option>').join('');
+  },
+  render(){
+    const provOpts=this.providers.map(p=>{const id=p.provider_id||p.id;return '<option value="'+esc(id)+'"'+(id===this.sel.provider?' selected':'')+'>'+esc(p.name||id)+'</option>'}).join('');
+    // ── Active-profile override ──
+    let html='<div class="box" style="padding:16px;margin-bottom:16px">'+
+      '<div class="sect-label" style="margin-top:0">Active Profile Voice</div>'+
+      '<div class="g2" style="margin-bottom:10px">'+
+        '<div class="fg"><label class="fl">TTS Provider</label><select id="tts-prov" onchange="TTS.onProv(this.value)">'+provOpts+'</select></div>'+
+        '<div class="fg"><label class="fl">Voice</label><select id="tts-voice">'+this._voiceOpts(this.sel.provider,this.sel.voice)+'</select></div>'+
+      '</div>'+
+      '<div style="display:flex;gap:8px;align-items:center">'+
+        '<button class="btn btn-g" onclick="TTS.saveOverride()">Save to Active Profile</button>'+
+        '<span id="tts-ov-status" style="font-size:12px;color:var(--dim)"></span>'+
+      '</div>'+
+      (this.profileId?'':'<div style="font-size:11px;color:var(--yellow);margin-top:6px">No active profile loaded — save disabled.</div>')+
+    '</div>';
+    // ── Provider cards: key status + test-speak ──
+    html+='<div class="sect-label">Providers &mdash; status &amp; test</div><div class="g2" style="align-items:start;gap:12px">';
+    html+=this.providers.map(p=>{
+      const id=p.provider_id||p.id;
+      const active=(p.status||'active')==='active';
+      const ring='<span style="display:inline-block;width:9px;height:9px;border-radius:50%;background:'+(active?'var(--green)':'var(--red)')+'"></span>';
+      const needsKey=p.requires_api_key;
+      const keyChip=needsKey?('<span class="badge '+(p.has_key===false?'b-gray':'b-blue')+'" style="font-size:10px">'+(p.has_key===false?'no key':'key set')+'</span>'):'<span class="badge b-gray" style="font-size:10px">no key needed</span>';
+      const vopts=this._voiceOpts(id,'');
+      return '<div class="box" style="padding:12px">'+
+        '<div style="display:flex;align-items:center;gap:8px">'+ring+'<span style="font-weight:600;color:var(--bright)">'+esc(p.name||id)+'</span>'+keyChip+'</div>'+
+        '<div style="font-size:11px;color:var(--dim);margin-top:3px">'+esc(id)+(p.latency?' &middot; '+esc(p.latency):'')+(p.cost_per_minute!=null?' &middot; $'+esc(String(p.cost_per_minute))+'/min':'')+'</div>'+
+        '<div style="display:flex;gap:6px;align-items:center;margin-top:10px;flex-wrap:wrap">'+
+          '<select id="tts-test-voice-'+esc(id)+'" style="background:var(--panel3);border:1px solid var(--border);border-radius:6px;padding:5px 8px;color:var(--text);font-size:12px;max-width:150px">'+vopts+'</select>'+
+          '<button class="btn btn-o btn-sm" onclick="TTS.testSpeak(\''+esc(id)+'\')">&#x25B6; Test speak</button>'+
+          '<span id="tts-test-status-'+esc(id)+'" style="font-size:11px;color:var(--dim)"></span>'+
+        '</div>'+
+      '</div>';
+    }).join('');
+    html+='</div>';
+    // ── Fallback chain editor ──
+    html+=this._fallbackEditor();
+    $('tts-content').innerHTML=html;
+  },
+  onProv(pid){
+    this.sel.provider=pid;
+    const v=$('tts-voice');if(v)v.innerHTML=this._voiceOpts(pid,'');
+  },
+  async saveOverride(){
+    if(!this.profileId){toast('No active profile','red');return}
+    const provider=$('tts-prov')?.value; const voice=$('tts-voice')?.value||undefined;
+    const st=$('tts-ov-status');if(st)st.textContent='Saving...';
+    try{
+      const r=await fetch('/api/profiles/'+encodeURIComponent(this.profileId),{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({voice:{tts_provider:provider,voice_id:voice}})});
+      const d=await r.json();
+      if(d.id||d.name){if(st)st.textContent='Saved (refresh voice app to apply)';toast('TTS saved to '+this.profileId,'green')}
+      else{if(st)st.textContent=d.error||'Failed';toast(d.error||'Save failed','red')}
+    }catch(e){if(st)st.textContent=e.message;toast(e.message,'red')}
+  },
+  async testSpeak(pid){
+    const voice=$('tts-test-voice-'+pid)?.value||undefined;
+    const st=$('tts-test-status-'+pid);if(st)st.textContent='Generating...';
+    try{
+      const body={text:'This is a test of the '+pid+' voice.',provider:pid};
+      if(voice)body.voice=voice;
+      const r=await fetch('/api/tts/generate',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+      if(!r.ok){const e=await r.json().catch(()=>({}));if(st)st.textContent=e.error||('HTTP '+r.status);toast(e.error||'TTS failed','red');return}
+      const blob=await r.blob();
+      const url=URL.createObjectURL(blob);
+      const a=new Audio(url);
+      a.onended=()=>URL.revokeObjectURL(url);
+      a.onerror=()=>{if(st)st.textContent='playback error';URL.revokeObjectURL(url)};
+      await a.play();
+      if(st)st.textContent='Playing '+(r.headers.get('X-TTS-Provider')||pid);
+    }catch(e){if(st)st.textContent=e.message;toast(e.message,'red')}
+  },
+  _fallbackEditor(){
+    const ids=this.fallback.provider_ids.length?this.fallback.provider_ids:this.providers.map(p=>p.provider_id||p.id);
+    const chain=this.fallback.chain||{};
+    let h='<div class="box" style="padding:16px;margin-top:16px">'+
+      '<div class="sect-label" style="margin-top:0">Fallback Chain</div>'+
+      '<div style="font-size:11px;color:var(--dim);margin-bottom:10px">When a provider fails, the next hop is tried (followed transitively, cycle-checked on save). Takes effect on the next utterance &mdash; no restart.</div>';
+    h+=ids.map(id=>{
+      const cur=chain[id]||'';
+      const opts='<option value="">(no fallback)</option>'+ids.filter(o=>o!==id).map(o=>'<option value="'+esc(o)+'"'+(o===cur?' selected':'')+'>'+esc(o)+'</option>').join('');
+      return '<div style="display:flex;gap:8px;align-items:center;margin-bottom:6px">'+
+        '<span style="min-width:120px;font-size:12px;color:var(--text)">'+esc(id)+'</span>'+
+        '<span style="color:var(--dim)">&rarr;</span>'+
+        '<select id="tts-fb-'+esc(id)+'" style="background:var(--panel3);border:1px solid var(--border);border-radius:6px;padding:5px 9px;color:var(--text);font-size:12px">'+opts+'</select>'+
+      '</div>';
+    }).join('');
+    h+='<div style="display:flex;gap:8px;align-items:center;margin-top:10px">'+
+        '<button class="btn btn-g btn-sm" onclick="TTS.saveFallback()">Save Chain</button>'+
+        '<span id="tts-fb-status" style="font-size:12px;color:var(--dim)"></span>'+
+      '</div></div>';
+    return h;
+  },
+  async saveFallback(){
+    const ids=this.fallback.provider_ids.length?this.fallback.provider_ids:this.providers.map(p=>p.provider_id||p.id);
+    const chain={};
+    ids.forEach(id=>{const v=$('tts-fb-'+id)?.value;if(v)chain[id]=v});
+    const st=$('tts-fb-status');if(st)st.textContent='Saving...';
+    try{
+      const r=await fetch('/api/admin/tts-fallback',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({chain:chain,voice_gender:this.fallback.voice_gender})});
+      const d=await r.json();
+      if(d.ok){this.fallback.chain=d.chain||chain;if(st)st.textContent='Saved';toast('Fallback chain saved','green')}
+      else{if(st)st.textContent=d.error||'Failed';toast(d.error||'Save failed','red')}
+    }catch(e){if(st)st.textContent=e.message;toast(e.message,'red')}
+  }
+};
+
+
+// Voice: STT & Wake (WO-3.2) — provider per profile, wake phrases, honest tests
+const STT={
+  profileId:null, sel:'webspeech', wake:[], descriptors:[], credStatus:{},
+  // STT provider id -> vault credential id (where the key is managed via vault).
+  VAULT_CRED:{deepgram:'deepgram',groq_whisper:'groq_tts'},
+  async load(){
+    const el=$('stt-content');
+    el.innerHTML='<div class="loading"><div class="spin"></div>Loading...</div>';
+    try{
+      const[cat,profR]=await Promise.all([
+        Catalog.get(true),
+        fetch('/api/profiles/active').then(r=>r.ok?r.json():null).catch(()=>null)
+      ]);
+      this.descriptors=Catalog.list('stt',cat);
+      this.credStatus=(cat&&cat.credential_status)||{};
+      if(!this.descriptors.length){
+        this.descriptors=[{id:'webspeech',name:'Web Speech API'},{id:'deepgram',name:'Deepgram'},{id:'groq_whisper',name:'Groq Whisper'},{id:'external',name:'External STT'}];
+      }
+      if(profR){
+        this.profileId=profR.id;
+        this.sel=profR.stt?.provider||'webspeech';
+        this.wake=Array.isArray(profR.stt?.wake_words)?profR.stt.wake_words:[];
+        $('stt-active').innerHTML='Active profile: <span style="color:var(--green)">'+esc(profR.id)+'</span>';
+      }
+      this.render();
+    }catch(e){el.innerHTML='<div class="empty"><div class="empty-icon">&#x26A0;&#xFE0F;</div>'+esc(e.message)+'</div>'}
+  },
+  _keyState(id){
+    // Returns {managed:bool, hasKey:bool, credId:string|null, label:string}
+    const cid=this.VAULT_CRED[id];
+    if(cid){const c=this.credStatus[cid];return {managed:true,hasKey:!!(c&&c.has_value),credId:cid,label:(c&&c.name)||cid}}
+    const d=this.descriptors.find(s=>s.id===id);
+    const h=d&&d.health||{};
+    if(id==='external')return {managed:false,hasKey:!!h.has_key,credId:null,label:'STT_API_URL / STT_API_KEY (env)'};
+    return {managed:false,hasKey:true,credId:null,label:''};
+  },
+  render(){
+    // ── Provider radio list ──
+    let html='<div class="box" style="padding:16px;margin-bottom:16px">'+
+      '<div class="sect-label" style="margin-top:0">STT Provider (active profile)</div>'+
+      '<div class="prov-list">';
+    html+=this.descriptors.map(s=>{
+      const id=s.id;
+      const ks=this._keyState(id);
+      let chip='';
+      if(ks.managed)chip='<span class="badge '+(ks.hasKey?'b-blue':'b-gray')+'" style="font-size:10px">'+(ks.hasKey?'key set':'no key')+'</span>';
+      else if(id==='external')chip='<span class="badge '+(ks.hasKey?'b-blue':'b-gray')+'" style="font-size:10px">'+(ks.hasKey?'env set':'env unset')+'</span>';
+      else if(id==='webspeech'||id==='whisper')chip='<span class="badge b-gray" style="font-size:10px">no key needed</span>';
+      const note=(s.meta&&s.meta.note)?s.meta.note:'';
+      return '<div class="prov-item'+(this.sel===id?' sel':'')+'" id="si-'+esc(id)+'" onclick="STT.select(\''+esc(id)+'\')">'+
+        '<div class="prov-radio"></div>'+
+        '<div style="flex:1;min-width:0">'+
+          '<div class="prov-info-name">'+esc(s.name||id)+' '+chip+'</div>'+
+          '<div class="prov-info-detail">'+esc(note||id)+'</div>'+
+        '</div>'+
+      '</div>';
+    }).join('');
+    html+='</div>'+
+      '<div style="display:flex;gap:8px;align-items:center;margin-top:12px">'+
+        '<button class="btn btn-g" onclick="STT.save()">Save to Active Profile</button>'+
+        '<button class="btn btn-o" onclick="STT.testSel()">Test Selected</button>'+
+        '<span id="stt-status" style="font-size:12px;color:var(--dim)"></span>'+
+      '</div>'+
+      (this.profileId?'':'<div style="font-size:11px;color:var(--yellow);margin-top:6px">No active profile loaded — save disabled.</div>')+
+    '</div>';
+    // ── Key management (vault-backed providers only) ──
+    html+='<div class="box" style="padding:16px;margin-bottom:16px">'+
+      '<div class="sect-label" style="margin-top:0">API Keys</div>'+
+      '<div style="font-size:11px;color:var(--dim);margin-bottom:10px">Cloud STT keys are stored in the vault (same store as the Connections tab). External STT uses env vars (<code>STT_API_URL</code> / <code>STT_API_KEY</code>) and is shown read-only here.</div>';
+    const keyed=this.descriptors.filter(s=>this.VAULT_CRED[s.id]||s.id==='external');
+    html+=keyed.map(s=>{
+      const id=s.id;const ks=this._keyState(id);
+      if(!ks.managed){
+        return '<div style="display:flex;gap:8px;align-items:center;margin-bottom:8px">'+
+          '<span style="min-width:130px;font-size:12px">'+esc(s.name||id)+'</span>'+
+          '<span class="badge '+(ks.hasKey?'b-blue':'b-gray')+'" style="font-size:10px">'+(ks.hasKey?'env set':'env unset')+'</span>'+
+          '<span style="font-size:11px;color:var(--dim)">'+esc(ks.label)+' — read-only</span>'+
+        '</div>';
+      }
+      return '<div style="display:flex;gap:8px;align-items:center;margin-bottom:8px;flex-wrap:wrap">'+
+        '<span style="min-width:130px;font-size:12px">'+esc(s.name||id)+'</span>'+
+        '<span class="badge '+(ks.hasKey?'b-blue':'b-gray')+'" style="font-size:10px">'+(ks.hasKey?'key set':'no key')+'</span>'+
+        '<input type="password" id="stt-key-'+esc(id)+'" placeholder="'+(ks.hasKey?'replace key…':'set key…')+'" autocomplete="off" style="flex:1;min-width:150px;background:var(--panel3);border:1px solid var(--border);border-radius:6px;padding:6px 10px;color:var(--text);font-family:var(--mono);font-size:12px">'+
+        '<button class="btn btn-o btn-sm" onclick="STT.saveKey(\''+esc(id)+'\')">Save Key</button>'+
+        '<span id="stt-key-status-'+esc(id)+'" style="font-size:11px;color:var(--dim)"></span>'+
+      '</div>';
+    }).join('')||'<div style="font-size:12px;color:var(--dim)">No keyed STT providers.</div>';
+    html+='</div>';
+    // ── Wake phrases ──
+    html+='<div class="box" style="padding:16px">'+
+      '<div class="sect-label" style="margin-top:0">Wake Words</div>'+
+      '<div style="font-size:11px;color:var(--dim);margin-bottom:8px">Comma-separated phrases that activate this agent. Empty = platform default.</div>'+
+      '<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">'+
+        '<input type="text" id="stt-wake" value="'+esc(this.wake.join(', '))+'" placeholder="wake up, hey jarvis" style="flex:1;min-width:200px;background:var(--panel3);border:1px solid var(--border);border-radius:6px;padding:7px 11px;color:var(--text);font-size:13px">'+
+        '<button class="btn btn-g" onclick="STT.saveWake()">Save Wake Words</button>'+
+        '<span id="stt-wake-status" style="font-size:12px;color:var(--dim)"></span>'+
+      '</div></div>';
+    $('stt-content').innerHTML=html;
+  },
+  select(id){
+    this.sel=id;
+    document.querySelectorAll('[id^="si-"]').forEach(el=>el.classList.remove('sel'));
+    $('si-'+id)?.classList.add('sel');
+  },
+  async save(){
+    if(!this.profileId){toast('No active profile','red');return}
+    const st=$('stt-status');if(st)st.textContent='Saving...';
+    try{
+      const r=await fetch('/api/profiles/'+encodeURIComponent(this.profileId),{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({stt:{provider:this.sel}})});
+      const d=await r.json();
+      if(d.id||d.name){if(st)st.textContent='Saved (refresh voice app to apply)';toast('STT provider saved','green')}
+      else{if(st)st.textContent=d.error||'Failed';toast(d.error||'Save failed','red')}
+    }catch(e){if(st)st.textContent=e.message;toast(e.message,'red')}
+  },
+  async saveKey(id){
+    const cid=this.VAULT_CRED[id];if(!cid){toast('Key managed via env (read-only)','yellow');return}
+    const val=$('stt-key-'+id)?.value.trim();
+    if(!val){toast('Enter a key','yellow');return}
+    const st=$('stt-key-status-'+id);if(st)st.textContent='Saving...';
+    try{
+      const r=await fetch('/api/vault/credentials/'+encodeURIComponent(cid),{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({value:val})});
+      const d=await r.json();
+      if(d.ok){if(st)st.textContent=d.message||'Saved';toast('Key saved for '+id,'green');const inp=$('stt-key-'+id);if(inp)inp.value='';this.load()}
+      else{if(st)st.textContent=d.message||d.error||'Failed';toast(d.message||d.error||'Save failed','red')}
+    }catch(e){if(st)st.textContent=e.message;toast(e.message,'red')}
+  },
+  async saveWake(){
+    if(!this.profileId){toast('No active profile','red');return}
+    const raw=($('stt-wake')?.value||'').trim();
+    const words=raw?raw.split(',').map(w=>w.trim()).filter(Boolean):[];
+    const st=$('stt-wake-status');if(st)st.textContent='Saving...';
+    try{
+      const r=await fetch('/api/profiles/'+encodeURIComponent(this.profileId),{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({stt:{wake_words:words.length?words:null}})});
+      const d=await r.json();
+      if(d.id||d.name){this.wake=words;if(st)st.textContent='Saved';toast('Wake words saved','green')}
+      else{if(st)st.textContent=d.error||'Failed';toast(d.error||'Save failed','red')}
+    }catch(e){if(st)st.textContent=e.message;toast(e.message,'red')}
+  },
+  async testSel(){
+    const id=this.sel;const st=$('stt-status');
+    // ADMIN-BUG-4 — honest STT test (no hardcoded pass).
+    if(id==='webspeech'){if(st)st.textContent='Web Speech is a browser API — can’t test server-side';toast('WebSpeech: browser API (client-side)','blue');return}
+    if(id==='whisper'){if(st)st.textContent='Local whisper — no key required';toast('whisper: local, no key','blue');return}
+    const ks=this._keyState(id);
+    const msg=id+': '+(ks.hasKey?(ks.managed?'key present':'env set'):'not configured')+' (key check only)';
+    if(st)st.textContent=msg;toast(msg,ks.hasKey?'green':'yellow');
   }
 };
 

--- a/src/admin.html
+++ b/src/admin.html
@@ -383,6 +383,10 @@ select{cursor:pointer}
   <div class="nav-section">
     <div class="nav-label">System</div>
     <div class="nav-item" id="nav-system" onclick="show('system')"><span class="nav-icon">&#x2699;</span><span class="nav-text">Health &amp; Stats</span></div>
+    <div class="nav-item" id="nav-health" onclick="show('health')"><span class="nav-icon">&#x1F4CA;</span><span class="nav-text">Service Health</span></div>
+    <div class="nav-item" id="nav-sessions" onclick="show('sessions')"><span class="nav-icon">&#x1F5C2;</span><span class="nav-text">Sessions</span></div>
+    <div class="nav-item" id="nav-updates" onclick="show('updates')"><span class="nav-icon">&#x2B06;</span><span class="nav-text">Updates</span></div>
+    <div class="nav-item" id="nav-tools" onclick="show('tools')"><span class="nav-icon">&#x1F9F0;</span><span class="nav-text">Tools &amp; Logs</span></div>
     <div class="nav-item" id="nav-tests" onclick="show('tests')"><span class="nav-icon">&#x2713;</span><span class="nav-text">Connector Tests</span></div>
   </div>
   <div class="sidebar-footer">
@@ -597,6 +601,52 @@ select{cursor:pointer}
   </div>
 
 
+  <!-- SERVICE HEALTH MATRIX (WO-5.3) -->
+  <div class="panel" id="panel-health">
+    <div class="panel-inner">
+      <div class="ph"><div class="ph-title">Service Health</div><div class="ph-sub">Every gateway, LLM, TTS, and STT service as one live matrix &mdash; health ring, latency, last error, and what a config change restarts. Auto-refreshes every 30s while this tab is open.</div></div>
+      <div class="ph-row"><button class="btn btn-o" onclick="Health.load()">&#8634; Refresh</button><span id="health-summary" style="font-size:12px;color:var(--dim);align-self:center;margin-left:8px"></span></div>
+      <div class="box" style="padding:0;overflow:hidden">
+        <table class="tbl">
+          <thead><tr><th>Service</th><th>ID</th><th>Type</th><th>Health</th><th>Latency</th><th>Detail / last error</th><th>Restart scope</th></tr></thead>
+          <tbody id="health-tbody"><tr><td colspan="7"><div class="loading" style="padding:14px"><div class="spin"></div></div></td></tr></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- SESSIONS VIEWER/KILLER (WO-4.1) -->
+  <div class="panel" id="panel-sessions">
+    <div class="panel-inner">
+      <div class="ph"><div class="ph-title">Gateway Sessions</div><div class="ph-sub">Live sessions on the active agent gateway &mdash; view history and abort. Uses the allowlisted admin RPC proxy (sessions.list / history / abort).</div></div>
+      <div class="ph-row"><button class="btn btn-o" onclick="Sessions.load()">&#8634; Refresh</button><span id="sessions-note" style="font-size:12px;color:var(--dim);align-self:center;margin-left:8px"></span></div>
+      <div id="sessions-content"><div class="loading"><div class="spin"></div>Loading...</div></div>
+    </div>
+  </div>
+
+  <!-- UPDATE MANAGER (WO-4.2) -->
+  <div class="panel" id="panel-updates">
+    <div class="panel-inner">
+      <div class="ph"><div class="ph-title">Updates</div><div class="ph-sub">Current version, what an update would change, apply, verify, and roll back. Preview and verify are read-only; Apply is guarded by an explicit confirm.</div></div>
+      <div class="ph-row"><button class="btn btn-o" onclick="Updates.load()">&#8634; Refresh</button></div>
+      <div id="updates-content"><div class="loading"><div class="spin"></div>Loading...</div></div>
+    </div>
+  </div>
+
+  <!-- TOOLS & LOGS (WO-4.3 read-only viewers + greetings) -->
+  <div class="panel" id="panel-tools">
+    <div class="panel-inner">
+      <div class="ph"><div class="ph-title">Tools &amp; Logs</div><div class="ph-sub">Operator read-only views &mdash; transcripts, usage, reported issues &mdash; plus the greetings editor.</div></div>
+      <div class="ph-row" style="flex-wrap:wrap;gap:6px">
+        <button class="btn btn-o btn-sm" onclick="Tools.tab('transcripts')" id="tools-tab-transcripts">Transcripts</button>
+        <button class="btn btn-o btn-sm" onclick="Tools.tab('usage')" id="tools-tab-usage">Usage</button>
+        <button class="btn btn-o btn-sm" onclick="Tools.tab('issues')" id="tools-tab-issues">Reported Issues</button>
+        <button class="btn btn-o btn-sm" onclick="Tools.tab('greetings')" id="tools-tab-greetings">Greetings</button>
+      </div>
+      <div id="tools-content"><div class="loading"><div class="spin"></div>Loading...</div></div>
+    </div>
+  </div>
+
   <!-- CANVAS PAGES -->
   <div class="panel" id="panel-canvas">
     <div class="panel-inner">
@@ -723,10 +773,18 @@ const loaders = {
   connections:()=>Connections.load(),
   'platform-setup':()=>PlatformSetup.load(),
   system:()=>System.load(),
+  health:()=>Health.load(),
+  sessions:()=>Sessions.load(),
+  updates:()=>Updates.load(),
+  tools:()=>Tools.load(),
   tests:()=>Tests.initSel(),
 };
 
 function show(name){
+  // Stop any tab-scoped timers before leaving (WO-5.3 — no leaked intervals).
+  // Health is a top-level const in this same classic script (not on window),
+  // and show() only runs after parse, so a direct reference is safe.
+  if(name!=='health'&&typeof Health!=='undefined'&&Health.stop)Health.stop();
   document.querySelectorAll('.panel').forEach(p=>p.classList.remove('active'));
   document.querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active'));
   $('panel-'+name)?.classList.add('active');
@@ -1267,8 +1325,16 @@ const Plugins={
   _hasPending:false,
   _availableCache:[],
   _installedCache:[],
+  _updates:{}, _availFilter:'',
   async load(){
-    const [ir,ar]=await Promise.all([fetch('/api/plugins').catch(()=>null),fetch('/api/plugins/available').catch(()=>null)]);
+    const [ir,ar,ur]=await Promise.all([
+      fetch('/api/plugins').catch(()=>null),
+      fetch('/api/plugins/available').catch(()=>null),
+      fetch('/api/admin/plugins/updates').catch(()=>null)
+    ]);
+    // WO-5.1 — version-diff map: plugin id -> {update_available, available_version, installed_version}
+    this._updates={};
+    if(ur&&ur.ok){try{const ud=await ur.json();(ud.plugins||[]).forEach(u=>{this._updates[u.id]=u})}catch(e){}}
     // Installed
     const installed=ir?await ir.json():{plugins:[]};
     this._installedCache=installed.plugins||[];
@@ -1282,12 +1348,17 @@ const Plugins={
       const statusLabel=p.status==='installed_pending_restart'?'pending restart':p.status||'?';
       const settingsBtn=p.install_config&&p.has_container
         ?'<button class="btn btn-o btn-sm" onclick="Plugins.toggleInstalledConfig(\''+esc(p.id)+'\')">Settings</button>':'';
+      const upd=this._updates[p.id]||{};
+      const updBadge=upd.update_available?'<span class="badge b-yellow" style="font-size:10px" title="Registry has v'+esc(upd.available_version||'?')+'">update available &rarr; v'+esc(upd.available_version||'?')+'</span>':'';
+      const updBtn=upd.update_available?'<button class="btn btn-p btn-sm" onclick="Plugins.update(\''+esc(p.id)+'\')">Update</button>':'';
       return '<div style="padding:10px 0;border-bottom:1px solid var(--border2)">'+
         '<div style="display:flex;align-items:center;justify-content:space-between">'+
           '<div><div style="font-weight:600;color:var(--bright)">'+esc(p.name)+'</div>'+
           '<div style="font-size:11px;color:var(--dim);margin-top:2px">'+esc(p.id)+' v'+esc(p.version||'?')+' &middot; '+esc(p.type||'extension')+'</div></div>'+
-          '<div style="display:flex;gap:6px;align-items:center">'+
+          '<div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;justify-content:flex-end">'+
+            updBadge+
             '<span class="badge '+statusClass+'">'+esc(statusLabel)+'</span>'+
+            updBtn+
             settingsBtn+
             '<button class="btn btn-d btn-sm" onclick="Plugins.uninstall(\''+esc(p.id)+'\')">Remove</button>'+
           '</div>'+
@@ -1295,6 +1366,7 @@ const Plugins={
         '<div style="font-size:12px;color:var(--dim);margin-top:4px">'+esc(p.description||'')+'</div>'+
         (p.faces?.length?'<div style="font-size:11px;color:var(--cyan);margin-top:4px">Faces: '+p.faces.map(f=>esc(f)).join(', ')+'</div>':'')+
         (p.pages?.length?'<div style="font-size:11px;color:var(--blue);margin-top:2px">Pages: '+p.pages.map(f=>esc(f)).join(', ')+'</div>':'')+
+        (p.has_container?'<div style="margin-top:6px">'+restartScopeBadge('container:'+esc(p.id))+'</div>':'')+
         (p.install_config&&p.has_container?'<div id="plugin-iconfig-'+esc(p.id)+'" style="display:none;margin-top:12px;border-top:1px solid var(--border2);padding-top:12px"></div>':'')+
       '</div>'}).join('')}
     // Available
@@ -1303,8 +1375,22 @@ const Plugins={
     const available=await ar.json();
     const avail=(available.plugins||[]).filter(p=>!installed.plugins?.find(i=>i.id===p.id));
     this._availableCache=avail;
-    if(!avail.length){ael.innerHTML='<div style="padding:16px;font-size:13px;color:var(--dim)">All available plugins are installed</div>'}
-    else{ael.innerHTML=avail.map(p=>{
+    this._renderAvailable();
+  },
+  _pluginCat(p){return p.category||(Array.isArray(p.categories)&&p.categories[0])||(Array.isArray(p.tags)&&p.tags[0])||''},
+  _renderAvailable(){
+    const ael=$('plugins-available');if(!ael)return;
+    const avail=this._availableCache||[];
+    if(!avail.length){ael.innerHTML='<div style="padding:16px;font-size:13px;color:var(--dim)">All available plugins are installed</div>';return}
+    // WO-5.1 — category/filter row (only if any plugin declares a category/tag)
+    const cats=[...new Set(avail.map(p=>this._pluginCat(p)).filter(Boolean))];
+    let filterRow='';
+    if(cats.length){
+      const chip=(val,label)=>'<button class="btn btn-sm '+(this._availFilter===val?'btn-p':'btn-o')+'" style="font-size:11px;padding:3px 9px" onclick="Plugins.filterAvail(\''+esc(val)+'\')">'+esc(label)+'</button>';
+      filterRow='<div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:10px">'+chip('','All')+cats.map(c=>chip(c,c)).join('')+'</div>';
+    }
+    const filtered=this._availFilter?avail.filter(p=>this._pluginCat(p)===this._availFilter):avail;
+    const rows=filtered.map(p=>{
       const hasConfig=p.install_config&&p.install_config.sections;
       const btn=hasConfig
         ?'<button class="btn btn-p btn-sm" onclick="Plugins.toggleConfig(\''+esc(p.id)+'\')">Configure</button>'
@@ -1317,7 +1403,19 @@ const Plugins={
         '</div>'+
         '<div style="font-size:12px;color:var(--dim);margin-top:4px">'+esc(p.description||'')+'</div>'+
         (hasConfig?'<div id="plugin-config-'+esc(p.id)+'" style="display:none;margin-top:12px;border-top:1px solid var(--border2);padding-top:12px"></div>':'')+
-      '</div>'}).join('')}
+      '</div>'}).join('');
+    ael.innerHTML=filterRow+(rows||'<div style="padding:16px;font-size:13px;color:var(--dim)">No plugins in this category</div>');
+  },
+  filterAvail(cat){this._availFilter=cat;this._renderAvailable();},
+  async update(id){
+    if(!confirm('Update plugin "'+id+'" to the latest catalog/registry version? The current version is archived (not deleted) and can be restored.'))return;
+    toast('Updating '+id+'…','blue');
+    try{
+      const r=await fetch('/api/admin/plugins/'+encodeURIComponent(id)+'/update',{method:'POST',headers:{'Content-Type':'application/json'},body:'{}'});
+      const d=await r.json();
+      if(d.ok){toast('Updated '+id+' → v'+(d.version||'?')+' — '+(d.note||'restart to activate'),'green');this.load();}
+      else toast('Update failed: '+(d.error||'unknown'),'red');
+    }catch(e){toast(e.message,'red');}
   },
   // Toggle config panel for available (pre-install) plugins
   toggleConfig(id){
@@ -1415,8 +1513,10 @@ const Plugins={
     const btnAction=isPostInstall
       ?'Plugins.saveConfig(\''+esc(id)+'\')'
       :'Plugins.installWithConfig(\''+esc(id)+'\')';
-    html+='<div style="display:flex;gap:8px;align-items:center;margin-top:12px">'+
+    const pRestart=plugin.has_container?restartScopeBadge('container:'+esc(id)):restartScopeBadge('ovui');
+    html+='<div style="display:flex;gap:8px;align-items:center;margin-top:12px;flex-wrap:wrap">'+
       '<button class="btn btn-g" onclick="'+btnAction+'">'+btnLabel+'</button>'+
+      pRestart+
       '<span id="pcfg-status-'+esc(id)+'" style="font-size:12px;color:var(--dim)"></span>'+
     '</div>';
     container.innerHTML=html;
@@ -2087,17 +2187,31 @@ const Providers={
 const TTS={
   profileId:null, providers:[], voicesByProv:{}, sel:{provider:'supertonic',voice:''},
   fallback:{chain:{},voice_gender:{},provider_ids:[]}, credStatus:{},
+  defaultProvider:'', clones:[],
   async load(){
     const el=$('tts-content');
     el.innerHTML='<div class="loading"><div class="spin"></div>Loading...</div>';
     try{
-      const[cat,provR,profR,fbR]=await Promise.all([
+      const[cat,provR,profR,fbR,voicesR]=await Promise.all([
         Catalog.get(true),
         fetch('/api/tts/providers').then(r=>r.ok?r.json():{providers:[]}).catch(()=>({providers:[]})),
         fetch('/api/profiles/active').then(r=>r.ok?r.json():null).catch(()=>null),
-        fetch('/api/admin/tts-fallback').then(r=>r.ok?r.json():null).catch(()=>null)
+        fetch('/api/admin/tts-fallback').then(r=>r.ok?r.json():null).catch(()=>null),
+        fetch('/api/tts/voices').then(r=>r.ok?r.json():null).catch(()=>null)
       ]);
       this.credStatus=(cat&&cat.credential_status)||{};
+      this.defaultProvider=(provR&&provR.default_provider)||'';
+      // Collect cloned voices across providers for the clone manager.
+      this.clones=[];
+      if(voicesR&&voicesR.voices){
+        Object.entries(voicesR.voices).forEach(([pid,v])=>{
+          (v.cloned||[]).forEach(c=>{
+            const cid=(typeof c==='string')?c:(c.id||c.voice_id||c.name||'');
+            const label=(typeof c==='string')?c:(c.name||c.id||c.voice_id||'');
+            if(cid)this.clones.push({provider:pid,id:cid,label:label});
+          });
+        });
+      }
       // Prefer the live registry (voices, status); fall back to catalog tts ids.
       let provs=(provR&&provR.providers)||[];
       if(!provs.length){provs=Catalog.list('tts',cat).map(s=>({provider_id:s.id,name:s.name,voices:[],status:s.health&&s.health.healthy?'active':'inactive'}))}
@@ -2161,9 +2275,92 @@ const TTS={
       '</div>';
     }).join('');
     html+='</div>';
+    // ── Server defaults (WO-4.3) ──
+    html+=this._serverDefaults();
+    // ── Cloned-voice manager (WO-4.3) ──
+    html+=this._cloneManager();
     // ── Fallback chain editor ──
     html+=this._fallbackEditor();
     $('tts-content').innerHTML=html;
+  },
+  _serverDefaults(){
+    const provOpts=this.providers.map(p=>{const id=p.provider_id||p.id;return '<option value="'+esc(id)+'"'+(id===this.defaultProvider?' selected':'')+'>'+esc(p.name||id)+'</option>'}).join('');
+    return '<div class="box" style="padding:16px;margin-top:16px">'+
+      '<div class="sect-label" style="margin-top:0">Server Defaults</div>'+
+      '<div style="font-size:11px;color:var(--dim);margin-bottom:10px">The instance-wide default provider + voice used when a request/profile does not specify one. Written to providers_config.json (survives restart).</div>'+
+      '<div class="g2" style="margin-bottom:10px">'+
+        '<div class="fg"><label class="fl">Default Provider</label><select id="tts-def-prov" onchange="TTS.onDefProv(this.value)">'+provOpts+'</select></div>'+
+        '<div class="fg"><label class="fl">Default Voice</label><select id="tts-def-voice">'+this._voiceOpts(this.defaultProvider,'')+'</select></div>'+
+      '</div>'+
+      '<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">'+
+        '<button class="btn btn-g btn-sm" onclick="TTS.saveDefaultProvider()">Save Default Provider</button>'+
+        '<button class="btn btn-o btn-sm" onclick="TTS.saveDefaultVoice()">Save Default Voice</button>'+
+        restartScopeBadge('none')+
+        '<span id="tts-def-status" style="font-size:12px;color:var(--dim)"></span>'+
+      '</div></div>';
+  },
+  onDefProv(pid){this.defaultProvider=pid;const v=$('tts-def-voice');if(v)v.innerHTML=this._voiceOpts(pid,'')},
+  async saveDefaultProvider(){
+    const provider=$('tts-def-prov')?.value;const st=$('tts-def-status');if(st)st.textContent='Saving...';
+    try{
+      const r=await fetch('/api/tts/default-provider',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({provider})});
+      const d=await r.json();
+      if(d.ok){if(st)st.textContent='Default provider saved';toast('Default provider → '+provider,'green')}
+      else{if(st)st.textContent=d.error||'Failed';toast(d.error||'Save failed','red')}
+    }catch(e){if(st)st.textContent=e.message;toast(e.message,'red')}
+  },
+  async saveDefaultVoice(){
+    const provider=$('tts-def-prov')?.value;const voice=$('tts-def-voice')?.value;
+    if(!voice){toast('Pick a voice','yellow');return}
+    const st=$('tts-def-status');if(st)st.textContent='Saving...';
+    try{
+      const r=await fetch('/api/tts/default-voice',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({provider,voice})});
+      const d=await r.json();
+      if(d.ok){if(st)st.textContent='Default voice saved';toast('Default voice saved','green')}
+      else{if(st)st.textContent=d.error||'Failed';toast(d.error||'Save failed','red')}
+    }catch(e){if(st)st.textContent=e.message;toast(e.message,'red')}
+  },
+  _cloneManager(){
+    let h='<div class="box" style="padding:16px;margin-top:16px">'+
+      '<div class="sect-label" style="margin-top:0">Cloned Voices</div>'+
+      '<div style="font-size:11px;color:var(--dim);margin-bottom:10px">Upload a WAV/MP3 sample to clone a voice. Retiring a clone renames it (never deletes) &mdash; it can be restored on disk.</div>';
+    h+=this.clones.length?this.clones.map(c=>
+      '<div style="display:flex;gap:8px;align-items:center;margin-bottom:6px;flex-wrap:wrap">'+
+        '<span style="min-width:160px;font-size:13px;color:var(--text)">'+esc(c.label||c.id)+'</span>'+
+        '<span class="badge b-gray" style="font-size:10px">'+esc(c.provider)+'</span>'+
+        '<span style="font-family:var(--mono);font-size:11px;color:var(--dim)">'+esc(c.id)+'</span>'+
+        (c.id.indexOf('clone_')===0?'<button class="btn btn-d btn-sm" onclick="TTS.retireClone(\''+esc(c.id)+'\')">Retire</button>':'')+
+      '</div>').join(''):'<div style="font-size:12px;color:var(--dim);margin-bottom:8px">No cloned voices yet.</div>';
+    h+='<div style="display:flex;gap:8px;align-items:center;margin-top:12px;flex-wrap:wrap;border-top:1px solid var(--border2);padding-top:12px">'+
+      '<input type="text" id="tts-clone-name" placeholder="voice name" style="min-width:140px;background:var(--panel3);border:1px solid var(--border);border-radius:6px;padding:6px 10px;color:var(--text);font-size:12px">'+
+      '<input type="file" id="tts-clone-file" accept="audio/*" style="font-size:12px;color:var(--dim)">'+
+      '<button class="btn btn-p btn-sm" onclick="TTS.uploadClone()">Clone Voice</button>'+
+      '<span id="tts-clone-status" style="font-size:12px;color:var(--dim)"></span>'+
+    '</div></div>';
+    return h;
+  },
+  async uploadClone(){
+    const name=($('tts-clone-name')?.value||'').trim();
+    const f=$('tts-clone-file')?.files?.[0];
+    if(!name){toast('Enter a voice name','yellow');return}
+    if(!f){toast('Choose an audio file','yellow');return}
+    const st=$('tts-clone-status');if(st)st.textContent='Uploading + cloning…';
+    try{
+      const fd=new FormData();fd.append('name',name);fd.append('audio',f);fd.append('file',f);
+      const r=await fetch('/api/tts/clone',{method:'POST',body:fd});
+      const d=await r.json();
+      if(r.ok&&!d.error){if(st)st.textContent='Cloned';toast('Voice cloned: '+(d.voice_id||name),'green');this.load()}
+      else{if(st)st.textContent=d.error||('HTTP '+r.status);toast(d.error||'Clone failed','red')}
+    }catch(e){if(st)st.textContent=e.message;toast(e.message,'red')}
+  },
+  async retireClone(id){
+    if(!confirm('Retire cloned voice "'+id+'"? It is renamed (not deleted) and can be restored.'))return;
+    try{
+      const r=await fetch('/api/tts/voices/'+encodeURIComponent(id),{method:'DELETE'});
+      const d=await r.json();
+      if(d.status==='ok'||d.action==='retired'){toast('Retired '+id,'green');this.load()}
+      else toast(d.error||'Failed','red');
+    }catch(e){toast(e.message,'red')}
   },
   onProv(pid){
     this.sel.provider=pid;
@@ -2212,8 +2409,9 @@ const TTS={
         '<select id="tts-fb-'+esc(id)+'" style="background:var(--panel3);border:1px solid var(--border);border-radius:6px;padding:5px 9px;color:var(--text);font-size:12px">'+opts+'</select>'+
       '</div>';
     }).join('');
-    h+='<div style="display:flex;gap:8px;align-items:center;margin-top:10px">'+
+    h+='<div style="display:flex;gap:8px;align-items:center;margin-top:10px;flex-wrap:wrap">'+
         '<button class="btn btn-g btn-sm" onclick="TTS.saveFallback()">Save Chain</button>'+
+        restartScopeBadge('none')+
         '<span id="tts-fb-status" style="font-size:12px;color:var(--dim)"></span>'+
       '</div></div>';
     return h;
@@ -2424,7 +2622,8 @@ const Connections={
         '</select>'+
         '<div style="margin-top:6px;font-size:11px;color:var(--dim)">Used when primary model fails or is rate-limited</div>'+
       '</div></div>'+
-    '</div>';
+    '</div>'+
+    '<div style="margin:-12px 0 20px;display:flex;align-items:center;gap:8px"><span style="font-size:11px;color:var(--dim)">Model changes route through the gateway config API:</span>'+restartScopeBadge('none')+'</div>';
 
     // Credential groups
     for(const group of d.groups){
@@ -2909,8 +3108,372 @@ const System={
   },
   async resetSession(){
     if(!confirm('Reset voice session? Next message will be slower (cold start).'))return;
-    try{const d=await(await fetch('/api/session/reset',{method:'POST',headers:{'Content-Type':'application/json'},body:'{}'})).json();toast(d.ok?'Session reset':d.error||'Failed',d.ok?'green':'red')}
-    catch(e){toast(e.message,'red')}
+    // ADMIN-BUG-2 — /api/session/reset is now the canonical soft/hard handler
+    // (server.py), which returns {old,new,mode} on success (no `ok` field).
+    try{
+      const r=await fetch('/api/session/reset',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({mode:'soft'})});
+      const d=await r.json();
+      if(r.ok&&(d.new||d.old))toast('Session reset ('+(d.mode||'soft')+'): '+esc(d.old||'?')+' → '+esc(d.new||'?'),'green');
+      else toast(d.error||'Failed','red');
+    }catch(e){toast(e.message,'red')}
+  }
+};
+
+// ── Restart-scope badge (WO-5.2) — one helper, used by every config surface ──
+// Renders the descriptor's restart_scope next to a Save button so the operator
+// knows what a change will restart before they click.
+function restartScopeBadge(scope){
+  if(!scope||scope==='none')return '<span class="badge b-gray" style="font-size:10px" title="Takes effect live — no restart">applies live</span>';
+  if(scope==='ovui')return '<span class="badge b-yellow" style="font-size:10px" title="Restarts the OpenVoiceUI app">restarts openvoiceui</span>';
+  if(scope.indexOf('container:')===0)return '<span class="badge b-yellow" style="font-size:10px" title="Restarts a container">restarts '+esc(scope.slice(10))+'</span>';
+  return '<span class="badge b-yellow" style="font-size:10px">restarts: '+esc(scope)+'</span>';
+}
+
+// Service Health matrix (WO-5.3) — one ring per gateway/llm/tts/stt service.
+const Health={
+  _timer:null,
+  async load(){await this.refresh();this.start();},
+  start(){this.stop();this._timer=setInterval(()=>{if($('panel-health')&&$('panel-health').classList.contains('active'))this.refresh();else this.stop();},30000);},
+  stop(){if(this._timer){clearInterval(this._timer);this._timer=null;}},
+  async refresh(){
+    const tb=$('health-tbody');
+    try{
+      const[hR,cR]=await Promise.all([
+        fetch('/api/services/health'),
+        Catalog.get(true)
+      ]);
+      const hd=hR.ok?await hR.json():{services:[],summary:{}};
+      // restart_scope lives on the catalog descriptor, not the health row — join by id.
+      const scopeById={};(cR.services||[]).forEach(s=>{scopeById[s.service+':'+s.id]=s.restart_scope||'none'});
+      const rows=hd.services||[];
+      const s=hd.summary||{};
+      $('health-summary').innerHTML=rows.length?('<span style="color:var(--green)">'+(s.healthy||0)+'</span> / '+(s.total||rows.length)+' healthy &middot; updated '+new Date().toLocaleTimeString()):'';
+      if(!rows.length){tb.innerHTML='<tr><td colspan="7"><div class="empty" style="padding:14px">No services reported</div></td></tr>';return;}
+      const typeColor={gateway:'b-blue',llm:'b-green',tts:'b-yellow',stt:'b-gray'};
+      tb.innerHTML=rows.map(r=>{
+        const ring='<span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:'+(r.healthy?'var(--green)':'var(--red)')+';box-shadow:0 0 6px '+(r.healthy?'var(--green)':'transparent')+'"></span>';
+        const det=r.detail||{};
+        const lastErr=det.status&&det.status!=='active'?det.status:(det.error||det.message||'');
+        const detailBits=[];
+        if(det.has_key===false)detailBits.push('no key');
+        else if(det.has_key===true&&(r.service==='llm'||r.service==='stt'||r.service==='tts'))detailBits.push('key set');
+        if(det.configured===false)detailBits.push('not configured');
+        if(det.in_registry===false&&r.service==='stt')detailBits.push('not in registry');
+        if(lastErr)detailBits.push(esc(String(lastErr)));
+        const scope=scopeById[r.service+':'+r.id]||'none';
+        return '<tr>'+
+          '<td style="padding:9px 12px">'+ring+' '+esc(r.name||r.id)+'</td>'+
+          '<td style="padding:9px 12px;font-family:var(--mono);font-size:11px;color:var(--dim)">'+esc(r.id)+'</td>'+
+          '<td style="padding:9px 12px"><span class="badge '+(typeColor[r.service]||'b-gray')+'" style="font-size:10px">'+esc(r.service)+'</span></td>'+
+          '<td style="padding:9px 12px"><span class="badge '+(r.healthy?'b-green':'b-red')+'" style="font-size:10px">'+(r.healthy?'healthy':'unhealthy')+'</span></td>'+
+          '<td style="padding:9px 12px;color:var(--dim);font-size:12px">'+(r.latency_ms!=null?r.latency_ms+'ms':'&mdash;')+'</td>'+
+          '<td style="padding:9px 12px;color:var(--dim);font-size:12px">'+(detailBits.join(' &middot; ')||'&mdash;')+'</td>'+
+          '<td style="padding:9px 12px">'+restartScopeBadge(scope)+'</td>'+
+        '</tr>';
+      }).join('');
+    }catch(e){tb.innerHTML='<tr><td colspan="7"><div class="empty" style="padding:14px">'+esc(e.message)+'</div></td></tr>';}
+  }
+};
+
+// Gateway Sessions viewer/killer (WO-4.1) — via the allowlisted RPC proxy.
+const Sessions={
+  sessions:[], supported:true, gatewayId:null,
+  async _rpc(method,params){
+    const r=await fetch('/api/admin/gateway/rpc',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({method,params:params||{}})});
+    const d=await r.json();
+    return {ok:r.ok&&d.ok,result:d.result,error:d.error,code:r.status};
+  },
+  async load(){
+    const el=$('sessions-content');
+    el.innerHTML='<div class="loading"><div class="spin"></div>Loading...</div>';
+    // Gate on the catalog 'sessions' capability of the active gateway.
+    try{
+      const cat=await Catalog.get(true);
+      const gw=Catalog.list('gateway',cat).find(g=>(g.capabilities||[]).indexOf('sessions')>=0);
+      // Prefer the active gateway if it supports sessions; else any gateway that does.
+      let active=null;
+      try{const gd=await(await fetch('/api/admin/gateways')).json();active=gd.active_gateway;
+        const ag=Catalog.list('gateway',cat).find(g=>g.id===active);
+        if(ag&&(ag.capabilities||[]).indexOf('sessions')<0){
+          $('sessions-note').innerHTML='Active gateway <b>'+esc(active||'?')+'</b> does not expose sessions.';
+          el.innerHTML='<div class="empty"><div class="empty-icon">&#x1F5C2;</div>The active agent gateway does not support session listing. Switch to a gateway with the <code>sessions</code> capability (e.g. openclaw).</div>';
+          return;
+        }
+      }catch(e){}
+      if(!gw){this.supported=false;el.innerHTML='<div class="empty"><div class="empty-icon">&#x1F5C2;</div>No registered gateway exposes the <code>sessions</code> capability.</div>';return;}
+      this.gatewayId=active||gw.id;
+    }catch(e){}
+    const res=await this._rpc('sessions.list',{});
+    if(!res.ok){
+      el.innerHTML='<div class="empty"><div class="empty-icon">&#x26A0;&#xFE0F;</div>Could not list sessions: '+esc(res.error||('HTTP '+res.code))+
+        '<br><br><span style="color:var(--dim);font-size:12px">The gateway may be down, or the active framework has no session API.</span></div>';
+      return;
+    }
+    const r=res.result||{};
+    this.sessions=r.sessions||r.list||(Array.isArray(r)?r:[]);
+    this.render();
+  },
+  _age(ts){
+    if(!ts)return '&mdash;';
+    const t=typeof ts==='number'?(ts<1e12?ts*1000:ts):Date.parse(ts);
+    if(isNaN(t))return esc(String(ts));
+    const s=Math.max(0,Math.floor((Date.now()-t)/1000));
+    if(s<60)return s+'s';if(s<3600)return Math.floor(s/60)+'m';if(s<86400)return Math.floor(s/3600)+'h';return Math.floor(s/86400)+'d';
+  },
+  render(){
+    const el=$('sessions-content');
+    if(!this.sessions.length){el.innerHTML='<div class="empty"><div class="empty-icon">&#x1F5C2;</div>No active sessions on '+esc(this.gatewayId||'gateway')+'.</div>';return;}
+    let html='<div class="box" style="padding:0;overflow:hidden"><table class="tbl">'+
+      '<thead><tr><th>Session</th><th>Agent</th><th>State</th><th>Age</th><th></th></tr></thead><tbody>';
+    html+=this.sessions.map((s,i)=>{
+      const id=s.sessionKey||s.key||s.id||s.sessionId||('#'+i);
+      const agent=s.agent||s.agentId||s.agent_uri||'&mdash;';
+      const state=s.state||s.status||'&mdash;';
+      const age=this._age(s.startedAt||s.started_at||s.createdAt||s.created_at||s.ts||s.updatedAt);
+      const idAttr=esc(String(id));
+      return '<tr id="sess-row-'+esc(String(i))+'">'+
+        '<td style="padding:9px 12px;font-family:var(--mono);font-size:11px">'+esc(String(id))+'</td>'+
+        '<td style="padding:9px 12px;font-size:12px">'+esc(String(agent))+'</td>'+
+        '<td style="padding:9px 12px"><span class="badge b-gray" style="font-size:10px">'+esc(String(state))+'</span></td>'+
+        '<td style="padding:9px 12px;color:var(--dim);font-size:12px">'+age+'</td>'+
+        '<td style="padding:9px 12px;text-align:right;white-space:nowrap">'+
+          '<button class="btn btn-o btn-sm" onclick="Sessions.history(\''+idAttr+'\','+i+')">History</button> '+
+          '<button class="btn btn-d btn-sm" onclick="Sessions.abort(\''+idAttr+'\')">Abort</button>'+
+        '</td></tr>'+
+        '<tr id="sess-hist-'+esc(String(i))+'" style="display:none"><td colspan="5" style="padding:0 12px 12px"><pre id="sess-hist-pre-'+esc(String(i))+'" style="max-height:320px;overflow:auto;background:var(--panel3);border:1px solid var(--border);border-radius:6px;padding:10px;font-size:11px;white-space:pre-wrap;word-break:break-word;color:var(--text)"></pre></td></tr>';
+    }).join('');
+    html+='</tbody></table></div>';
+    el.innerHTML=html;
+  },
+  async history(id,i){
+    const row=$('sess-hist-'+i);const pre=$('sess-hist-pre-'+i);
+    if(!row||!pre)return;
+    if(row.style.display!=='none'){row.style.display='none';return;}
+    row.style.display='';pre.textContent='Loading history…';
+    const res=await this._rpc('sessions.history',{sessionKey:id,sessionId:id,key:id});
+    if(!res.ok){pre.textContent='Could not load history: '+(res.error||('HTTP '+res.code));return;}
+    try{pre.textContent=JSON.stringify(res.result,null,2);}catch(e){pre.textContent=String(res.result);}
+  },
+  async abort(id){
+    if(!confirm('Abort session "'+id+'"? Any in-flight run is cancelled.'))return;
+    const res=await this._rpc('sessions.abort',{sessionKey:id,sessionId:id,key:id});
+    if(res.ok){toast('Aborted '+id,'green');this.load();}
+    else toast('Abort failed: '+(res.error||('HTTP '+res.code)),'red');
+  }
+};
+
+// Update manager panel (WO-4.2) — preview / apply / verify / rollback.
+const Updates={
+  status:null, preview:null,
+  async load(){
+    const el=$('updates-content');
+    el.innerHTML='<div class="loading"><div class="spin"></div>Loading...</div>';
+    try{
+      this.status=await(await fetch('/api/admin/update/status')).json();
+      this.render();
+    }catch(e){el.innerHTML='<div class="empty"><div class="empty-icon">&#x26A0;&#xFE0F;</div>'+esc(e.message)+'</div>';}
+  },
+  render(){
+    const s=this.status||{};
+    let html='<div class="box" style="padding:16px;margin-bottom:16px">'+
+      '<div class="sect-label" style="margin-top:0">Current Build</div>'+
+      '<div class="stat-r"><span class="stat-l">Version</span><span class="stat-v">'+esc(s.version||'unknown')+'</span></div>'+
+      '<div class="stat-r"><span class="stat-l">Commit</span><span class="stat-v" style="font-family:var(--mono)">'+esc(s.commit||'unknown')+'</span></div>'+
+      '<div class="stat-r"><span class="stat-l">Branch</span><span class="stat-v">'+esc(s.branch||'unknown')+'</span></div>'+
+      '<div class="stat-r"><span class="stat-l">Deployment</span><span class="stat-v">'+esc(s.deployment_type||'?')+'</span></div>'+
+      '<div class="stat-r"><span class="stat-l">Git repo</span><span class="stat-v">'+(s.is_git_repo?'yes':'no (managed/image build)')+'</span></div>'+
+    '</div>';
+    html+='<div class="box" style="padding:16px;margin-bottom:16px">'+
+      '<div class="sect-label" style="margin-top:0">Actions</div>'+
+      '<div style="display:flex;gap:8px;flex-wrap:wrap;align-items:center">'+
+        '<button class="btn btn-o" onclick="Updates.checkPreview()">Check for update (preview)</button>'+
+        '<button class="btn btn-o" onclick="Updates.verify()">Verify checkout</button>'+
+        '<span id="upd-action-status" style="font-size:12px;color:var(--dim)"></span>'+
+      '</div>'+
+      '<div style="font-size:11px;color:var(--dim);margin-top:8px">Preview and verify are read-only. Apply is guarded by an explicit confirmation. '+restartScopeBadge('ovui')+' after a successful apply.</div>'+
+    '</div>';
+    html+='<div id="upd-preview"></div>';
+    // Rollback
+    html+='<div class="box" style="padding:16px;margin-top:16px">'+
+      '<div class="sect-label" style="margin-top:0">Rollback</div>'+
+      '<div style="font-size:11px;color:var(--dim);margin-bottom:8px">Reset the checkout to a prior commit (git reset --hard + restore .pre-update backups). Use the commit you were on before an update.</div>'+
+      '<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">'+
+        '<input type="text" id="upd-rollback-sha" placeholder="target commit SHA" value="'+esc(s.commit||'')+'" style="min-width:220px;background:var(--panel3);border:1px solid var(--border);border-radius:6px;padding:7px 11px;color:var(--text);font-family:var(--mono);font-size:12px">'+
+        '<button class="btn btn-d btn-sm" onclick="Updates.rollback()">Roll back</button>'+
+        '<span id="upd-rollback-status" style="font-size:12px;color:var(--dim)"></span>'+
+      '</div>'+
+    '</div>';
+    $('updates-content').innerHTML=html;
+  },
+  async checkPreview(){
+    const st=$('upd-action-status');if(st)st.textContent='Analysing upstream…';
+    try{
+      const d=await(await fetch('/api/admin/update/preview')).json();
+      this.preview=d;
+      if(st)st.textContent='';
+      const el=$('upd-preview');
+      if(d.error){el.innerHTML='<div class="box" style="padding:16px"><span style="color:var(--red)">'+esc(d.error)+'</span></div>';return;}
+      if(d.can_update===false){el.innerHTML='<div class="box" style="padding:16px">'+esc(d.error||'Cannot update')+'</div>';return;}
+      const changed=d.changed_file_count||0;
+      if(!changed){el.innerHTML='<div class="box" style="padding:16px"><span style="color:var(--green)">Already up to date.</span></div>';return;}
+      const riskCls=d.risk==='high'?'b-red':d.risk==='medium'?'b-yellow':'b-green';
+      let h='<div class="box" style="padding:16px"><div class="sect-label" style="margin-top:0">Update Preview</div>'+
+        '<div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:10px">'+
+          '<span class="badge '+riskCls+'">risk: '+esc(d.risk||'?')+'</span>'+
+          '<span class="badge b-gray">'+changed+' files</span>'+
+          '<span class="badge b-gray">'+esc(d.update_method||'')+'</span>'+
+          (d.conflicts&&d.conflicts.length?'<span class="badge b-yellow">'+d.conflicts.length+' conflicts</span>':'')+
+        '</div>';
+      if(d.incoming_commits)h+='<div style="font-size:11px;color:var(--dim);margin-bottom:6px">Incoming commits:</div><pre style="max-height:160px;overflow:auto;background:var(--panel3);border:1px solid var(--border);border-radius:6px;padding:8px;font-size:11px;white-space:pre-wrap;color:var(--text)">'+esc(d.incoming_commits)+'</pre>';
+      if(d.changed_files&&d.changed_files.length)h+='<details style="margin-top:8px"><summary style="cursor:pointer;font-size:12px;color:var(--blue)">Changed files ('+d.changed_files.length+')</summary><div style="font-size:11px;color:var(--dim);margin-top:6px;font-family:var(--mono)">'+d.changed_files.map(f=>esc(f)).join('<br>')+'</div></details>';
+      h+='<div style="display:flex;gap:8px;align-items:center;margin-top:12px">'+
+        '<button class="btn btn-d" onclick="Updates.apply()">Apply update</button>'+
+        restartScopeBadge('ovui')+
+        '<span id="upd-apply-status" style="font-size:12px;color:var(--dim)"></span>'+
+      '</div></div>';
+      el.innerHTML=h;
+    }catch(e){if(st)st.textContent='';toast(e.message,'red');}
+  },
+  async verify(){
+    const st=$('upd-action-status');if(st)st.textContent='Verifying…';
+    try{
+      const d=await(await fetch('/api/admin/update/verify',{method:'POST'})).json();
+      if(st)st.textContent='';
+      if(d.healthy)toast('Checkout healthy ✓','green');
+      else toast('Verify found issues: '+((d.errors||[]).join('; ')||'unknown'),'red');
+    }catch(e){if(st)st.textContent='';toast(e.message,'red');}
+  },
+  async apply(){
+    if(!confirm('Apply the update now? The app will attempt the update and restart. This runs against the live checkout.'))return;
+    const st=$('upd-apply-status');if(st)st.textContent='Applying — do not navigate away…';
+    try{
+      const r=await fetch('/api/admin/update/apply',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({confirm:true})});
+      const d=await r.json();
+      if(d.ok){if(st)st.textContent=(d.status||'done')+' via '+(d.method||'?')+' — restarting…';toast('Update '+(d.status||'applied'),'green');}
+      else{if(st)st.textContent=d.error||d.reason||'failed';toast('Update failed: '+(d.error||d.reason||d.status||'?'),'red');}
+    }catch(e){if(st)st.textContent=e.message;toast(e.message,'red');}
+  },
+  async rollback(){
+    const sha=($('upd-rollback-sha')?.value||'').trim();
+    if(!sha){toast('Enter a target commit SHA','yellow');return;}
+    if(!confirm('Roll back the checkout to '+sha+'? Restart afterwards to load the reverted code.'))return;
+    const st=$('upd-rollback-status');if(st)st.textContent='Rolling back…';
+    try{
+      const r=await fetch('/api/admin/update/rollback',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({target_commit:sha})});
+      const d=await r.json();
+      if(d.ok){if(st)st.textContent=d.message||'Rolled back';toast('Rolled back to '+sha,'green');}
+      else{if(st)st.textContent=d.error||'Failed';toast(d.error||'Rollback failed','red');}
+    }catch(e){if(st)st.textContent=e.message;toast(e.message,'red');}
+  }
+};
+
+// Tools & Logs (WO-4.3) — transcripts / usage / issues viewers + greetings editor.
+const Tools={
+  _tab:'transcripts', _user:null, _greetings:null,
+  async load(){this.tab(this._tab);},
+  tab(name){
+    this._tab=name;
+    ['transcripts','usage','issues','greetings'].forEach(t=>{
+      const b=$('tools-tab-'+t);if(b)b.className='btn btn-sm '+(t===name?'btn-p':'btn-o');
+    });
+    if(name==='transcripts')this.transcripts();
+    else if(name==='usage')this.usage();
+    else if(name==='issues')this.issues();
+    else if(name==='greetings')this.greetings();
+  },
+  async transcripts(){
+    const el=$('tools-content');el.innerHTML='<div class="loading"><div class="spin"></div>Loading...</div>';
+    try{
+      const list=await(await fetch('/api/transcripts')).json();
+      if(!Array.isArray(list)||!list.length){el.innerHTML='<div class="empty"><div class="empty-icon">&#x1F4C4;</div>No transcripts</div>';return;}
+      el.innerHTML='<div class="box" style="padding:0;overflow:hidden"><table class="tbl"><thead><tr><th>Title</th><th>Date</th><th>Words</th><th></th></tr></thead><tbody>'+
+        list.map(t=>'<tr><td style="padding:8px 12px">'+esc(t.title||t.filename)+'</td><td style="padding:8px 12px;color:var(--dim);font-size:12px">'+esc(t.date||'')+'</td><td style="padding:8px 12px;color:var(--dim)">'+esc(String(t.words||0))+'</td>'+
+          '<td style="padding:8px 12px;text-align:right"><button class="btn btn-o btn-sm" onclick="Tools.readTranscript(\''+esc(t.date||'')+'\',\''+esc(t.filename||'')+'\')">View</button></td></tr>').join('')+
+        '</tbody></table></div><div id="tools-transcript-view" style="margin-top:12px"></div>';
+    }catch(e){el.innerHTML='<div class="empty">'+esc(e.message)+'</div>';}
+  },
+  async readTranscript(date,file){
+    const v=$('tools-transcript-view');if(!v)return;
+    v.innerHTML='<div class="loading"><div class="spin"></div></div>';
+    try{
+      const r=await fetch('/api/transcripts/'+encodeURIComponent(date)+'/'+encodeURIComponent(file));
+      const txt=await r.text();
+      v.innerHTML='<div class="box" style="padding:12px"><pre style="max-height:420px;overflow:auto;white-space:pre-wrap;word-break:break-word;font-size:12px;color:var(--text)">'+esc(txt)+'</pre></div>';
+    }catch(e){v.innerHTML='<div class="empty">'+esc(e.message)+'</div>';}
+  },
+  async usage(){
+    const el=$('tools-content');el.innerHTML='<div class="loading"><div class="spin"></div>Loading...</div>';
+    try{
+      if(!this._user){try{const me=await(await fetch('/api/auth/me')).json();this._user=me.username||'default';}catch(e){this._user='default';}}
+      const[uR,dR]=await Promise.all([
+        fetch('/api/usage/'+encodeURIComponent(this._user)).then(r=>r.ok?r.json():null).catch(()=>null),
+        fetch('/api/diagnostics').then(r=>r.ok?r.json():null).catch(()=>null)
+      ]);
+      let html='<div class="box" style="padding:16px;margin-bottom:16px"><div class="sect-label" style="margin-top:0">Usage &mdash; '+esc(this._user)+'</div>';
+      if(uR){
+        html+='<div class="stat-r"><span class="stat-l">Used this month</span><span class="stat-v">'+esc(String(uR.used))+'</span></div>'+
+          '<div class="stat-r"><span class="stat-l">Limit</span><span class="stat-v">'+(uR.limit===-1?'unlimited':esc(String(uR.limit)))+'</span></div>'+
+          '<div class="stat-r"><span class="stat-l">Remaining</span><span class="stat-v">'+(uR.remaining===-1?'∞':esc(String(uR.remaining)))+'</span></div>'+
+          '<div class="stat-r"><span class="stat-l">Allowed</span><span class="stat-v '+(uR.allowed?'g':'r')+'">'+(uR.allowed?'yes':'no')+'</span></div>';
+      }else html+='<div style="color:var(--dim);font-size:12px">Usage unavailable for this user.</div>';
+      html+='</div>';
+      if(dR){
+        html+='<div class="box" style="padding:16px"><div class="sect-label" style="margin-top:0">Diagnostics</div><pre style="max-height:360px;overflow:auto;white-space:pre-wrap;font-size:11px;color:var(--text)">'+esc(JSON.stringify(dR,null,2))+'</pre></div>';
+      }
+      el.innerHTML=html;
+    }catch(e){el.innerHTML='<div class="empty">'+esc(e.message)+'</div>';}
+  },
+  async issues(){
+    const el=$('tools-content');el.innerHTML='<div class="loading"><div class="spin"></div>Loading...</div>';
+    try{
+      const list=await(await fetch('/api/report-issues')).json();
+      if(!Array.isArray(list)||!list.length){el.innerHTML='<div class="empty"><div class="empty-icon">&#x1F41E;</div>No reported issues</div>';return;}
+      el.innerHTML='<div class="box" style="padding:0;overflow:hidden"><table class="tbl"><thead><tr><th>When</th><th>Category</th><th>Message</th></tr></thead><tbody>'+
+        list.map(r=>'<tr><td style="padding:8px 12px;color:var(--dim);font-size:12px;white-space:nowrap">'+esc(r.timestamp||r.ts||r.created_at||'')+'</td><td style="padding:8px 12px">'+esc(r.category||r.type||'&mdash;')+'</td><td style="padding:8px 12px;font-size:12px">'+esc(r.message||r.description||r.text||JSON.stringify(r).slice(0,200))+'</td></tr>').join('')+
+        '</tbody></table></div>';
+    }catch(e){el.innerHTML='<div class="empty">'+esc(e.message)+'</div>';}
+  },
+  async greetings(){
+    const el=$('tools-content');el.innerHTML='<div class="loading"><div class="spin"></div>Loading...</div>';
+    try{
+      this._greetings=await(await fetch('/api/greetings')).json();
+      const g=(this._greetings&&this._greetings.greetings)||{};
+      const contextual=g.contextual||[];
+      const next=this._greetings.next_greeting||'';
+      let html='<div class="box" style="padding:16px;margin-bottom:16px"><div class="sect-label" style="margin-top:0">Queue next greeting</div>'+
+        '<div style="font-size:11px;color:var(--dim);margin-bottom:8px">One-shot &mdash; used at the very next session start, then cleared.'+(next?' Currently queued: <b>'+esc(next)+'</b>':'')+'</div>'+
+        '<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">'+
+          '<input type="text" id="tools-greet-next" placeholder="Welcome back, Mike." maxlength="300" style="flex:1;min-width:220px;background:var(--panel3);border:1px solid var(--border);border-radius:6px;padding:7px 11px;color:var(--text);font-size:13px">'+
+          '<button class="btn btn-g btn-sm" onclick="Tools.queueGreeting()">Queue</button>'+
+        '</div></div>';
+      html+='<div class="box" style="padding:16px;margin-bottom:16px"><div class="sect-label" style="margin-top:0">Add contextual greeting</div>'+
+        '<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">'+
+          '<input type="text" id="tools-greet-add" placeholder="Good to see you again." maxlength="300" style="flex:1;min-width:220px;background:var(--panel3);border:1px solid var(--border);border-radius:6px;padding:7px 11px;color:var(--text);font-size:13px">'+
+          '<button class="btn btn-p btn-sm" onclick="Tools.addGreeting()">Add</button>'+
+        '</div></div>';
+      html+='<div class="box" style="padding:16px"><div class="sect-label" style="margin-top:0">Contextual greetings ('+contextual.length+')</div>';
+      html+=contextual.length?contextual.map(t=>'<div style="display:flex;gap:8px;align-items:center;margin-bottom:6px"><span style="flex:1;font-size:13px;color:var(--text)">'+esc(t)+'</span><button class="btn btn-d btn-sm" onclick="Tools.removeGreeting(this.getAttribute(\'data-g\'))" data-g="'+esc(t)+'">Remove</button></div>').join(''):'<div style="color:var(--dim);font-size:12px">None</div>';
+      html+='</div>';
+      // Generic / user pools (read-only overview)
+      const cats=[];Object.entries(g.generic||{}).forEach(([k,v])=>cats.push([k,(v||[]).length]));
+      if(cats.length)html+='<div class="box" style="padding:16px;margin-top:16px"><div class="sect-label" style="margin-top:0">Generic pools (read-only)</div>'+cats.map(([k,n])=>'<div class="stat-r"><span class="stat-l">'+esc(k)+'</span><span class="stat-v">'+n+'</span></div>').join('')+'</div>';
+      el.innerHTML=html;
+    }catch(e){el.innerHTML='<div class="empty">'+esc(e.message)+'</div>';}
+  },
+  async queueGreeting(){
+    const v=($('tools-greet-next')?.value||'').trim();if(!v){toast('Enter a greeting','yellow');return;}
+    try{const d=await(await fetch('/api/admin/greetings/queue',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({greeting:v})})).json();
+      if(d.ok){toast('Queued','green');this.greetings();}else toast(d.error||'Failed','red');}catch(e){toast(e.message,'red');}
+  },
+  async addGreeting(){
+    const v=($('tools-greet-add')?.value||'').trim();if(!v){toast('Enter a greeting','yellow');return;}
+    try{const d=await(await fetch('/api/greetings/add',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({greeting:v})})).json();
+      if(d.ok){toast('Added','green');this.greetings();}else toast(d.error||'Failed','red');}catch(e){toast(e.message,'red');}
+  },
+  async removeGreeting(text){
+    if(!confirm('Remove this contextual greeting?'))return;
+    try{const d=await(await fetch('/api/admin/greetings/remove-contextual',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({greeting:text})})).json();
+      if(d.ok){toast('Removed','green');this.greetings();}else toast(d.error||'Failed','red');}catch(e){toast(e.message,'red');}
   }
 };
 
@@ -3345,7 +3908,7 @@ addEventListener('DOMContentLoaded', async function(){
     if(d.clients?.length)$('nav-section-platform').style.display=''
   }).catch(()=>{});
   const hash=location.hash.slice(1);
-  const valid=['agents','builder','tests','providers','system','canvas','plugins','workspace','music','clients','faces','connections','platform-setup'];
+  const valid=['agents','builder','tests','providers','system','canvas','plugins','workspace','music','clients','faces','connections','platform-setup','framework','tts','stt','health','sessions','updates','tools'];
   show(valid.includes(hash)?hash:'agents');
 });
 </script>

--- a/src/app.js
+++ b/src/app.js
@@ -1438,6 +1438,44 @@ connectAiradio();
                 this._postExternalState('bandcamp', trackOrAlbumUrl, title, artist);
             },
 
+            // Spotify is a display/state mode: we receive only a track name + artist
+            // from the [SPOTIFY:] tag, not a Spotify URI, so a real playable embed
+            // can't be built headlessly. Mirror the reference MusicPlayer.playSpotify:
+            // switch the panel to spotify-mode, show the track, and notify the backend
+            // so status/context reflect it. Degrades gracefully — never throws.
+            async playSpotify(trackName, artist) {
+                console.log('[MusicModule] playSpotify:', trackName, artist);
+                try {
+                    try { this.audio?.pause?.(); } catch {}
+                    this.currentPlaylist = 'spotify';
+                    this.isPlaying = true;
+                    this.currentTrack = trackName;
+                    this.currentMetadata = { title: trackName, artist, source: 'spotify', playlist: 'spotify' };
+
+                    const displayName = artist ? `${trackName} — ${artist}` : trackName;
+                    if (this.trackName) this.trackName.textContent = displayName;
+
+                    this._clearExternalEmbed();
+                    if (this.button) this.button.classList.add('active');
+                    if (this.panel) {
+                        this.panel.classList.add('playing', 'spotify-mode');
+                    }
+                    this._syncPlayButtons(true);
+                    if (this.panelState === 'closed') this.openPanel();
+
+                    // Notify backend so status/context reflect Spotify
+                    try {
+                        const u = new URL(`${CONFIG.serverUrl}/api/music`);
+                        u.searchParams.set('action', 'spotify');
+                        u.searchParams.set('track', trackName);
+                        if (artist) u.searchParams.set('artist', artist);
+                        await fetch(u);
+                    } catch (e) { console.warn('[MusicModule] Spotify state sync failed:', e); }
+                } catch (e) {
+                    console.warn('[MusicModule] playSpotify failed (non-fatal):', e);
+                }
+            },
+
             _renderEmbed(provider, iframeHtml) {
                 // Render the embed as a SEPARATE floating element attached to <body>, not inside
                 // the music panel. Music panel is bottom-anchored, so content appended inside it
@@ -1956,6 +1994,48 @@ connectAiradio();
                 this._notifyAgent(title);
             },
 
+            // Play an announcement audio blob through the SAME STT-mute / _ttsPlaying
+            // discipline the main TTS path uses (FE-4). Without this the raw new Audio()
+            // playback is transcribed by the open mic → a paid echo turn ("play it").
+            _playMutedAnnouncement(url) {
+                const cm = (typeof ModeManager !== 'undefined') ? ModeManager?.clawdbotMode : null;
+                const stt = cm?.stt;
+                const audio = new Audio(url);
+                let _restored = false;
+                const _restore = () => {
+                    if (_restored) return;
+                    _restored = true;
+                    try { URL.revokeObjectURL(url); } catch {}
+                    if (!cm) return;
+                    try {
+                        // Match the main path's echo cooldown so buffered STT results
+                        // arriving after the announcement aren't re-submitted as speech.
+                        cm._ttsEchoCooldownUntil = Date.now() + 2500;
+                        setTimeout(() => {
+                            cm._ttsPlaying = false;
+                            if (cm._voiceActive && stt) {
+                                if (stt._micMuted || stt._pttHolding) return;
+                                if (stt.resume) stt.resume();
+                                else if (!stt.isListening && stt.start) stt.start();
+                                cm.callbacks?.onListening?.();
+                            }
+                        }, 300);
+                    } catch (e) { console.warn('[Suno] announce restore failed:', e); }
+                };
+                try {
+                    if (cm) {
+                        if (stt) {
+                            if (stt.mute) stt.mute();
+                            else { if (stt.isListening && stt.stop) stt.stop(); if (stt.resetProcessing) stt.resetProcessing(); }
+                        }
+                        cm._ttsPlaying = true;
+                    }
+                } catch (e) { console.warn('[Suno] announce mute failed:', e); }
+                audio.onended = _restore;
+                audio.onerror = _restore;
+                audio.play().catch(() => _restore());
+            },
+
             async _speakCompletion(title) {
                 try {
                     const resp = await fetch(`${CONFIG.serverUrl}/api/tts/generate`, {
@@ -1966,9 +2046,7 @@ connectAiradio();
                     if (!resp.ok) return;
                     const blob = await resp.blob();
                     const url = URL.createObjectURL(blob);
-                    const audio = new Audio(url);
-                    audio.onended = () => URL.revokeObjectURL(url);
-                    audio.play().catch(() => {});
+                    this._playMutedAnnouncement(url);
                 } catch (e) {
                     console.warn('[Suno] TTS completion error:', e);
                 }
@@ -1993,9 +2071,7 @@ connectAiradio();
                     if (!resp.ok) throw new Error(`tts ${resp.status}`);
                     const blob = await resp.blob();
                     const url = URL.createObjectURL(blob);
-                    const audio = new Audio(url);
-                    audio.onended = () => URL.revokeObjectURL(url);
-                    audio.play().catch(() => {});
+                    this._playMutedAnnouncement(url);
                 } catch (e) {
                     console.warn('[Suno] announce TTS failed:', e);
                 }
@@ -4159,7 +4235,17 @@ connectAiradio();
                     const uiContext = this.getUIContext();
 
                     const gatewayAgentId = localStorage.getItem('gateway_agent_id') || null;
-                    this._fetchAbortController = new AbortController();
+                    // Capture this stream's own controller in the closure so the finally
+                    // block only clears the shared slot if it STILL belongs to this stream
+                    // (FE-6). Otherwise a slow finally can null a newer send's controller,
+                    // and the next interrupt starts a second concurrent stream.
+                    const _localAbortController = new AbortController();
+                    this._fetchAbortController = _localAbortController;
+                    // FE-9: a new user turn starts here — reset duplicate-response
+                    // suppression so an identical short reply ("Done.", "Yes.") in a
+                    // LATER turn is not silently swallowed. Suppression stays effective
+                    // within this same turn (text_done sets _lastResponse below).
+                    this._lastResponse = null;
                     this._textDoneReceived = false;  // new stream — reset the race-window guard
                     this._streamingResponseActive = true;  // stream open — TTS chunks may arrive with long gaps; see constructor note
                     const response = await fetch(`${this.config.serverUrl}/api/conversation?stream=1`, {
@@ -4208,7 +4294,7 @@ connectAiradio();
                     const _resetInactivity = () => {
                         if (_inactivityTimer) clearTimeout(_inactivityTimer);
                         _inactivityTimer = setTimeout(() => {
-                            console.warn('[Stream] No data for 60s — aborting');
+                            console.warn(`[Stream] No data for ${INACTIVITY_TIMEOUT_MS / 1000}s — aborting`);
                             this._abortReason = 'inactivity';
                             this._fetchAbortController?.abort();
                         }, INACTIVITY_TIMEOUT_MS);
@@ -4278,6 +4364,14 @@ connectAiradio();
 
                     // Helper: check for canvas/music commands in accumulated text
                     const checkCanvasInStream = async (text) => {
+                        // Per-tag isolation (FE-3): run each side-effecting tag handler
+                        // through _tag() so a throw in one (e.g. a missing player method)
+                        // is logged and contained — later tag handlers in the SAME pass
+                        // still run instead of being skipped.
+                        const _tag = (label, fn) => {
+                            try { return fn(); }
+                            catch (e) { console.error(`[tag:${label}] handler failed:`, e); }
+                        };
                         text = normalizeActionTags(text);
                         // Check for [CANVAS_MENU]
                         if (/\[CANVAS_MENU\]/i.test(text) && !canvasCommandsProcessed.has('CANVAS_MENU')) {
@@ -4285,7 +4379,7 @@ connectAiradio();
                             console.log('[Canvas] CANVAS_MENU trigger detected');
                             ActionConsole.addEntry('system', 'Canvas: opening menu');
                             AgentActivityChip.handleTag('canvas_menu');
-                            CanvasControl.showMenu?.() || document.getElementById('canvas-menu-button')?.click();
+                            _tag('canvas_menu', () => CanvasControl.showMenu?.() || document.getElementById('canvas-menu-button')?.click());
                         }
                         // Check for [CANVAS:pagename]
                         const canvasMatch = text.match(/\[CANVAS:([^\]]+)\]/i);
@@ -4300,7 +4394,7 @@ connectAiradio();
                                 await fetch(`${CONFIG.serverUrl}/api/canvas/manifest/sync`, { method: 'POST' });
                                 await window.CanvasMenu?.loadManifest();
                             } catch (e) { console.warn('[Canvas] manifest sync failed:', e); }
-                            CanvasControl.showPage?.(pageName);
+                            _tag('canvas_page', () => CanvasControl.showPage?.(pageName));
                         }
                         // Check for [MUSIC_PLAY] or [MUSIC_PLAY:track]
                         const musicPlay = text.match(/\[MUSIC_PLAY(?::([^\]]+))?\]/i);
@@ -4310,26 +4404,28 @@ connectAiradio();
                             ActionConsole.addEntry('system', trackName ? `Music: playing "${trackName}"` : 'Music: playing');
                             AgentActivityChip.handleTag('music_play', trackName);
                             // Always open the panel regardless of whether tracks exist
-                            if (window.musicPlayer?.panelState === 'closed') window.musicPlayer.openPanel();
-                            if (trackName) {
-                                window.musicPlayer?.play(trackName);
-                            } else {
-                                window.musicPlayer?.play();
-                            }
+                            _tag('music_play', () => {
+                                if (window.musicPlayer?.panelState === 'closed') window.musicPlayer.openPanel();
+                                if (trackName) {
+                                    window.musicPlayer?.play(trackName);
+                                } else {
+                                    window.musicPlayer?.play();
+                                }
+                            });
                         }
                         // Check for [MUSIC_STOP]
                         if (/\[MUSIC_STOP\]/i.test(text) && !canvasCommandsProcessed.has('MUSIC_STOP')) {
                             canvasCommandsProcessed.add('MUSIC_STOP');
                             ActionConsole.addEntry('system', 'Music: stopped');
                             AgentActivityChip.handleTag('music_stop');
-                            window.musicPlayer?.stop();
+                            _tag('music_stop', () => window.musicPlayer?.stop());
                         }
                         // Check for [MUSIC_NEXT]
                         if (/\[MUSIC_NEXT\]/i.test(text) && !canvasCommandsProcessed.has('MUSIC_NEXT')) {
                             canvasCommandsProcessed.add('MUSIC_NEXT');
                             ActionConsole.addEntry('system', 'Music: next track');
                             AgentActivityChip.handleTag('music_next');
-                            window.musicPlayer?.next();
+                            _tag('music_next', () => window.musicPlayer?.next());
                         }
                         [...text.matchAll(/\[SUNO_GENERATE:([^\]]+)\]/gi)].forEach(m => {
                             const sunoPrompt = m[1].trim();
@@ -4338,7 +4434,7 @@ connectAiradio();
                             canvasCommandsProcessed.add(key);
                             ActionConsole?.addEntry('system', `🎵 Suno: generating "${sunoPrompt.substring(0, 60)}${sunoPrompt.length > 60 ? '...' : ''}"`);
                             AgentActivityChip?.handleTag('suno', sunoPrompt);
-                            window.sunoModule?.generate(sunoPrompt);
+                            _tag('suno', () => window.sunoModule?.generate(sunoPrompt));
                         });
                         // [JINGLE_GENERATE:brand|style|gender|instrumental|repeat] — short logo jingle (10-15s)
                         // Parts: brand (required), style (preset key or freetext), gender (m|f),
@@ -4360,7 +4456,7 @@ connectAiradio();
                             }
                             ActionConsole?.addEntry('system', `🎵 Jingle: "${brand}" (${style || 'random style'}${instrumental ? ', instrumental' : ', ' + (gender === 'f' ? 'female' : 'male')}${repeat !== 2 ? `, ${repeat}×` : ''})`);
                             AgentActivityChip?.handleTag('suno', `${brand} jingle`);
-                            window.sunoModule?.generateJingle(brand, style, gender, instrumental, repeat);
+                            _tag('jingle', () => window.sunoModule?.generateJingle(brand, style, gender, instrumental, repeat));
                         });
                         // Check for [SPOTIFY:track name|artist] — switches player to Spotify mode
                         const spotifyMatch = text.match(/\[SPOTIFY:([^|\]]+)(?:\|([^\]]+))?\]/i);
@@ -4370,7 +4466,7 @@ connectAiradio();
                             const spotifyArtist = spotifyMatch[2]?.trim() || '';
                             ActionConsole.addEntry('system', `Spotify: "${spotifyTrack}"${spotifyArtist ? ` by ${spotifyArtist}` : ''}`);
                             AgentActivityChip.handleTag('spotify', spotifyTrack);
-                            window.musicPlayer?.playSpotify(spotifyTrack, spotifyArtist);
+                            _tag('spotify', () => window.musicPlayer?.playSpotify(spotifyTrack, spotifyArtist));
                         }
                         // [AIRADIO_*] — dispatch each unique tag once; bridge maps verb→endpoint
                         const _airadioRe = /\[AIRADIO_([A-Z_]+)(?::([^\]]*))?\]/gi;
@@ -4383,7 +4479,7 @@ connectAiradio();
                             canvasCommandsProcessed.add(key);
                             ActionConsole.addEntry('system', `AI-Radio: ${verb}${data ? ` (${data})` : ''}`);
                             AgentActivityChip.handleTag('airadio', `${verb}${data ? `: ${data}` : ''}`);
-                            window.airadioDispatch?.(verb, data);
+                            _tag('airadio', () => window.airadioDispatch?.(verb, data));
                         }
                         // [SOUNDCLOUD:url] — play track in music player embed
                         const soundcloudMatch = text.match(/\[SOUNDCLOUD:([^\]]+)\]/i);
@@ -4392,7 +4488,7 @@ connectAiradio();
                             const scUrl = soundcloudMatch[1].trim();
                             ActionConsole.addEntry('system', `SoundCloud: ${scUrl}`);
                             AgentActivityChip.handleTag('soundcloud', scUrl);
-                            window.musicPlayer?.playSoundCloud(scUrl);
+                            _tag('soundcloud', () => window.musicPlayer?.playSoundCloud(scUrl));
                         }
                         // [SOUNDCLOUD_PAGE:url] — open full-screen canvas page with the embed
                         const soundcloudPageMatch = text.match(/\[SOUNDCLOUD_PAGE:([^\]]+)\]/i);
@@ -4401,7 +4497,7 @@ connectAiradio();
                             const scUrl = soundcloudPageMatch[1].trim();
                             ActionConsole.addEntry('system', `SoundCloud page: ${scUrl}`);
                             AgentActivityChip.handleTag('soundcloud_page', scUrl);
-                            window.openEmbedCanvasPage?.('soundcloud', scUrl);
+                            _tag('soundcloud_page', () => window.openEmbedCanvasPage?.('soundcloud', scUrl));
                         }
                         // [BANDCAMP:url] — play in music player embed
                         const bandcampMatch = text.match(/\[BANDCAMP:([^\]]+)\]/i);
@@ -4410,7 +4506,7 @@ connectAiradio();
                             const bcUrl = bandcampMatch[1].trim();
                             ActionConsole.addEntry('system', `Bandcamp: ${bcUrl}`);
                             AgentActivityChip.handleTag('bandcamp', bcUrl);
-                            window.musicPlayer?.playBandcamp(bcUrl);
+                            _tag('bandcamp', () => window.musicPlayer?.playBandcamp(bcUrl));
                         }
                         // [BANDCAMP_PAGE:url] — full-screen canvas page
                         const bandcampPageMatch = text.match(/\[BANDCAMP_PAGE:([^\]]+)\]/i);
@@ -4419,7 +4515,7 @@ connectAiradio();
                             const bcUrl = bandcampPageMatch[1].trim();
                             ActionConsole.addEntry('system', `Bandcamp page: ${bcUrl}`);
                             AgentActivityChip.handleTag('bandcamp_page', bcUrl);
-                            window.openEmbedCanvasPage?.('bandcamp', bcUrl);
+                            _tag('bandcamp_page', () => window.openEmbedCanvasPage?.('bandcamp', bcUrl));
                         }
                         // Check for [REGISTER_FACE:name] — agent registers current camera frame
                         const registerFaceMatch = text.match(/\[REGISTER_FACE:([^\]]+)\]/i);
@@ -4455,7 +4551,7 @@ connectAiradio();
                             console.log('[Sound] DJ sound trigger:', soundName);
                             ActionConsole.addEntry('system', `Sound: ${soundName}`);
                             AgentActivityChip.handleTag('sound', soundName);
-                            DJSoundboard.play(soundName);
+                            _tag('sound', () => DJSoundboard.play(soundName));
                         }
                         // Check for [CANVAS_URL:https://example.com] — load external URL in iframe
                         const canvasUrlMatch = text.match(/\[CANVAS_URL:([^\]]+)\]/i);
@@ -4487,15 +4583,19 @@ connectAiradio();
                                 const dedupeKey = 'CANVAS_ACTION:' + action + ':' + JSON.stringify(t.payload?.payload ?? '');
                                 if (canvasCommandsProcessed.has(dedupeKey)) continue;
                                 canvasCommandsProcessed.add(dedupeKey);
-                                dispatchCanvasAction(action, t.payload?.payload || {});
+                                _tag('canvas_action', () => dispatchCanvasAction(action, t.payload?.payload || {}));
                             }
                         }
-                        // Check for [MOOD:xxx] — agent-driven facial expression change
+                        // Check for [MOOD:xxx] — agent-driven facial expression change.
+                        // Dedupe so the mood fires ONCE per response, not on every delta pass
+                        // (FE-11) — the tag is present in the accumulated text on every subsequent
+                        // delta, which otherwise re-set the mood repeatedly.
                         const moodTagMatch = text.match(/\[MOOD:(neutral|happy|sad|angry|thinking|surprised|listening)\]/i);
-                        if (moodTagMatch) {
+                        if (moodTagMatch && !canvasCommandsProcessed.has('MOOD')) {
+                            canvasCommandsProcessed.add('MOOD');
                             const newMood = moodTagMatch[1].toLowerCase();
                             console.log('[Mood] Agent set mood:', newMood);
-                            FaceModule.setMood(newMood);
+                            _tag('mood', () => FaceModule.setMood(newMood));
                             ActionConsole.addEntry('system', `Mood: ${newMood}`);
                         }
                         // Check for [SLEEP] — agent-initiated return to wake-word mode
@@ -4517,7 +4617,7 @@ connectAiradio();
                                 console.log('[Canvas] Complete HTML detected in stream, saving early...');
                                 ActionConsole.addEntry('system', 'Canvas: building page from HTML');
                                 AgentActivityChip.handleTag('html_canvas');
-                                this._saveAndShowHtml(htmlEarlyMatch[1].trim());
+                                _tag('html_canvas', () => this._saveAndShowHtml(htmlEarlyMatch[1].trim()));
                             }
                         }
                     };
@@ -4535,9 +4635,22 @@ connectAiradio();
                             buffer = buffer.slice(newlineIdx + 1);
                             if (!line) continue;
 
+                            // Parse in its own narrow try/catch — a genuine parse
+                            // failure skips only this line, it never masks a handler
+                            // exception below (FE-2).
+                            let data;
                             try {
-                                const data = JSON.parse(line);
+                                data = JSON.parse(line);
+                            } catch (parseErr) {
+                                console.warn('Failed to parse stream line:', parseErr, line.slice(0, 200));
+                                continue;
+                            }
 
+                            // Dispatch OUTSIDE the parse try/catch, wrapped in its own
+                            // handler try/catch so an exception in one event handler
+                            // (e.g. a text_done DOM/tag throw) is logged with its real
+                            // event type and does NOT kill the read loop.
+                            try {
                                 // Filtered: server rejected garbage STT — silently resume
                                 if (data.type === 'filtered') {
                                     console.log('[stream] Garbage STT filtered by server:', data.reason);
@@ -4575,8 +4688,12 @@ connectAiradio();
                                         TranscriptPanel.updateStreaming(stripCanvasTags(streamingText));
                                     }
 
-                                    // Check for canvas commands as they stream in
-                                    checkCanvasInStream(streamingText);
+                                    // Check for canvas commands as they stream in.
+                                    // checkCanvasInStream is async — catch its rejection so a
+                                    // failing tag handler never becomes an unhandled promise
+                                    // rejection (FE-3). Fire-and-forget by design (streaming).
+                                    checkCanvasInStream(streamingText).catch(e =>
+                                        console.error('[stream] checkCanvasInStream failed:', e));
                                 }
 
                                 // Heartbeat: server is alive, agent is working
@@ -4821,8 +4938,10 @@ connectAiradio();
                                     }
                                 }
 
-                            } catch (parseErr) {
-                                console.warn('Failed to parse stream line:', parseErr);
+                            } catch (dispatchErr) {
+                                // Real handler error — log with the event type so it is
+                                // debuggable, and keep reading the stream (don't rethrow).
+                                console.error(`[stream] handler error for event '${data?.type}':`, dispatchErr);
                             }
                         }
                     }
@@ -4849,7 +4968,7 @@ connectAiradio();
                             ActionConsole.addEntry('system', 'Task redirected by user');
                         } else if (_reason === 'inactivity') {
                             TranscriptPanel.finalizeStreaming('⏳ Agent went quiet — stream timed out.');
-                            ActionConsole.addEntry('system', 'Stream timed out (agent silent 60s) — not a user action');
+                            ActionConsole.addEntry('system', 'Stream timed out (agent silent 300s) — not a user action');
                         } else if (_wasAgentic && !_reason) {
                             // Unknown-source abort during agentic work — don't blame
                             // the user; just close the stream quietly.
@@ -4913,7 +5032,11 @@ connectAiradio();
                 } finally {
                     if (_inactivityTimer) clearTimeout(_inactivityTimer);
                     this._sending = false;
-                    this._fetchAbortController = null;
+                    // Only clear the shared controller slot if it is STILL this stream's
+                    // own controller — a newer send may have already replaced it (FE-6).
+                    if (this._fetchAbortController === _localAbortController) {
+                        this._fetchAbortController = null;
+                    }
                     // Stream is done. Future drain timer fires should use the short
                     // 800ms wait again. If an extended-wait drain timer is currently
                     // pending and the queue is empty, collapse it to the short window
@@ -5959,7 +6082,10 @@ connectAiradio();
                     const gatewayAgentId = localStorage.getItem('gateway_agent_id') || null;
 
                     // Get AI response from backend
-                    this._fetchAbortController = new AbortController();
+                    // Capture this stream's own controller so the finally only clears
+                    // the shared slot when it still belongs to this stream (FE-6).
+                    const _localAbortController = new AbortController();
+                    this._fetchAbortController = _localAbortController;
                     const response = await fetch(`${this.config.serverUrl}/api/conversation`, {
                         method: 'POST',
                         signal: this._fetchAbortController.signal,
@@ -6041,7 +6167,9 @@ connectAiradio();
                         setTimeout(() => FaceModule.setMood('neutral'), 2000);
                     }
                 } finally {
-                    this._fetchAbortController = null;
+                    if (this._fetchAbortController === _localAbortController) {
+                        this._fetchAbortController = null;
+                    }
                     // Reset processing flag to allow new transcripts
                     TranscriptPanel.removeThinking();
                     document.getElementById('thought-bubbles')?.classList.remove('active');
@@ -7519,14 +7647,20 @@ ${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
                 // Poll every 10 seconds for file changes on the displayed canvas page
                 if (this._pollInterval) return;
                 this._pollInterval = setInterval(() => this._checkForUpdates(), 10000);
-                // Pause polling when tab is hidden to reduce server load
-                document.addEventListener('visibilitychange', () => {
-                    if (document.hidden) {
-                        if (this._pollInterval) { clearInterval(this._pollInterval); this._pollInterval = null; }
-                    } else if (this.isVisible) {
-                        this._startPoll();
-                    }
-                });
+                // Pause polling when tab is hidden to reduce server load.
+                // Register the visibilitychange listener ONCE (FE-7) — _startPoll is
+                // re-called from inside this very handler on re-show, so an unguarded
+                // addEventListener leaked one extra listener per hide/show cycle.
+                if (!this._visibilityBound) {
+                    this._visibilityBound = true;
+                    document.addEventListener('visibilitychange', () => {
+                        if (document.hidden) {
+                            if (this._pollInterval) { clearInterval(this._pollInterval); this._pollInterval = null; }
+                        } else if (this.isVisible) {
+                            this._startPoll();
+                        }
+                    });
+                }
             },
 
             async _checkForUpdates() {
@@ -9809,6 +9943,14 @@ ${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
                 // Stop recording and force transcription — pttRelease handles all state
                 // onstop handler will send to Groq and call onResult asynchronously
                 stt.pttRelease();
+            },
+
+            // Set PTT mode to a specific target state (idempotent). Delegates to
+            // _toggleMode so all the STT-mute / wake-word side-effects run exactly
+            // once — never toggling twice. No-op if already in the requested state.
+            _setPTT(enabled) {
+                if (this.pttMode === !!enabled) return;
+                this._toggleMode();
             }
         };
         window.PTTButton.init();
@@ -9999,115 +10141,135 @@ ${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
                 window.providerManager._activeProfileId = profile.id;
             }
 
+            // Each numbered step is wrapped in its own try/catch so one failing step
+            // (e.g. a missing PTT method or a face-plugin throw) can't abort the rest
+            // of profile setup — the actual damage mechanism behind FE-1.
+
             // 1. STT silence timeout — applied immediately if STT is live, else deferred to poll
-            const stt = window._sttInstance;
-            if (stt) {
-                const ms = profile?.stt?.silence_timeout_ms;
-                if (ms != null) {
-                    stt.silenceDelayMs = ms;
-                    console.log(`[Profile] stt.silenceDelayMs = ${ms}ms`);
+            try {
+                const stt = window._sttInstance;
+                if (stt) {
+                    const ms = profile?.stt?.silence_timeout_ms;
+                    if (ms != null) {
+                        stt.silenceDelayMs = ms;
+                        console.log(`[Profile] stt.silenceDelayMs = ${ms}ms`);
+                    }
+                    const vt = profile?.stt?.vad_threshold;
+                    if (vt != null) {
+                        stt.vadThreshold = vt;
+                        console.log(`[Profile] stt.vadThreshold = ${vt}`);
+                    }
+                    const maxRec = profile?.stt?.max_recording_s;
+                    if (maxRec != null) {
+                        stt.maxRecordingMs = maxRec * 1000;
+                        console.log(`[Profile] stt.maxRecordingMs = ${maxRec * 1000}ms`);
+                    }
+                    const accMs = profile?.stt?.accumulation_delay_ms;
+                    if (accMs != null) {
+                        stt.accumulationDelayMs = accMs;
+                        console.log(`[Profile] stt.accumulationDelayMs = ${accMs}ms`);
+                    }
+                    // PTT default — auto-enable if profile says so
+                    if (profile?.stt?.ptt_default === true && window.PTTButton && !window.PTTButton.pttMode) {
+                        window.PTTButton._setPTT(true);
+                    }
                 }
-                const vt = profile?.stt?.vad_threshold;
-                if (vt != null) {
-                    stt.vadThreshold = vt;
-                    console.log(`[Profile] stt.vadThreshold = ${vt}`);
-                }
-                const maxRec = profile?.stt?.max_recording_s;
-                if (maxRec != null) {
-                    stt.maxRecordingMs = maxRec * 1000;
-                    console.log(`[Profile] stt.maxRecordingMs = ${maxRec * 1000}ms`);
-                }
-                const accMs = profile?.stt?.accumulation_delay_ms;
-                if (accMs != null) {
-                    stt.accumulationDelayMs = accMs;
-                    console.log(`[Profile] stt.accumulationDelayMs = ${accMs}ms`);
-                }
-                // PTT default — auto-enable if profile says so
-                if (profile?.stt?.ptt_default === true && window.PTTButton && !window.PTTButton.pttMode) {
-                    window.PTTButton._setPTT(true);
-                }
-            }
+            } catch (e) { console.error('[Profile] step 1 (STT) failed:', e); }
 
             // 2. Mode picker — show/hide options based on profile.modes
-            const modes = profile?.modes || {};
-            ['normal', 'listen', 'a2a'].forEach(key => {
-                const btn = document.getElementById('mode-opt-' + key);
-                if (btn) btn.style.display = (modes[key] === false) ? 'none' : '';
-            });
-            // PTT button
-            const pttBtn = document.getElementById('ptt-button');
-            if (pttBtn) pttBtn.style.display = (modes.ptt === false) ? 'none' : '';
+            try {
+                const modes = profile?.modes || {};
+                ['normal', 'listen', 'a2a'].forEach(key => {
+                    const btn = document.getElementById('mode-opt-' + key);
+                    if (btn) btn.style.display = (modes[key] === false) ? 'none' : '';
+                });
+                // PTT button
+                const pttBtn = document.getElementById('ptt-button');
+                if (pttBtn) pttBtn.style.display = (modes.ptt === false) ? 'none' : '';
+            } catch (e) { console.error('[Profile] step 2 (mode picker) failed:', e); }
 
             // 3. UI theme preset (maps to CSS data attribute → color overrides)
-            const preset = profile?.ui?.theme_preset || '';
-            document.body.dataset.themePreset = preset;
+            try {
+                const preset = profile?.ui?.theme_preset || '';
+                document.body.dataset.themePreset = preset;
+            } catch (e) { console.error('[Profile] step 3 (theme preset) failed:', e); }
 
             // 4. Mode badge
-            const showBadge = profile?.ui?.show_mode_badge;
-            const badgeText = profile?.ui?.mode_badge_text;
-            let badge = document.getElementById('profile-mode-badge');
-            if (!badge && showBadge) {
-                badge = document.createElement('div');
-                badge.id = 'profile-mode-badge';
-                badge.className = 'profile-mode-badge';
-                document.body.appendChild(badge);
-            }
-            if (badge) {
-                badge.style.display = showBadge ? '' : 'none';
-                if (badgeText) badge.textContent = badgeText;
-            }
+            try {
+                const showBadge = profile?.ui?.show_mode_badge;
+                const badgeText = profile?.ui?.mode_badge_text;
+                let badge = document.getElementById('profile-mode-badge');
+                if (!badge && showBadge) {
+                    badge = document.createElement('div');
+                    badge.id = 'profile-mode-badge';
+                    badge.className = 'profile-mode-badge';
+                    document.body.appendChild(badge);
+                }
+                if (badge) {
+                    badge.style.display = showBadge ? '' : 'none';
+                    if (badgeText) badge.textContent = badgeText;
+                }
+            } catch (e) { console.error('[Profile] step 4 (mode badge) failed:', e); }
 
             // 5. Conversation flags stored for use in API calls and TTS player
-            window._interruptionEnabled = profile?.conversation?.interruption_enabled === true;
-            window._maxResponseChars   = profile?.conversation?.max_response_chars || null;
+            try {
+                window._interruptionEnabled = profile?.conversation?.interruption_enabled === true;
+                window._maxResponseChars   = profile?.conversation?.max_response_chars || null;
+            } catch (e) { console.error('[Profile] step 5 (conversation flags) failed:', e); }
 
             // 6. Camera auth / identify-on-wake flags (read at wake-time from _activeProfileData)
             // These are read directly from window._activeProfileData in the wake callback —
             // no extra storage needed here.
 
             // 7. Wake words — update detector when profile overrides them
-            if (window.wakeDetector) {
-                const profileWords = profile?.stt?.wake_words;
-                if (Array.isArray(profileWords) && profileWords.length > 0) {
-                    window.wakeDetector.wakeWords = profileWords;
-                } else if (profileWords === null || profileWords === undefined) {
-                    // null = use platform default
-                    window.wakeDetector.wakeWords = ['wake up'];
+            try {
+                if (window.wakeDetector) {
+                    const profileWords = profile?.stt?.wake_words;
+                    if (Array.isArray(profileWords) && profileWords.length > 0) {
+                        window.wakeDetector.wakeWords = profileWords;
+                    } else if (profileWords === null || profileWords === undefined) {
+                        // null = use platform default
+                        window.wakeDetector.wakeWords = ['wake up'];
+                    }
+                    // [] = empty array means disable wake word (leave as-is, detector won't match anything)
+                    console.log(`[Profile] wakeWords = ${JSON.stringify(window.wakeDetector.wakeWords)}`);
                 }
-                // [] = empty array means disable wake word (leave as-is, detector won't match anything)
-                console.log(`[Profile] wakeWords = ${JSON.stringify(window.wakeDetector.wakeWords)}`);
-            }
+            } catch (e) { console.error('[Profile] step 7 (wake words) failed:', e); }
 
             // 8. TTS provider/voice — switch ProviderManager to match profile voice settings
-            if (profile?.voice && window.providerManager) {
-                const newProvider = profile.voice.tts_provider;
-                const newVoice = profile.voice.voice_id;
-                if (newProvider) {
-                    window.providerManager.selectedProvider = newProvider;
-                    if (newVoice) window.providerManager.currentVoice = newVoice;
-                    // Update provider dropdown
-                    const provSelect = document.getElementById('voice-provider-select');
-                    if (provSelect) provSelect.value = newProvider;
-                    // Rebuild voice dropdown (includes cloned voices)
-                    window.providerManager.updateProviderStatus();
-                    window.providerManager.updateVoiceUI();
-                    // Update active voice conversation
-                    if (window.voiceAgent?.setTTSProvider) {
-                        window.voiceAgent.setTTSProvider(newProvider, newVoice || 'autumn');
+            try {
+                if (profile?.voice && window.providerManager) {
+                    const newProvider = profile.voice.tts_provider;
+                    const newVoice = profile.voice.voice_id;
+                    if (newProvider) {
+                        window.providerManager.selectedProvider = newProvider;
+                        if (newVoice) window.providerManager.currentVoice = newVoice;
+                        // Update provider dropdown
+                        const provSelect = document.getElementById('voice-provider-select');
+                        if (provSelect) provSelect.value = newProvider;
+                        // Rebuild voice dropdown (includes cloned voices)
+                        window.providerManager.updateProviderStatus();
+                        window.providerManager.updateVoiceUI();
+                        // Update active voice conversation
+                        if (window.voiceAgent?.setTTSProvider) {
+                            window.voiceAgent.setTTSProvider(newProvider, newVoice || 'autumn');
+                        }
+                        console.log(`[Profile] TTS: ${newProvider} / ${newVoice}`);
                     }
-                    console.log(`[Profile] TTS: ${newProvider} / ${newVoice}`);
                 }
-            }
+            } catch (e) { console.error('[Profile] step 8 (TTS provider/voice) failed:', e); }
 
             // 9. Face plugin — switch mode + config from profile (generic, not face-type-specific)
-            const faceMode = profile?.ui?.face_mode;
-            const faceConfig = profile?.ui?.face_config || null;
-            if (faceMode && window.FaceRenderer) {
-                if (window.FaceRenderer.currentMode !== faceMode || faceConfig) {
-                    // skipPersist: applyProfile is READING the profile, not user-initiated
-                    window.FaceRenderer.setMode(faceMode, faceConfig, { skipPersist: true });
+            try {
+                const faceMode = profile?.ui?.face_mode;
+                const faceConfig = profile?.ui?.face_config || null;
+                if (faceMode && window.FaceRenderer) {
+                    if (window.FaceRenderer.currentMode !== faceMode || faceConfig) {
+                        // skipPersist: applyProfile is READING the profile, not user-initiated
+                        window.FaceRenderer.setMode(faceMode, faceConfig, { skipPersist: true });
+                    }
                 }
-            }
+            } catch (e) { console.error('[Profile] step 9 (face plugin) failed:', e); }
 
             console.log(`[Profile] applied: ${profile?.id} | silence=${profile?.stt?.silence_timeout_ms ?? 'default'}ms | accumulation=${profile?.stt?.accumulation_delay_ms ?? 'default'}ms | interruption=${window._interruptionEnabled} | wakeWords=${JSON.stringify(profile?.stt?.wake_words)} | modes=${JSON.stringify(profile?.modes)} | tts=${profile?.voice?.tts_provider}/${profile?.voice?.voice_id}`);
         };

--- a/tests/test_admin_panel_wave.py
+++ b/tests/test_admin_panel_wave.py
@@ -1,0 +1,143 @@
+"""
+Tests for the final admin-panel wave (WO-4.1..5.3 + ADMIN-BUG-2).
+
+Covers the NEW admin-gated endpoints added to routes/admin.py, the plugins
+update-diff service helpers, and the ADMIN-BUG-2 session-reset route move.
+
+Only cheap / validation-only paths are exercised — we deliberately do NOT call
+the update preview/apply/verify paths (they run git fetch + subprocess imports),
+nor mutate greetings.json.
+"""
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def admin_client():
+    from app import create_app
+    app, _ = create_app(config_override={"TESTING": True})
+    from routes.admin import admin_bp
+    app.register_blueprint(admin_bp)
+    return app.test_client()
+
+
+# ── WO-4.2 Update manager wrappers ──────────────────────────────────────────
+
+class TestUpdateManagerPanel:
+    def test_status_200_and_shape(self, admin_client):
+        r = admin_client.get("/api/admin/update/status")
+        assert r.status_code == 200
+        d = r.get_json()
+        for k in ("commit", "branch", "version", "deployment_type", "is_git_repo"):
+            assert k in d
+
+    def test_apply_requires_confirm(self, admin_client):
+        # No body → must NOT run a live update.
+        r = admin_client.post("/api/admin/update/apply", json={})
+        assert r.status_code == 400
+        assert r.get_json()["ok"] is False
+
+    def test_apply_rejects_confirm_false(self, admin_client):
+        r = admin_client.post("/api/admin/update/apply", json={"confirm": False})
+        assert r.status_code == 400
+
+    def test_rollback_requires_target(self, admin_client):
+        r = admin_client.post("/api/admin/update/rollback", json={})
+        assert r.status_code == 400
+
+    def test_rollback_rejects_non_sha(self, admin_client):
+        r = admin_client.post("/api/admin/update/rollback",
+                              json={"target_commit": "HEAD; rm -rf /"})
+        assert r.status_code == 400
+        r2 = admin_client.post("/api/admin/update/rollback",
+                               json={"target_commit": "main"})
+        assert r2.status_code == 400
+
+
+# ── WO-5.1 Marketplace update-diff ──────────────────────────────────────────
+
+class TestPluginUpdates:
+    def test_updates_list_200(self, admin_client):
+        r = admin_client.get("/api/admin/plugins/updates")
+        assert r.status_code == 200
+        d = r.get_json()
+        assert "plugins" in d and isinstance(d["plugins"], list)
+        assert "update_count" in d
+
+    def test_update_unknown_plugin_404(self, admin_client):
+        r = admin_client.post("/api/admin/plugins/__nope__/update", json={})
+        assert r.status_code == 404
+        assert r.get_json()["ok"] is False
+
+
+class TestPluginUpdateService:
+    def test_version_tuple_ordering(self):
+        from services.plugins import _version_tuple
+        assert _version_tuple("1.2.0") > _version_tuple("1.1.9")
+        assert _version_tuple("v2.0") > _version_tuple("1.9.9")
+        assert _version_tuple("") == (0,)
+
+    def test_get_plugin_updates_returns_rows(self):
+        from services.plugins import get_plugin_updates
+        rows = get_plugin_updates()
+        assert isinstance(rows, list)
+        for r in rows:
+            assert {"id", "installed_version", "available_version",
+                    "update_available", "source"} <= set(r.keys())
+
+    def test_update_plugin_not_installed_returns_none(self):
+        from services.plugins import update_plugin
+        assert update_plugin("__definitely_not_installed__") is None
+
+
+# ── WO-4.3 Greetings editor wrappers ────────────────────────────────────────
+
+class TestGreetingsAdmin:
+    def test_queue_requires_greeting(self, admin_client):
+        r = admin_client.post("/api/admin/greetings/queue", json={})
+        assert r.status_code == 400
+
+    def test_queue_rejects_too_long(self, admin_client):
+        r = admin_client.post("/api/admin/greetings/queue",
+                              json={"greeting": "x" * 400})
+        assert r.status_code == 400
+
+    def test_remove_missing_contextual_404(self, admin_client):
+        r = admin_client.post("/api/admin/greetings/remove-contextual",
+                              json={"greeting": "this greeting does not exist zzz"})
+        assert r.status_code == 404
+
+
+# ── ADMIN-BUG-2 — session-reset route disambiguation ────────────────────────
+
+class TestSessionResetRouteMove:
+    def test_conversation_bp_no_longer_owns_session_reset(self):
+        from app import create_app
+        app, _ = create_app(config_override={"TESTING": True})
+        from routes.conversation import conversation_bp
+        app.register_blueprint(conversation_bp)
+        rules = {r.rule: r.endpoint for r in app.url_map.iter_rules()}
+        # The deep-reset handler moved to the explicit path...
+        assert "/api/session/reset-openclaw" in rules
+        # ...and conversation_bp no longer registers the shadowing /api/session/reset.
+        assert rules.get("/api/session/reset") != "conversation.session_reset"
+
+
+# ── Gate wiring — all new endpoints live under an admin-gated prefix ─────────
+
+class TestAdminPrefixGate:
+    def test_new_routes_under_api_admin(self, admin_client):
+        from app import create_app
+        app, _ = create_app(config_override={"TESTING": True})
+        from routes.admin import admin_bp
+        app.register_blueprint(admin_bp)
+        new = [
+            "/api/admin/update/status", "/api/admin/update/preview",
+            "/api/admin/update/verify", "/api/admin/update/apply",
+            "/api/admin/update/rollback", "/api/admin/plugins/updates",
+            "/api/admin/greetings/queue", "/api/admin/greetings/remove-contextual",
+        ]
+        rules = {r.rule for r in app.url_map.iter_rules()}
+        for path in new:
+            assert path in rules, f"{path} not registered"
+            assert path.startswith("/api/admin/")

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -58,12 +58,35 @@ class TestReadiness:
         assert result.details is not None
         assert "tts" in result.details
 
-    def test_readiness_healthy_when_gateway_configured(self, health_checker, monkeypatch):
-        """When Gateway env vars are set and TTS loads, probe should be healthy."""
+    def test_readiness_healthy_when_gateway_reachable(self, health_checker, monkeypatch):
+        """WO-0.3: readiness now probes REACHABILITY (a live socket), not just
+        env-var presence. With a real listener bound at the gateway URL the
+        gateway sub-check is healthy."""
+        import socket as _socket
+        listener = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
         monkeypatch.setenv("CLAWDBOT_AUTH_TOKEN", "test-token")
-        monkeypatch.setenv("CLAWDBOT_GATEWAY_URL", "ws://127.0.0.1:18791")
-
-        result = health_checker.readiness()
-        # Gateway check should pass; TTS may or may not load in CI — only
-        # assert the gateway sub-check is healthy.
+        monkeypatch.setenv("CLAWDBOT_GATEWAY_URL", f"ws://127.0.0.1:{port}")
+        try:
+            result = health_checker.readiness()
+        finally:
+            listener.close()
+        # Gateway sub-check should pass because the socket is reachable; TTS may
+        # or may not load in CI — only assert the gateway sub-check.
         assert result.details["gateway"]["healthy"] is True
+
+    def test_readiness_unhealthy_when_gateway_unreachable(self, health_checker, monkeypatch):
+        """WO-0.3: env vars set but nothing listening → gateway is NOT ready
+        (previously this returned healthy on env-var presence alone)."""
+        import socket as _socket
+        # Bind then immediately close to get a definitely-closed port.
+        s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+        s.bind(("127.0.0.1", 0))
+        dead_port = s.getsockname()[1]
+        s.close()
+        monkeypatch.setenv("CLAWDBOT_AUTH_TOKEN", "test-token")
+        monkeypatch.setenv("CLAWDBOT_GATEWAY_URL", f"ws://127.0.0.1:{dead_port}")
+        result = health_checker.readiness()
+        assert result.details["gateway"]["healthy"] is False

--- a/tts_providers/__init__.py
+++ b/tts_providers/__init__.py
@@ -24,6 +24,7 @@ Date: 2026-02-11
 
 import json
 import os
+import threading
 from typing import Optional, Dict, Any, List
 
 from .base_provider import TTSProvider
@@ -31,6 +32,7 @@ from .hume_provider import HumeProvider
 from .supertonic_provider import SupertonicProvider
 from .groq_provider import GroqProvider
 from .qwen3_provider import Qwen3Provider
+from .qwen3_local_provider import Qwen3LocalProvider
 from .resemble_provider import ResembleProvider
 from .elevenlabs_provider import ElevenLabsProvider
 
@@ -40,29 +42,81 @@ _PROVIDERS = {
     'supertonic': SupertonicProvider,
     'groq': GroqProvider,
     'qwen3': Qwen3Provider,
+    'qwen3-local': Qwen3LocalProvider,
     'resemble': ResembleProvider,
     'elevenlabs': ElevenLabsProvider,
 }
 
+_CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'providers_config.json')
+
+# ── Module-level singleton caches (perf: TTS-1) ────────────────────────────────
+# get_provider() used to build a FRESH provider instance AND re-read the config
+# from disk on every call — which, on the voice hot path, happened once per
+# sentence. That defeated every instance-level cache (ElevenLabs voices,
+# Supertonic ONNX/voice cache) and re-read JSON per utterance. We now hold one
+# instance per provider id for the process lifetime, guarded by a lock so two
+# threads racing the first generate can't build two instances. Config is cached
+# with an mtime check so an admin edit is still picked up without a restart.
+_INSTANCE_CACHE: Dict[str, TTSProvider] = {}
+_INSTANCE_LOCK = threading.Lock()
+
+_CONFIG_CACHE: Optional[Dict[str, Any]] = None
+_CONFIG_MTIME: float = -1.0
+_CONFIG_LOCK = threading.Lock()
+
 
 def _load_config() -> Dict[str, Any]:
-    """Load providers configuration from JSON file."""
-    config_path = os.path.join(os.path.dirname(__file__), 'providers_config.json')
+    """Load providers configuration from JSON file (cached, mtime-reloaded)."""
+    global _CONFIG_CACHE, _CONFIG_MTIME
     try:
-        with open(config_path, 'r') as f:
-            return json.load(f)
-    except FileNotFoundError:
+        mtime = os.path.getmtime(_CONFIG_PATH)
+    except OSError:
         return {'providers': {}, 'default_provider': 'supertonic'}
+    # Fast path — cache still valid
+    if _CONFIG_CACHE is not None and mtime == _CONFIG_MTIME:
+        return _CONFIG_CACHE
+    with _CONFIG_LOCK:
+        # Re-check under the lock (another thread may have just loaded it)
+        if _CONFIG_CACHE is not None and mtime == _CONFIG_MTIME:
+            return _CONFIG_CACHE
+        try:
+            with open(_CONFIG_PATH, 'r') as f:
+                _CONFIG_CACHE = json.load(f)
+            _CONFIG_MTIME = mtime
+        except (FileNotFoundError, ValueError):
+            _CONFIG_CACHE = {'providers': {}, 'default_provider': 'supertonic'}
+            _CONFIG_MTIME = mtime
+    return _CONFIG_CACHE
+
+
+def invalidate(provider_id: Optional[str] = None) -> None:
+    """Drop cached provider instance(s) and the config cache.
+
+    Call this whenever providers_config.json is rewritten (default provider /
+    default voice change) so the next get_provider() rebuilds against fresh
+    config. Pass a provider_id to evict just that instance, or None for all.
+    """
+    global _CONFIG_CACHE, _CONFIG_MTIME
+    with _INSTANCE_LOCK:
+        if provider_id is None:
+            _INSTANCE_CACHE.clear()
+        else:
+            _INSTANCE_CACHE.pop(provider_id, None)
+    with _CONFIG_LOCK:
+        _CONFIG_CACHE = None
+        _CONFIG_MTIME = -1.0
+
 
 def get_provider(provider_id: Optional[str] = None) -> TTSProvider:
     """
-    Get a TTS provider instance.
+    Get a cached TTS provider instance (one per provider id, process lifetime).
 
     Args:
-        provider_id: Provider identifier ('hume', 'supertonic'). If None, uses default.
+        provider_id: Provider identifier ('hume', 'supertonic', ...). If None,
+            uses the configured default_provider.
 
     Returns:
-        TTSProvider instance
+        TTSProvider instance (shared singleton — do not mutate per-request state).
 
     Raises:
         ValueError: If provider_id is unknown
@@ -71,61 +125,82 @@ def get_provider(provider_id: Optional[str] = None) -> TTSProvider:
         >>> provider = get_provider('supertonic')
         >>> audio = provider.generate_speech("Hello", voice='M1')
     """
-    config = _load_config()
     if provider_id is None:
-        provider_id = config.get('default_provider', 'supertonic')
+        provider_id = _load_config().get('default_provider', 'supertonic')
 
     if provider_id not in _PROVIDERS:
         available = ', '.join(_PROVIDERS.keys())
         raise ValueError(f"Unknown provider '{provider_id}'. Available: {available}")
 
-    return _PROVIDERS[provider_id]()
+    inst = _INSTANCE_CACHE.get(provider_id)
+    if inst is not None:
+        return inst
+    with _INSTANCE_LOCK:
+        inst = _INSTANCE_CACHE.get(provider_id)
+        if inst is None:
+            inst = _PROVIDERS[provider_id]()
+            _INSTANCE_CACHE[provider_id] = inst
+        return inst
 
-def list_providers(include_inactive: bool = True) -> List[Dict[str, Any]]:
+
+def _catalog_info(provider_id: str, config: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a provider info dict from the config catalog (no instantiation)."""
+    cfg = dict(config.get('providers', {}).get(provider_id, {}))
+    cfg['provider_id'] = provider_id
+    cfg.setdefault('name', provider_id)
+    cfg.setdefault('status', 'active')
+    cfg.setdefault('voices', [])
+    # Reflect the live status of an ALREADY-cached instance (network-free —
+    # the instance exists so reading its _status touches no vendor API).
+    cached = _INSTANCE_CACHE.get(provider_id)
+    if cached is not None:
+        cfg['status'] = getattr(cached, '_status', cfg['status'])
+    return cfg
+
+
+def list_providers(include_inactive: bool = True,
+                   probe: bool = False) -> List[Dict[str, Any]]:
     """
     List all TTS providers with metadata.
 
     Args:
         include_inactive: If True, include inactive providers. Default True.
+        probe: If False (default — used by the readiness/health path), build
+            metadata from the config catalog WITHOUT instantiating providers or
+            calling any vendor API. If True (used by the admin/UI endpoint),
+            instantiate cached singletons and call get_info() for live detail
+            (cloned voices, dynamic status). Never make the health probe hit a
+            third-party API (HEALTH-1 / TTS-10).
 
     Returns:
-        List of provider metadata dictionaries
-
-    Example:
-        >>> for p in list_providers():
-        ...     print(f"{p['name']}: ${p['cost_per_minute']}/min")
+        List of provider metadata dictionaries.
     """
     config = _load_config()
     providers = []
 
-    for provider_id, provider_class in _PROVIDERS.items():
+    for provider_id in _PROVIDERS:
         try:
-            instance = provider_class()
-            info = instance.get_info()
+            if probe:
+                info = get_provider(provider_id).get_info()
+                # Merge catalog metadata (cost/quality/latency/etc.)
+                cfg = config.get('providers', {}).get(provider_id)
+                if cfg:
+                    for k in ('cost_per_minute', 'quality', 'latency', 'features',
+                              'requires_api_key', 'languages', 'notes'):
+                        if k in cfg:
+                            info[k] = cfg[k]
+                info['provider_id'] = provider_id
+            else:
+                info = _catalog_info(provider_id, config)
 
-            # Merge with config metadata
-            if provider_id in config.get('providers', {}):
-                config_data = config['providers'][provider_id]
-                info.update({
-                    'provider_id': provider_id,
-                    'cost_per_minute': config_data.get('cost_per_minute', 0.0),
-                    'quality': config_data.get('quality', 'unknown'),
-                    'latency': config_data.get('latency', 'unknown'),
-                    'features': config_data.get('features', []),
-                    'requires_api_key': config_data.get('requires_api_key', False),
-                    'languages': config_data.get('languages', []),
-                    'notes': config_data.get('notes', ''),
-                })
-
-            # Filter inactive if requested
             if not include_inactive and info.get('status') != 'active':
                 continue
-
             providers.append(info)
         except Exception as e:
             print(f"Warning: Failed to load provider {provider_id}: {e}")
 
     return providers
+
 
 __all__ = [
     'TTSProvider',
@@ -133,8 +208,10 @@ __all__ = [
     'SupertonicProvider',
     'GroqProvider',
     'Qwen3Provider',
+    'Qwen3LocalProvider',
     'ResembleProvider',
     'ElevenLabsProvider',
     'get_provider',
     'list_providers',
+    'invalidate',
 ]

--- a/tts_providers/elevenlabs_provider.py
+++ b/tts_providers/elevenlabs_provider.py
@@ -291,7 +291,13 @@ class ElevenLabsProvider(TTSProvider):
         return bool(self.api_key)
 
     def get_info(self) -> dict:
-        voices = self._fetch_voices() if self.api_key else []
+        # LAZY (TTS-4): NEVER fetch voices over the network on the info/readiness
+        # path — get_info() is called by list_providers()/health and, historically,
+        # once per sentence. A synchronous _fetch_voices() (15s timeout) here was
+        # the live 401-spam source and stalled the stream. Use only the already
+        # populated cache; callers that truly need a fresh voice list use
+        # list_voices() (which fetches with its own 5-min TTL cache).
+        voices = self._voices_cache or []
         cloned = [v for v in voices if v.get('category') == 'cloned']
         builtin = [v for v in voices if v.get('category') != 'cloned']
         return {

--- a/tts_providers/providers_config.json
+++ b/tts_providers/providers_config.json
@@ -71,6 +71,27 @@
       "audio_format": "mp3",
       "sample_rate": 24000
     },
+    "qwen3-local": {
+      "name": "Qwen3-TTS (local GPU)",
+      "provider_id": "qwen3-local",
+      "cost_per_minute": 0.0,
+      "quality": "very-high",
+      "latency": "fast",
+      "voices": [],
+      "features": ["voice-cloning", "multilingual", "local-gpu", "free", "mp3-output", "no-api-key"],
+      "requires_api_key": false,
+      "status": "active",
+      "description": "Qwen3-TTS-1.7B on residential RTX 3070 GPU — free, no API cost. Cloned voices only. Requires laptop + tunnel to be up.",
+      "languages": ["en", "zh", "es", "fr", "de", "it", "ja", "ko", "pt", "ru"],
+      "max_characters": 5000,
+      "notes": "Free local GPU inference via reverse SSH tunnel. Cloned voices only (.pt). Auto-disabled when laptop offline — falls back to qwen3 (fal.ai). OVUI_BRIDGE_AUTH_TOKEN required.",
+      "clone_endpoint": "/api/tts/clone",
+      "requires_microphone": false,
+      "requires_websocket": false,
+      "mode": "tts-only",
+      "audio_format": "mp3",
+      "sample_rate": 24000
+    },
     "resemble": {
       "name": "Resemble AI (Chatterbox)",
       "provider_id": "resemble",

--- a/tts_providers/resemble_provider.py
+++ b/tts_providers/resemble_provider.py
@@ -43,10 +43,12 @@ MODELS = {
 DEFAULT_MODEL = "chatterbox-turbo"
 
 # Timeouts
-STREAM_TIMEOUT = 120.0   # Max wait for full streaming response. Resemble's custom-clone
-                         # base model is slow (~53ms/char → a long ~1500-char chunk needs
-                         # ~80s); 30s used to cut long replies off mid-stream → silence.
-                         # 120s lets a full reply finish so the clone voice always speaks. (2026-06-07)
+STREAM_TIMEOUT = 30.0    # Max wait for one streaming request (TTS-2). Was 120s, which
+                         # — combined with up to 6 retries — let a hung Resemble cluster
+                         # head-of-line-block the ordered audio flush for MINUTES. tts.py
+                         # chunks Resemble at 400 chars (~21s at ~53ms/char), so a single
+                         # request finishes well under 30s; a request that doesn't is hung,
+                         # and bailing fast to retry/fallback beats blocking the whole reply.
 CONNECT_TIMEOUT = 10.0   # TCP connect timeout
 API_TIMEOUT = 15.0       # For voice listing / non-synthesis calls
 

--- a/tts_providers/supertonic_provider.py
+++ b/tts_providers/supertonic_provider.py
@@ -140,20 +140,21 @@ class SupertonicProvider(TTSProvider):
         # ── API mode ──────────────────────────────────────────────────────────
         # Preferred: call the shared supertonic-tts microservice.
         # Models are loaded once system-wide; no per-process ONNX loading.
+        #
+        # LAZY (TTS-3): __init__ must NEVER make a blocking network call — with the
+        # provider singleton this runs once, but a readiness/health probe or a
+        # cold first-sentence must not eat a 3s health GET (and then, on local
+        # fallback, a multi-second in-process ONNX load). If SUPERTONIC_API_URL is
+        # set we assume API mode and let the FIRST generate reveal an outage (the
+        # tts.py fallback chain handles a down service in <1s). No health GET here.
         if _API_URL:
-            try:
-                import requests
-                resp = requests.get(f"{_API_URL}/health", timeout=3)
-                if resp.ok:
-                    self._use_api = True
-                    self._api_url = _API_URL
-                    self.onnx_dir = onnx_dir or self.DEFAULT_ONNX_DIR
-                    self.voice_styles_dir = ""
-                    self._status = 'active'
-                    logger.info(f"SupertonicProvider: API mode → {_API_URL}")
-                    return
-            except Exception as e:
-                logger.warning(f"SupertonicProvider: API at {_API_URL} unreachable ({e}), trying local")
+            self._use_api = True
+            self._api_url = _API_URL
+            self.onnx_dir = onnx_dir or self.DEFAULT_ONNX_DIR
+            self.voice_styles_dir = ""
+            self._status = 'active'
+            logger.info(f"SupertonicProvider: API mode → {_API_URL} (lazy — no init health GET)")
+            return
 
         self._use_api = False
 
@@ -184,14 +185,11 @@ class SupertonicProvider(TTSProvider):
             logger.warning(f"SupertonicProvider: {self._init_error}")
             return
 
-        try:
-            self._create_tts_instance(self.default_voice)
-            self._status = 'active'
-            logger.info(f"SupertonicProvider: local mode, voice '{default_voice}'")
-        except Exception as e:
-            self._status = 'error'
-            self._init_error = str(e)
-            logger.error(f"SupertonicProvider initialization failed: {e}")
+        # LAZY (TTS-3): dirs exist → mark active but DO NOT load ONNX models here.
+        # The first generate_speech() lazily creates (and caches) the SupertonicTTS
+        # instance via _create_tts_instance(), so __init__ stays fast/non-blocking.
+        self._status = 'active'
+        logger.info(f"SupertonicProvider: local mode ready (voice '{default_voice}', ONNX loads on first use)")
 
     def _get_voice_style_path(self, voice: str) -> str:
         """


### PR DESCRIPTION
Implements the full remediation from the 2026-07-11 Fable review of OpenVoiceUI. Spec docs: `docs/reviews/FABLE-OVUI-FULL-REVIEW-2026-07-11.md` (bugs + latency) and `docs/reviews/FABLE-OVUI-ADMIN-PANEL-PLAN-2026-07-11.md` (admin plan) in the MIKE-AI repo.

**35 files, +4339/-529. Full suite: 507 passed, 1 skipped. Additive-only, no deletions.**

## Security (Phase 0) — two live exposures closed
- **SEC-1:** `/api/stt/deepgram/token` no longer returns the raw Deepgram API key unauthenticated — `/api/stt/` removed from the public allowlist; verified 401 unauthenticated.
- **SEC-2:** canvas lock/publish guards are now unconditional (admin-only) — an unauthenticated caller can no longer unlock and publish a private page.
- Public prefixes split into all-methods vs GET/HEAD/OPTIONS-only: writes under canvas/tts/chat/music/faces/custom-faces/icons/suno/profiles now require agent-key or Clerk session; the agent-key preserve-list is intact.
- `/openclaw-ui` WS proxy admin-gated + RPC method allowlist; registry reflected-XSS escaped; empty `ALLOWED_USER_IDS` now fails closed; Suno callback warns + https-only (fail-closed deferred until `SUNO_WEBHOOK_SECRET` is provisioned fleet-wide).
- Model-save silent no-op fixed: honest errors, routed through the hardened gateway `config.patch` path.
- `/health/ready` makes zero third-party calls (ends the live ElevenLabs 401-spam) and probes real gateway reachability.

## P1 correctness
- **WS:** reconnect after a passive gateway drop (proactive push no longer goes silently deaf); per-client single-writer queue (no cross-thread frame corruption); executor-based receives so idle sockets don't starve the gateway direction; connection-leak fix; activity-based stream watchdog.
- **TTS:** provider singleton cache (kills per-sentence re-init — the biggest latency source); hung-provider skip-ahead that never discards paid audio; transitive fallback with cycle guard; honest per-chunk audio format; qwen3-local registered.
- **Frontend:** `_setPTT` profile-abort fixed; stream dispatch moved out of the parse `catch`; per-tag handler isolation; Suno-announcement echo mute; interrupt race; listener leak; duplicate-reply swallowing.
- **RT-1:** music delete now soft-deletes (`.deleted`) per the NEVER-DELETE house rule.

## Admin panel — framework-agnostic control surface
- **Service Catalog** (`/api/services/catalog` + `/health`, admin-gated): unified descriptor per gateway/llm/tts/stt — capabilities, config schema, credential refs (never values), health, restart_scope. The panel renders from data; adding a provider never edits the panel.
- `GatewayBase` config contract (capabilities/get_config_schema/configure/check_health) — OpenClaw via `config.patch` RPC; defaults degrade gracefully. AI-config dispatches through the active framework so a Hermes-primary tenant doesn't 502.
- New tabs: **Agent Framework**, **Voice: TTS** (live fallback-chain editor, test-speak, server defaults + cloned-voice manager), **Voice: STT & Wake**, **Sessions** (list/history/abort), **Updates** (preview/verify/apply/rollback), **Tools** (transcripts/usage/diagnostics/issues/greetings), **System Health** matrix.
- Marketplace: version-diff + update-available badges + one-click update (soft-archive + rollback). Restart-scope badges on every config save. Catalog-driven dropdowns replace drifted schema enums.

## Notes
- `plugins/hermes-agent/gateway.py` is gitignored (installs from the plugin registry); its contract implementation is captured at `dev-tasks/hermes-agent-gateway-catalog-contract.patch` for upstreaming.
- **No image rebuild / fleet roll in this PR** — repo caught up, ready for a test-dev staging image and Mike's test before fleet.
