### PR TITLE
feat(desktop): critical bug fixes, nested Start Menu flyouts, auto icon-gen + glass/3D style

### DIFF
--- a/default-pages/desktop.html
+++ b/default-pages/desktop.html
@@ -149,8 +149,9 @@ html,body{width:100%!important;height:100%!important;overflow:hidden!important;b
 .sm-item{
   padding:5px 12px;cursor:pointer;
   font-size:12px;display:flex;align-items:center;gap:8px;
-  white-space:nowrap;
+  white-space:nowrap;position:relative;
 }
+.sm-item.has-sub::after{content:'▶';position:absolute;right:8px;font-size:8px;opacity:.6}
 .sm-item .sm-icon{width:24px;height:24px;flex-shrink:0}
 .sm-item .sm-icon svg{width:100%;height:100%}
 .sm-separator{margin:2px 0;border:none}
@@ -334,8 +335,10 @@ html,body{width:100%!important;height:100%!important;overflow:hidden!important;b
   border-radius:6px;
 }
 
-/* ── Mobile / small container responsive ── */
-@media (max-width:600px) {
+/* ── Mobile / small container responsive ──
+   Thresholds must match JS getBreakpoint() (480=phone, 1024=tablet ceiling)
+   so icon sizing/grid math and CSS layout never disagree. */
+@media (max-width:768px) {
   /* Desktop icons — smaller grid */
   .desktop-icon{width:56px!important}
   .desktop-icon .icon-img{width:32px!important;height:32px!important}
@@ -383,7 +386,7 @@ html,body{width:100%!important;height:100%!important;overflow:hidden!important;b
   #dock .dock-icon svg{width:28px!important;height:28px!important}
   #dock{padding:2px 4px!important;gap:1px!important;border-radius:10px!important}
 }
-@media (max-width:400px) {
+@media (max-width:480px) {
   .desktop-icon{width:48px!important}
   .desktop-icon .icon-img{width:26px!important;height:26px!important}
   .desktop-icon .icon-label{font-size:8px!important;max-width:46px!important}
@@ -833,6 +836,10 @@ const ICONS = {
   recycle:`<svg viewBox="0 0 48 48"><rect x="14" y="6" width="20" height="4" rx="2" fill="#7f8c8d"/><rect x="20" y="4" width="8" height="4" rx="1" fill="#95a5a6"/><rect x="10" y="10" width="28" height="3" rx="1" fill="#95a5a6"/><path d="M13 13h22l-2 31H15z" fill="#bdc3c7"/><path d="M13 13h22l-1 4H14z" fill="#aab4be"/><line x1="20" y1="20" x2="19" y2="40" stroke="#95a5a6" stroke-width="1.5"/><line x1="24" y1="20" x2="24" y2="40" stroke="#95a5a6" stroke-width="1.5"/><line x1="28" y1="20" x2="29" y2="40" stroke="#95a5a6" stroke-width="1.5"/></svg>`,
   'recycle-full':`<svg viewBox="0 0 48 48"><rect x="14" y="6" width="20" height="4" rx="2" fill="#7f8c8d"/><rect x="20" y="4" width="8" height="4" rx="1" fill="#95a5a6"/><rect x="10" y="10" width="28" height="3" rx="1" fill="#95a5a6"/><path d="M13 13h22l-2 31H15z" fill="#bdc3c7"/><path d="M13 13h22l-1 4H14z" fill="#aab4be"/><rect x="17" y="15" width="5" height="8" rx="1" fill="#e8e8e8" transform="rotate(-10 19 19)"/><rect x="25" y="14" width="5" height="9" rx="1" fill="#d0d0d0" transform="rotate(5 27 18)"/><rect x="20" y="17" width="4" height="7" rx="1" fill="#f0f0f0" transform="rotate(-3 22 20)"/></svg>`,
   document:`<svg viewBox="0 0 48 48"><path d="M12 4h18l10 10v30a2 2 0 01-2 2H12a2 2 0 01-2-2V6a2 2 0 012-2z" fill="#fff" stroke="#ccc" stroke-width="1"/><path d="M30 4v10h10" fill="#eee" stroke="#ccc" stroke-width="1"/><line x1="16" y1="22" x2="34" y2="22" stroke="#ddd" stroke-width="1.5"/><line x1="16" y1="28" x2="34" y2="28" stroke="#ddd" stroke-width="1.5"/><line x1="16" y1="34" x2="28" y2="34" stroke="#ddd" stroke-width="1.5"/></svg>`,
+  image:`<svg viewBox="0 0 48 48"><rect x="4" y="6" width="40" height="36" rx="3" fill="#fff" stroke="#ccc" stroke-width="1"/><circle cx="16" cy="18" r="4.5" fill="#f5c842"/><path d="M8 36l11-13 8 9 5-6 12 10v2a2 2 0 01-2 2H10a2 2 0 01-2-2v-2z" fill="#5dade2"/></svg>`,
+  video:`<svg viewBox="0 0 48 48"><rect x="4" y="10" width="40" height="28" rx="3" fill="#1a1a2e"/><path d="M20 18l12 8-12 8z" fill="#fff"/><rect x="4" y="10" width="40" height="5" fill="#0d0d1a"/><circle cx="9" cy="12.5" r="1.2" fill="#e63030"/><circle cx="14" cy="12.5" r="1.2" fill="#f5c842"/><circle cx="19" cy="12.5" r="1.2" fill="#34d399"/></svg>`,
+  pdf:`<svg viewBox="0 0 48 48"><path d="M12 4h18l10 10v30a2 2 0 01-2 2H12a2 2 0 01-2-2V6a2 2 0 012-2z" fill="#fff" stroke="#ccc" stroke-width="1"/><path d="M30 4v10h10" fill="#eee" stroke="#ccc" stroke-width="1"/><rect x="9" y="26" width="24" height="14" rx="2" fill="#e63030"/><text x="21" y="36" text-anchor="middle" font-family="system-ui,sans-serif" font-size="9" font-weight="800" fill="#fff">PDF</text></svg>`,
+  archive:`<svg viewBox="0 0 48 48"><rect x="6" y="8" width="36" height="32" rx="2" fill="#e8b84b" stroke="#c99a35" stroke-width="1"/><rect x="20" y="8" width="8" height="32" fill="#c99a35" opacity="0.5"/><rect x="20" y="8" width="8" height="4" fill="#c99a35"/><rect x="20" y="16" width="8" height="4" fill="#c99a35"/><rect x="20" y="24" width="8" height="4" fill="#c99a35"/><circle cx="24" cy="33" r="3" fill="#7f8c8d"/></svg>`,
   internet:`<svg viewBox="0 0 48 48"><circle cx="24" cy="24" r="20" fill="#3498db"/><circle cx="24" cy="24" r="20" fill="none" stroke="#2980b9" stroke-width="1"/><ellipse cx="24" cy="24" rx="10" ry="20" fill="none" stroke="rgba(255,255,255,0.5)" stroke-width="1.5"/><line x1="4" y1="24" x2="44" y2="24" stroke="rgba(255,255,255,0.5)" stroke-width="1.5"/><ellipse cx="24" cy="15" rx="17" ry="5" fill="none" stroke="rgba(255,255,255,0.3)" stroke-width="1"/><ellipse cx="24" cy="33" rx="17" ry="5" fill="none" stroke="rgba(255,255,255,0.3)" stroke-width="1"/></svg>`,
   music:`<svg viewBox="0 0 48 48"><circle cx="14" cy="36" r="6" fill="#e74c3c"/><circle cx="14" cy="36" r="2" fill="#c0392b"/><circle cx="34" cy="32" r="6" fill="#e74c3c"/><circle cx="34" cy="32" r="2" fill="#c0392b"/><rect x="18" y="8" width="3" height="28" fill="#2c3e50" rx="1"/><rect x="38" y="4" width="3" height="28" fill="#2c3e50" rx="1"/><rect x="18" y="6" width="23" height="5" fill="#2c3e50" rx="1"/></svg>`,
   game:`<svg viewBox="0 0 48 48"><rect x="4" y="14" width="40" height="22" rx="11" fill="#2c3e50"/><rect x="4" y="14" width="40" height="11" rx="11" fill="#34495e"/><circle cx="14" cy="25" r="3.5" fill="#ecf0f1"/><rect x="11.5" y="23.5" width="5" height="1.5" rx=".5" fill="#bdc3c7"/><rect x="13.2" y="21.5" width="1.5" height="5" rx=".5" fill="#bdc3c7"/><circle cx="34" cy="22" r="2.5" fill="#e74c3c"/><circle cx="38" cy="26" r="2.5" fill="#3498db"/><circle cx="30" cy="26" r="2.5" fill="#2ecc71"/><circle cx="34" cy="30" r="2.5" fill="#f39c12"/></svg>`,
@@ -889,8 +896,13 @@ function getActivePositions() {
   return iconPositions;
 }
 
-// Save state to server (debounced)
+// Save state to server (debounced). _stateDirty guards fetchManifest from
+// clobbering unsaved local changes (drag positions, etc.) — a 30s manifest
+// poll landing between a drag and its debounced save used to silently
+// discard the drag.
+let _stateDirty = false;
 function saveState() {
+  _stateDirty = true;
   clearTimeout(_saveTimer);
   _saveTimer = setTimeout(_doSaveState, 500);
 }
@@ -900,25 +912,28 @@ function _doSaveState() {
     theme: currentTheme, iconPositions, recycleBin,
     customFolders, desktopPages, knownPages, wallpaperUrl, savedPageCategories,
   });
-  fetch('/api/canvas/manifest/page/desktop', {
-    method: 'PATCH',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({description: state}),
-  }).catch(() => {});
+  const saves = [
+    fetch('/api/canvas/manifest/page/desktop', {
+      method: 'PATCH',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({description: state}),
+    }).catch(() => {}),
+  ];
   // Save breakpoint-specific positions to their own manifest entries
   if (currentBreakpoint === 'tablet') {
-    fetch('/api/canvas/manifest/page/desktop-tablet', {
+    saves.push(fetch('/api/canvas/manifest/page/desktop-tablet', {
       method: 'PATCH',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({description: JSON.stringify({iconPositions: iconPositionsTablet})}),
-    }).catch(() => {});
+    }).catch(() => {}));
   } else if (currentBreakpoint === 'phone') {
-    fetch('/api/canvas/manifest/page/desktop-phone', {
+    saves.push(fetch('/api/canvas/manifest/page/desktop-phone', {
       method: 'PATCH',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({description: JSON.stringify({iconPositions: iconPositionsPhone})}),
-    }).catch(() => {});
+    }).catch(() => {}));
   }
+  Promise.all(saves).finally(() => { _stateDirty = false; });
 }
 
 // Load state from server — fetch all three breakpoint entries in parallel
@@ -973,6 +988,7 @@ async function loadState() {
    MANIFEST SYNC — fetch pages dynamically from server
    ══════════════════════════════════════════════════════════════ */
 async function fetchManifest(forceSync) {
+  if (_stateDirty && !forceSync) return; // unsaved local changes — don't clobber
   try {
     const url = '/api/canvas/manifest' + (forceSync ? '?sync=1' : '');
     const resp = await fetch(url);
@@ -1191,10 +1207,11 @@ function getIconName(item) {
 
 function buildDesktopIcons() {
   const desktop = document.getElementById('desktop');
+  bindDesktopIconListeners();
   desktop.querySelectorAll('.desktop-icon').forEach(el => el.remove());
   const isRightToLeft = currentTheme === 'mac';
   const container = document.getElementById('os-container');
-  const isSmall = container && container.offsetWidth < 500;
+  const isSmall = container && container.offsetWidth <= 480; // matches getBreakpoint() phone threshold
   const startX = isRightToLeft ? desktop.offsetWidth - (isSmall ? 65 : 90) : 10;
   const startY = getDesktopTop() + 10;
   const colH = getDesktopHeight() - 20;
@@ -1224,17 +1241,44 @@ function buildDesktopIcons() {
       ? `<img src="${item.iconUrl}" style="width:100%;height:100%;object-fit:contain;">`
       : getIcon(recycleIcon);
     el.innerHTML = `<div class="icon-img">${iconHtml}</div><div class="icon-label">${getIconName(item)}</div>`;
-    el.addEventListener('mousedown', (e) => onIconMouseDown(e, item));
-    el.addEventListener('touchstart', (e) => onIconTouchStart(e, item), {passive:false});
-    el.addEventListener('dblclick', (e) => { e.stopPropagation(); onIconDblClick(item); });
     desktop.appendChild(el);
+  });
+}
+
+// Delegated icon listeners — attached once to #desktop, never re-attached on
+// rebuild. buildDesktopIcons() destroys/recreates icon DOM every manifest
+// poll; per-icon listeners would otherwise be re-registered every cycle.
+let _desktopIconListenersBound = false;
+function bindDesktopIconListeners() {
+  if (_desktopIconListenersBound) return;
+  _desktopIconListenersBound = true;
+  const desktop = document.getElementById('desktop');
+  desktop.addEventListener('mousedown', (e) => {
+    const el = e.target.closest('.desktop-icon');
+    if (!el) return;
+    const item = DESKTOP_ITEMS.find(i => i.id === el.dataset.id);
+    if (item) onIconMouseDown(e, item);
+  });
+  desktop.addEventListener('touchstart', (e) => {
+    const el = e.target.closest('.desktop-icon');
+    if (!el) return;
+    const item = DESKTOP_ITEMS.find(i => i.id === el.dataset.id);
+    if (item) onIconTouchStart(e, item);
+  }, {passive:false});
+  desktop.addEventListener('dblclick', (e) => {
+    const el = e.target.closest('.desktop-icon');
+    if (!el) return;
+    const item = DESKTOP_ITEMS.find(i => i.id === el.dataset.id);
+    if (item) { e.stopPropagation(); onIconDblClick(item); }
   });
 }
 
 function onIconTouchStart(e, item) {
   e.preventDefault();
   const touch = e.touches[0];
-  const el = e.currentTarget;
+  // e.currentTarget is #desktop (delegated listener) — find the actual icon.
+  const el = e.target.closest('.desktop-icon');
+  if (!el) return;
   const startX = touch.clientX, startY = touch.clientY;
   const origLeft = parseInt(el.style.left), origTop = parseInt(el.style.top);
   let moved = false;
@@ -1296,7 +1340,9 @@ function onIconMouseDown(e, item) {
   selectedIcons.add(item.id);
   updateIconSelection();
 
-  const el = e.currentTarget;
+  // e.currentTarget is #desktop (delegated listener) — find the actual icon.
+  const el = e.target.closest('.desktop-icon');
+  if (!el) return;
   const startX = e.clientX, startY = e.clientY;
   const origLeft = parseInt(el.style.left), origTop = parseInt(el.style.top);
   let moved = false;
@@ -1458,28 +1504,21 @@ function createWindow(opts) {
     ? {close:'', min:'', max:''}
     : {close:'\u00D7', min:'\u2013', max:'\u25A1'};
 
-  el.innerHTML = `
-    <div class="titlebar" onmousedown="startWindowDrag(event,${id})">
-      <div class="titlebar-btns">
+  const btnsHtml = `<div class="titlebar-btns">
         <button class="tb-btn close" onclick="closeWindow(${id})" title="Close">${btnSymbols.close}</button>
         <button class="tb-btn min" onclick="minimizeWindow(${id})" title="Minimize">${btnSymbols.min}</button>
         <button class="tb-btn max" onclick="maximizeWindow(${id})" title="Maximize">${btnSymbols.max}</button>
-      </div>
-      <div class="titlebar-title">${opts.title || 'Window'}</div>
-      ${!isMacLike ? '<div class="titlebar-btns"><button class="tb-btn min" onclick="minimizeWindow('+id+')" title="Minimize">\u2013</button><button class="tb-btn max" onclick="maximizeWindow('+id+')" title="Maximize">\u25A1</button><button class="tb-btn close" onclick="closeWindow('+id+')" title="Close">\u00D7</button></div>' : ''}
+      </div>`;
+  const titlebarInnerHtml = isMacLike
+    ? `${btnsHtml}<div class="titlebar-title">${opts.title || 'Window'}</div>`
+    : `<div class="titlebar-title">${opts.title || 'Window'}</div>${btnsHtml}`;
+
+  el.innerHTML = `
+    <div class="titlebar" onmousedown="startWindowDrag(event,${id})">
+      ${titlebarInnerHtml}
     </div>
     <div class="win-body">${opts.content || ''}</div>
   `;
-
-  // For non-mac-like themes, remove the first set of buttons (left-side ones)
-  if (!isMacLike) {
-    const firstBtns = el.querySelector('.titlebar-btns');
-    if (firstBtns) firstBtns.remove();
-  } else {
-    // For mac-like, remove the second set (right-side)
-    const allBtns = el.querySelectorAll('.titlebar-btns');
-    if (allBtns.length > 1) allBtns[1].remove();
-  }
 
   // Add resize handles
   ['n','s','e','w','nw','ne','sw','se'].forEach(dir => {
@@ -2132,6 +2171,7 @@ function closeAllMenus() {
   document.getElementById('start-menu').classList.remove('show');
   contextMenuOpen = false;
   startMenuOpen = false;
+  hideStartFlyoutNow();
 }
 
 function arrangeIcons() {
@@ -2153,6 +2193,72 @@ function toggleStartMenu() {
   buildStartMenu();
   menu.classList.add('show');
   startMenuOpen = true;
+}
+
+/* ── Start Menu category flyouts (real Windows-style nested submenus) ──
+   Reuses the existing .ctx-submenu hover-flyout look (see CONTEXT MENU
+   section) but appended to #app instead of nested in the row, because
+   #start-menu / .sm-left clip overflow (needed for their own scrollbars)
+   and would otherwise chop the flyout off. */
+let _smFlyoutEl = null;
+let _smFlyoutHideTimer = null;
+let _smFlyoutCatId = null;
+
+function showStartCategoryFlyout(anchorEl, catId) {
+  clearTimeout(_smFlyoutHideTimer);
+  if (_smFlyoutCatId === catId && _smFlyoutEl) return;
+  hideStartFlyoutNow();
+  _smFlyoutCatId = catId;
+
+  const pages = Object.entries(PAGES)
+    .filter(([id, p]) => p.cat === catId && !recycleBin.includes(id))
+    .sort((a, b) => a[1].name.localeCompare(b[1].name));
+
+  const el = document.createElement('div');
+  el.className = 'ctx-submenu sm-flyout';
+  el.style.display = 'block';
+  el.style.position = 'absolute';
+
+  let html = '';
+  if (!pages.length) {
+    html += '<div class="ctx-item" style="opacity:.5;cursor:default">(empty)</div>';
+  } else {
+    pages.slice(0, 30).forEach(([pid, p]) => {
+      html += `<div class="ctx-item" onclick="openCanvasPage('${pid}');closeAllMenus()"><span style="display:inline-block;width:16px;height:16px;vertical-align:-3px;margin-right:6px">${getIcon(getPageIconType(catId, pid, p.name))}</span>${p.name}</div>`;
+    });
+  }
+  html += '<div class="ctx-separator"></div>';
+  html += `<div class="ctx-item" onclick="openExplorer('${catId}');closeAllMenus()"><em>Open Folder…</em></div>`;
+  el.innerHTML = html;
+
+  el.addEventListener('mouseenter', () => clearTimeout(_smFlyoutHideTimer));
+  el.addEventListener('mouseleave', scheduleHideStartFlyout);
+
+  const app = document.getElementById('app');
+  app.appendChild(el);
+
+  const appRect = app.getBoundingClientRect();
+  const anchorRect = anchorEl.getBoundingClientRect();
+  const flyoutW = el.offsetWidth || 180;
+  let left = anchorRect.right - appRect.left;
+  if (left + flyoutW > appRect.width) {
+    left = anchorRect.left - appRect.left - flyoutW; // flip left if it would overflow the right edge
+  }
+  el.style.left = Math.max(0, left) + 'px';
+  el.style.top = Math.max(0, Math.min(anchorRect.top - appRect.top, appRect.height - el.offsetHeight)) + 'px';
+
+  _smFlyoutEl = el;
+}
+
+function scheduleHideStartFlyout() {
+  clearTimeout(_smFlyoutHideTimer);
+  _smFlyoutHideTimer = setTimeout(hideStartFlyoutNow, 250);
+}
+
+function hideStartFlyoutNow() {
+  if (_smFlyoutEl) { _smFlyoutEl.remove(); _smFlyoutEl = null; }
+  _smFlyoutCatId = null;
+  clearTimeout(_smFlyoutHideTimer);
 }
 
 function buildStartMenu() {
@@ -2185,7 +2291,7 @@ function buildStartMenu() {
     html += '<div class="ctx-item" onclick="openThemeSettings();closeAllMenus()">'+(isMac?'System Preferences...':(isUbuntu?'Settings...':'Control Panel'))+'</div>';
     html += '<div class="ctx-separator"></div>';
     Object.keys(CATEGORIES).forEach(catId => {
-      html += `<div class="ctx-item" onclick="openExplorer('${catId}');closeAllMenus()">${CATEGORIES[catId].name}</div>`;
+      html += `<div class="ctx-item has-sub" onmouseenter="showStartCategoryFlyout(this,'${catId}')" onmouseleave="scheduleHideStartFlyout()" onclick="openExplorer('${catId}');closeAllMenus()">${CATEGORIES[catId].name}</div>`;
     });
     html += '<div class="ctx-separator"></div>';
     html += '<div class="ctx-item" onclick="openCanvasPage(\'file-explorer\');closeAllMenus()">'+(isMac?'Open Finder':(isUbuntu?'Files':'File Manager'))+'</div>';
@@ -2215,9 +2321,9 @@ function buildStartMenu() {
     html += `<div class="sm-item" onclick="openCanvasPage('${pid}');closeAllMenus()"><div class="sm-icon">${getIcon('document')}</div>${p.name}</div>`;
   });
   html += '<div class="sm-separator"></div>';
-  // All Programs submenu - show categories
+  // All Programs submenu - show categories, hover expands a flyout of pages in it
   Object.keys(CATEGORIES).forEach(catId => {
-    html += `<div class="sm-item" onclick="openExplorer('${catId}');closeAllMenus()"><div class="sm-icon">${getIcon('folder')}</div>${CATEGORIES[catId].name}</div>`;
+    html += `<div class="sm-item has-sub" onmouseenter="showStartCategoryFlyout(this,'${catId}')" onmouseleave="scheduleHideStartFlyout()" onclick="openExplorer('${catId}');closeAllMenus()"><div class="sm-icon">${getIcon('folder')}</div>${CATEGORIES[catId].name}</div>`;
   });
   html += '</div>';
 
@@ -2443,6 +2549,18 @@ function buildExplorerGrid(catId) {
 function getPageIconType(cat, pageId, pageName) {
   const n = (pageName || pageId || '').toLowerCase();
   const pid = (pageId || '').toLowerCase();
+  // File-type icons — a literal extension on the id/name (e.g. an uploaded
+  // image/video/audio/pdf surfaced as a desktop shortcut) is a stronger
+  // signal than name-keyword guessing, so it's checked first.
+  const extMatch = pid.match(/\.([a-z0-9]+)$/) || n.match(/\.([a-z0-9]+)$/);
+  if (extMatch) {
+    const ext = extMatch[1];
+    if (['png','jpg','jpeg','gif','webp','svg','bmp','avif'].includes(ext)) return 'image';
+    if (['mp4','mov','webm','avi','mkv'].includes(ext)) return 'video';
+    if (['mp3','wav','m4a','ogg','flac'].includes(ext)) return 'music';
+    if (ext === 'pdf') return 'pdf';
+    if (['zip','tar','gz','rar','7z'].includes(ext)) return 'archive';
+  }
   // Specific page ID overrides — precise icons for known pages
   const pidMap = {
     'voice-studio':'voice','music-library':'music','song-tagger':'music',
@@ -2464,7 +2582,7 @@ function getPageIconType(cat, pageId, pageName) {
   if (/voice.studio|voice.clone/.test(n)) return 'voice';
   if (/music|song|audio|tts|suno/.test(n)) return 'music';
   if (/game|arcade|wolf|doom|quake|duke|play|shooter|civ.sim|bored/.test(n)) return 'game';
-  if (/video|film|remotion/.test(n)) return 'folder';
+  if (/video|film|remotion/.test(n)) return 'video';
   if (/book|doc|ref|guide|manual/.test(n)) return 'book';
   if (/tool|build|code|dev|api|terminal/.test(n)) return 'tools';
   if (/crm|contact|lead/.test(n)) return 'crm';
@@ -2604,7 +2722,7 @@ function openCanvasPage(pageId, newWindow) {
     type: 'canvas-action',
     action: 'navigate',
     page: pageId,
-  }, '*');
+  }, window.location.origin);
 }
 
 /* ══════════════════════════════════════════════════════════════

--- a/routes/canvas.py
+++ b/routes/canvas.py
@@ -362,7 +362,78 @@ def generate_voice_aliases(title: str) -> list[str]:
 def sync_canvas_manifest() -> dict:
     """Full sync with pages directory."""
     with _manifest_lock:
-        return _sync_canvas_manifest_locked()
+        manifest = _sync_canvas_manifest_locked()
+    _kick_off_pending_icon_generation(manifest)
+    return manifest
+
+
+# Pages still missing a custom icon after HTML-meta extraction get a real
+# generated one automatically — the icon-generation skill tells agents to do
+# this themselves, but nothing enforced it (grep found no call site besides
+# the route), so pages silently fell back to the generic document icon
+# whenever an agent skipped the step. This is the enforcement layer.
+_ICON_GEN_RETRY_COOLDOWN = 6 * 3600  # seconds — backoff after a failed attempt
+
+
+def _kick_off_pending_icon_generation(manifest: dict) -> None:
+    """Fire-and-forget: spawn a background thread to generate icons for any
+    page still missing one. Must never run inline here — this function is
+    called on every /api/canvas/manifest sync (throttled to 60s, but still a
+    request path polled by every open desktop), and Gemini calls take
+    seconds. The thread generates sequentially, never concurrently, so a
+    tenant with many icon-less pages doesn't fire a burst of API calls."""
+    now = time.time()
+    pending = []
+    for page_id, page_data in manifest.get('pages', {}).items():
+        if page_id == 'desktop' or page_data.get('icon'):
+            continue
+        failed_at = page_data.get('icon_gen_failed_at')
+        if failed_at and now - failed_at < _ICON_GEN_RETRY_COOLDOWN:
+            continue
+        pending.append(page_id)
+    if not pending:
+        return
+    threading.Thread(target=_generate_pending_icons, args=(pending,), daemon=True).start()
+
+
+def _generate_pending_icons(page_ids) -> None:
+    """Background-thread worker — see _kick_off_pending_icon_generation()."""
+    from routes.icons import generate_icon_image, IconGenerationError
+    logger = logging.getLogger(__name__)
+    for i, page_id in enumerate(page_ids):
+        if i > 0:
+            time.sleep(2)  # stagger Gemini calls
+        try:
+            with _manifest_lock:
+                manifest = load_canvas_manifest()
+                page_data = manifest['pages'].get(page_id)
+                if not page_data or page_data.get('icon'):
+                    continue  # something else set an icon meanwhile
+                title = page_data.get('display_name') or page_id.replace('-', ' ').title()
+                category = page_data.get('category', 'uncategorized')
+                description = page_data.get('description', '')
+
+            prompt = f'A {category} icon for: {title}.' + (f' {description}' if description else '')
+            try:
+                result = generate_icon_image(prompt, name=f'{page_id}-icon')
+            except IconGenerationError as e:
+                logger.warning(f'Auto icon-gen failed for {page_id}: {e}')
+                with _manifest_lock:
+                    manifest = load_canvas_manifest()
+                    if page_id in manifest['pages']:
+                        manifest['pages'][page_id]['icon_gen_failed_at'] = time.time()
+                        save_canvas_manifest(manifest)
+                continue
+
+            with _manifest_lock:
+                manifest = load_canvas_manifest()
+                if page_id in manifest['pages'] and not manifest['pages'][page_id].get('icon'):
+                    manifest['pages'][page_id]['icon'] = result['url']
+                    manifest['pages'][page_id].pop('icon_gen_failed_at', None)
+                    save_canvas_manifest(manifest)
+                    logger.info(f"Auto-generated icon for {page_id}: {result['url']}")
+        except Exception as e:
+            logger.warning(f'Auto icon-gen error for {page_id}: {e}')
 
 
 def _sync_canvas_manifest_locked() -> dict:

--- a/routes/icons.py
+++ b/routes/icons.py
@@ -187,39 +187,47 @@ def serve_icon(name):
 #  AI ICON GENERATION (Gemini)
 # ══════════════════════════════════════════════════════════════
 
-@icons_bp.route('/api/icons/generate', methods=['POST'])
-def generate_icon():
+# Default style for generated icons — modern glassmorphic 3D, matching the
+# rest of the desktop's move away from flat/retro toward an Apple-style look.
+# Override per-call with the `style` param (e.g. retro/pixel-art for games).
+DEFAULT_ICON_STYLE = (
+    'modern 3D glassmorphic app icon, frosted translucent glass material, '
+    'soft rounded squircle shape, subtle depth and drop shadow, vibrant '
+    'gradient accent color, macOS Big Sur / visionOS app icon style'
+)
+
+
+class IconGenerationError(Exception):
+    """Raised by generate_icon_image() on any failure — callers (HTTP route
+    or internal auto-gen hook) decide how to surface it."""
+    def __init__(self, message, status=502):
+        super().__init__(message)
+        self.status = status
+
+
+def generate_icon_image(prompt, name=None, style=None):
     """
-    Generate a custom icon via Gemini image generation.
+    Core icon-generation logic — callable directly (used by the auto-gen
+    hook in routes/canvas.py) or via the /api/icons/generate HTTP route.
 
-    POST body:
-      { "prompt": "description of icon",
-        "name": "optional-filename-slug",
-        "style": "optional style override" }
-
-    Returns:
-      { "url": "/api/icons/generated/my-icon.png",
-        "name": "my-icon",
-        "prompt": "..." }
+    Returns a dict: {url, name, filename, prompt, size}
+    Raises IconGenerationError on any failure.
     """
     if not GEMINI_API_KEY:
-        return jsonify({'error': 'GEMINI_API_KEY not configured'}), 500
+        raise IconGenerationError('GEMINI_API_KEY not configured', status=500)
 
-    data = request.get_json(silent=True) or {}
-    user_prompt = data.get('prompt', '').strip()
+    user_prompt = (prompt or '').strip()
     if not user_prompt:
-        return jsonify({'error': 'Missing "prompt" field'}), 400
+        raise IconGenerationError('Missing prompt', status=400)
 
-    name_slug = data.get('name', '').strip()
-    style = data.get('style', '').strip()
+    name_slug = (name or '').strip()
+    style = (style or '').strip()
 
     # Build the generation prompt
     # NOTE: NEVER say "transparent background" — AI models render checkerboard patterns
     # instead of real alpha. Use a solid chroma-key color that we remove in post-processing.
     # The green bg is ALWAYS appended regardless of custom style — background removal depends on it.
-    base_style = style or (
-        'Windows XP style icon, clean vector art, vibrant colors, slight 3D shading'
-    )
+    base_style = style or DEFAULT_ICON_STYLE
     # Strip any "transparent" from custom styles — it causes checkerboard
     base_style = base_style.replace('transparent background', 'solid background')
     style_instruction = f'{base_style}, solid bright green (#00FF00) background'
@@ -255,7 +263,7 @@ def generate_icon():
         resp.raise_for_status()
         result = resp.json()
     except requests.RequestException as e:
-        return jsonify({'error': f'Gemini API error: {str(e)}'}), 502
+        raise IconGenerationError(f'Gemini API error: {str(e)}', status=502)
 
     # Extract image from response
     image_data = None
@@ -273,10 +281,7 @@ def generate_icon():
         pass
 
     if not image_data:
-        return jsonify({
-            'error': 'Gemini did not return an image',
-            'raw': result.get('candidates', [{}])[0].get('content', {}).get('parts', []),
-        }), 502
+        raise IconGenerationError('Gemini did not return an image', status=502)
 
     # Remove background → real PNG alpha transparency
     # Save original as backup first, then process
@@ -312,15 +317,38 @@ def generate_icon():
         'mime': mime_type,
     }, indent=2))
 
-    url = f'/api/icons/generated/{filename}'
-
-    return jsonify({
-        'url': url,
+    return {
+        'url': f'/api/icons/generated/{filename}',
         'name': safe_name,
         'filename': filename,
         'prompt': user_prompt,
         'size': len(image_data),
-    })
+    }
+
+
+@icons_bp.route('/api/icons/generate', methods=['POST'])
+def generate_icon():
+    """
+    Generate a custom icon via Gemini image generation.
+
+    POST body:
+      { "prompt": "description of icon",
+        "name": "optional-filename-slug",
+        "style": "optional style override" }
+
+    Returns:
+      { "url": "/api/icons/generated/my-icon.png",
+        "name": "my-icon",
+        "prompt": "..." }
+    """
+    data = request.get_json(silent=True) or {}
+    try:
+        result = generate_icon_image(
+            data.get('prompt', ''), name=data.get('name', ''), style=data.get('style', ''),
+        )
+    except IconGenerationError as e:
+        return jsonify({'error': str(e)}), e.status
+    return jsonify(result)
 
 
 # ══════════════════════════════════════════════════════════════

--- a/src/app.js
+++ b/src/app.js
@@ -7486,7 +7486,7 @@ ${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
                             await window.CanvasMenu?.loadManifest?.();
                         } catch {}
                         const pageId = saveRes.page_id || saveRes.filename.replace(/\.html$/, '');
-                        window.CanvasControl?.showPage?.(pageId);
+                        window.CanvasControl?.showPageById?.(pageId);
                     }
                 } catch (e) {
                     console.error('[openEmbedCanvasPage] save failed:', e);
@@ -7567,8 +7567,9 @@ ${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
                             }
                             break;
                         case 'navigate':
-                            // Navigate to another canvas page
-                            if (page) CanvasControl.showPage(page);
+                            // Navigate to another canvas page. The desktop
+                            // sends exact page ids here — never fuzzy match.
+                            if (page) CanvasControl.showPageById(page);
                             break;
                         case 'open-url':
                             // Load external URL in the iframe
@@ -7751,14 +7752,39 @@ ${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
                 this.openPage('desktop.html');
             },
 
-            showPage(pageName) {
-                // Fuzzy-find page by name using CanvasMenu's lookup
+            showPageById(pageId) {
+                // Exact match ONLY — no fuzzy scoring. Used by the desktop's
+                // postMessage navigation and any other caller that already
+                // knows the precise page id/filename stem (never voice input).
+                if (!pageId) return;
+                const menu = window.CanvasMenu;
+                const filename = pageId.endsWith('.html') ? pageId : pageId + '.html';
+                const stem = filename.replace(/\.html$/, '');
+                if (menu?.manifest?.pages?.[stem]) {
+                    console.log('[Canvas] showPageById exact:', stem);
+                    menu.showPage(menu.manifest.pages[stem].filename);
+                    return;
+                }
+                // Manifest doesn't have it (not synced yet, or a raw filename
+                // stem) — direct-load by filename. Still exact, no fuzzy fallback.
+                console.log('[Canvas] showPageById direct:', filename);
+                if (this.iframe) {
+                    this.iframe.src = `/pages/${filename}?t=${Date.now()}`;
+                    localStorage.setItem('canvas_last_page', filename);
+                    this._lastMtime = null;
+                    this.show();
+                }
+            },
+
+            showPageByName(pageName) {
+                // Fuzzy-find page by name — for voice commands and agent
+                // [CANVAS:pagename] tags where the exact id isn't known.
                 if (!pageName) return;
                 const menu = window.CanvasMenu;
                 if (!menu?.manifest) {
                     // Manifest not loaded yet — try direct filename
                     const filename = pageName.replace(/\s+/g, '-').toLowerCase() + '.html';
-                    console.log('[Canvas] showPage direct:', filename);
+                    console.log('[Canvas] showPageByName direct:', filename);
                     if (this.iframe) {
                         this.iframe.src = `/pages/${filename}?t=${Date.now()}`;
                         localStorage.setItem('canvas_last_page', filename);
@@ -7769,12 +7795,12 @@ ${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
                 }
                 const match = menu.findPageByName(pageName);
                 if (match) {
-                    console.log('[Canvas] showPage matched:', match.page.display_name);
+                    console.log('[Canvas] showPageByName matched:', match.page.display_name);
                     menu.showPage(match.page.filename);
                 } else {
                     // Fallback: try as-is with .html
                     const filename = pageName.replace(/\s+/g, '-').toLowerCase() + '.html';
-                    console.log('[Canvas] showPage fallback:', filename);
+                    console.log('[Canvas] showPageByName fallback:', filename);
                     if (this.iframe) {
                         this.iframe.src = `/pages/${filename}?t=${Date.now()}`;
                         localStorage.setItem('canvas_last_page', filename);
@@ -7782,6 +7808,12 @@ ${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
                         this.show();
                     }
                 }
+            },
+
+            showPage(pageName) {
+                // Back-compat alias — fuzzy match (voice/agent-tag callers).
+                // Programmatic exact-id callers should use showPageById().
+                this.showPageByName(pageName);
             },
 
             async updateDisplay(type, path, title) {
@@ -8517,6 +8549,11 @@ ${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
                     }
                 }
 
+                // Reject weak matches — a bare single-word substring hit
+                // (score ~53) used to be enough to win and open the wrong
+                // page. Require at least a solid partial-name/alias match.
+                const MIN_MATCH_SCORE = 70;
+                if (bestMatch && bestMatch.score < MIN_MATCH_SCORE) return null;
                 return bestMatch;
             },
 


### PR DESCRIPTION
## Summary
- Critical bug fixes on the desktop canvas: icon listener churn (event delegation), fetchManifest/saveState race (dirty-state guard), titlebar button duplication, postMessage wildcard origin, JS/CSS mobile breakpoint mismatch (aligned to 480/768/1024)
- Fixed desktop icons occasionally opening the wrong page: split canvas navigation into `showPageById` (exact, used by desktop/programmatic callers) vs `showPageByName` (fuzzy, voice/agent-tag only) + minimum match score of 70
- Start Menu category rows now expand a real nested flyout of their pages (reusing the existing `.ctx-submenu` hover pattern), with "Open Folder..." still available for the full grid view
- `routes/canvas.py` sync now auto-generates a Gemini icon in the background for any page still missing one after HTML-meta extraction (6h backoff on failure) — previously icon generation only happened if the building agent remembered to follow the icon-generation skill; nothing enforced it
- Default generated-icon style switched from Windows XP to modern 3D glassmorphic (macOS/visionOS look)
- Added `image`/`video`/`pdf`/`archive` icon types + extension-based detection in `getPageIconType`, fixed `video` incorrectly mapping to the folder icon

## Test plan
- [x] Static syntax/brace-balance verification on desktop.html and app.js (no node runtime available on this host)
- [x] `python3 -m py_compile` on routes/canvas.py and routes/icons.py
- [ ] Build `jambot/openvoiceui:latest` and deploy to test-dev only, then verify end-to-end (drag persistence, window titlebars per theme, Start Menu flyouts per theme, auto icon-gen firing, file-type icons) before any fleet roll