### PR TITLE
fix(icons): distinguish rate-limited from broken in auto-gen retry logic

### DIFF
--- a/routes/canvas.py
+++ b/routes/canvas.py
@@ -419,9 +419,10 @@ def _generate_pending_icons(page_ids) -> None:
 def _generate_pending_icons_inner(page_ids) -> None:
     from routes.icons import generate_icon_image, IconGenerationError
     logger = logging.getLogger(__name__)
+    extra_backoff = 0  # seconds — grows on a 429, so the batch self-throttles instead of hammering a rate-limited API
     for i, page_id in enumerate(page_ids):
         if i > 0:
-            time.sleep(2)  # stagger Gemini calls
+            time.sleep(2 + extra_backoff)  # stagger Gemini calls
         try:
             with _manifest_lock:
                 manifest = load_canvas_manifest()
@@ -435,13 +436,21 @@ def _generate_pending_icons_inner(page_ids) -> None:
             prompt = f'A {category} icon for: {title}.' + (f' {description}' if description else '')
             try:
                 result = generate_icon_image(prompt, name=f'{page_id}-icon')
+                extra_backoff = 0  # reset once a call actually succeeds
             except IconGenerationError as e:
                 logger.warning(f'Auto icon-gen failed for {page_id}: {e}')
-                with _manifest_lock:
-                    manifest = load_canvas_manifest()
-                    if page_id in manifest['pages']:
-                        manifest['pages'][page_id]['icon_gen_failed_at'] = time.time()
-                        save_canvas_manifest(manifest)
+                is_rate_limited = '429' in str(e)
+                if is_rate_limited:
+                    # Rate-limited, not actually broken — don't stamp the long
+                    # cooldown (that would strand it for 6h over a transient
+                    # limit). Back off harder for the rest of THIS batch instead.
+                    extra_backoff = min(extra_backoff + 4, 20)
+                else:
+                    with _manifest_lock:
+                        manifest = load_canvas_manifest()
+                        if page_id in manifest['pages']:
+                            manifest['pages'][page_id]['icon_gen_failed_at'] = time.time()
+                            save_canvas_manifest(manifest)
                 continue
 
             with _manifest_lock:


### PR DESCRIPTION
## Summary
Live evidence on test-dev after the concurrency-storm fix (#356): the backlog started processing serially but most calls still hit Gemini's per-minute rate limit (429), separate from the account quota. Every 429 was stamped with the full 6h retry cooldown identically to a genuine failure, stranding otherwise-fine pages for hours.

- 429 no longer sets the long cooldown — stays eligible for the very next run
- In-batch adaptive backoff on consecutive 429s (+4s, capped at 20s, resets on success)
- Non-429 failures keep the original 6h cooldown (retrying those immediately wouldn't help)

## Test plan
- [x] py_compile check
- [ ] Deploy to test-dev, confirm backlog processes with a healthier success rate and no pages get needlessly stuck on 6h cooldowns from transient rate limits