### PR TITLE
fix(desktop): flyout z-index, real recent-pages tracking, icon-gen concurrency storm

### DIFF
--- a/default-pages/desktop.html
+++ b/default-pages/desktop.html
@@ -882,6 +882,7 @@ let knownPages = [];       // all page IDs we've ever seen
 let _manifestTimer = null;
 let wallpaperUrl = null;   // server URL of custom desktop wallpaper
 let savedPageCategories = {}; // { pageId: catId } — persists drag-to-folder assignments across fetchManifest cycles
+let recentPages = []; // most-recently-opened page ids, newest first — Start Menu shows the last 2
 
 // Breakpoint helpers
 function getBreakpoint() {
@@ -910,7 +911,7 @@ function _doSaveState() {
   // Always save full state to master desktop entry (iconPositions = desktop positions)
   const state = JSON.stringify({
     theme: currentTheme, iconPositions, recycleBin,
-    customFolders, desktopPages, knownPages, wallpaperUrl, savedPageCategories,
+    customFolders, desktopPages, knownPages, wallpaperUrl, savedPageCategories, recentPages,
   });
   const saves = [
     fetch('/api/canvas/manifest/page/desktop', {
@@ -958,6 +959,7 @@ async function loadState() {
           if (state.knownPages) knownPages = state.knownPages;
           if (state.wallpaperUrl) { wallpaperUrl = state.wallpaperUrl; applyWallpaper(wallpaperUrl); }
           if (state.savedPageCategories) savedPageCategories = state.savedPageCategories;
+          if (state.recentPages) recentPages = state.recentPages;
         }
       } catch(e) {}
     }
@@ -2218,6 +2220,12 @@ function showStartCategoryFlyout(anchorEl, catId) {
   el.className = 'ctx-submenu sm-flyout';
   el.style.display = 'block';
   el.style.position = 'absolute';
+  // .ctx-submenu's base rule has no z-index of its own — it normally relies
+  // on being DOM-nested inside #context-menu (z-index:10000). This flyout is
+  // appended to #app as a SIBLING of #start-menu instead (see comment above),
+  // so it needs an explicit z-index above #start-menu's 9500 or it renders
+  // behind the menu it's supposed to expand out of.
+  el.style.zIndex = '9600';
 
   let html = '';
   if (!pages.length) {
@@ -2313,12 +2321,13 @@ function buildStartMenu() {
 
   html += '<div class="sm-body">';
   html += '<div class="sm-left">';
-  // Recent/pinned pages
-  const pinned = ['bored-arcade','civ-sim','music-library','wolf3d-engine','office-hub'];
-  pinned.forEach(pid => {
+  // Recently opened pages — real usage (see openCanvasPage), filtered against
+  // both PAGES (still exists) AND recycleBin (not trashed) so a recycled page
+  // can't keep showing up here just because the manifest hasn't purged it yet.
+  const recent = recentPages.filter(pid => PAGES[pid] && !recycleBin.includes(pid)).slice(0, 2);
+  recent.forEach(pid => {
     const p = PAGES[pid];
-    if (!p) return;
-    html += `<div class="sm-item" onclick="openCanvasPage('${pid}');closeAllMenus()"><div class="sm-icon">${getIcon('document')}</div>${p.name}</div>`;
+    html += `<div class="sm-item" onclick="openCanvasPage('${pid}');closeAllMenus()"><div class="sm-icon">${getIcon(getPageIconType(p.cat, pid, p.name))}</div>${p.name}</div>`;
   });
   html += '<div class="sm-separator"></div>';
   // All Programs submenu - show categories, hover expands a flyout of pages in it
@@ -2708,6 +2717,12 @@ function refreshExplorers() {
    OPEN CANVAS PAGE
    ══════════════════════════════════════════════════════════════ */
 function openCanvasPage(pageId, newWindow) {
+  // Track for the Start Menu's recent-pages row — real usage, not a
+  // hardcoded shortlist (that list used to keep showing pages long after
+  // they'd been recycled, since it only checked PAGES[pid] existence and
+  // never checked recycleBin membership).
+  recentPages = [pageId, ...recentPages.filter(id => id !== pageId)].slice(0, 2);
+  saveState();
   if (newWindow) {
     window.open('/pages/' + pageId + '.html', '_blank');
     return;

--- a/routes/canvas.py
+++ b/routes/canvas.py
@@ -373,6 +373,7 @@ def sync_canvas_manifest() -> dict:
 # the route), so pages silently fell back to the generic document icon
 # whenever an agent skipped the step. This is the enforcement layer.
 _ICON_GEN_RETRY_COOLDOWN = 6 * 3600  # seconds — backoff after a failed attempt
+_icon_gen_lock = threading.Lock()  # single-flight guard — see _kick_off_pending_icon_generation
 
 
 def _kick_off_pending_icon_generation(manifest: dict) -> None:
@@ -380,8 +381,18 @@ def _kick_off_pending_icon_generation(manifest: dict) -> None:
     page still missing one. Must never run inline here — this function is
     called on every /api/canvas/manifest sync (throttled to 60s, but still a
     request path polled by every open desktop), and Gemini calls take
-    seconds. The thread generates sequentially, never concurrently, so a
-    tenant with many icon-less pages doesn't fire a burst of API calls."""
+    seconds.
+
+    Single-flight: _kick_off_pending_icon_generation is called on every sync,
+    and a large backlog takes many sync cycles (2s stagger per page) to work
+    through. Without this lock, each cycle spawned its OWN thread over the
+    SAME still-pending list — multiple overlapping threads generating the
+    same pages concurrently. That burst blew through Gemini's rate limit
+    (confirmed live: 429s across 139 pages) and none of them recovered until
+    their independent 6h cooldowns expired. Only one batch may run at a time,
+    fleet-wide within this process."""
+    if not _icon_gen_lock.acquire(blocking=False):
+        return  # a batch is already in flight — this sync cycle's backlog will be picked up next time
     now = time.time()
     pending = []
     for page_id, page_data in manifest.get('pages', {}).items():
@@ -392,12 +403,20 @@ def _kick_off_pending_icon_generation(manifest: dict) -> None:
             continue
         pending.append(page_id)
     if not pending:
+        _icon_gen_lock.release()
         return
     threading.Thread(target=_generate_pending_icons, args=(pending,), daemon=True).start()
 
 
 def _generate_pending_icons(page_ids) -> None:
     """Background-thread worker — see _kick_off_pending_icon_generation()."""
+    try:
+        _generate_pending_icons_inner(page_ids)
+    finally:
+        _icon_gen_lock.release()
+
+
+def _generate_pending_icons_inner(page_ids) -> None:
     from routes.icons import generate_icon_image, IconGenerationError
     logger = logging.getLogger(__name__)
     for i, page_id in enumerate(page_ids):


### PR DESCRIPTION
## Summary
- Start Menu category flyout rendered behind the Start Menu (no explicit z-index on the #app-level sibling element)
- Start Menu "recent" row was a hardcoded shortlist that didn't check recycleBin — replaced with real last-2-opened tracking
- Found and fixed a live bug in today's earlier icon auto-gen hook: no guard against overlapping background threads. Confirmed on test-dev: this burst-fired requests and got 139/140 pending pages 429-rate-limited by Gemini, stuck in a 6h cooldown. Added a single-flight lock.

## Test plan
- [x] py_compile + brace-balance checks
- [ ] Deploy to test-dev, visually confirm flyout renders above Start Menu, confirm recent-pages row reflects real usage, clear stale icon_gen_failed_at cooldowns and confirm generation resumes without re-triggering a 429 storm