### PR TITLE
fix(canvas-style): CANVAS_STYLE tag pointed at an OVU-internal path Hermes can't see

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1615,7 +1615,9 @@ def _conversation_inner():
             context_parts.append(
                 f'[CANVAS_STYLE: The user chose the "{_style_id}" design system for all '
                 f'canvas pages. BEFORE creating or restyling ANY canvas page you MUST '
-                f'read /app/runtime/canvas-pages/canvas-styles/ACTIVE-STYLE.md and start '
+                f'read canvas-styles/ACTIVE-STYLE.md inside your canvas-pages directory '
+                f'(OpenClaw: /app/runtime/canvas-pages/canvas-styles/ACTIVE-STYLE.md; '
+                f'Hermes: /workspace/canvas-pages/canvas-styles/ACTIVE-STYLE.md) and start '
                 f'by cp-ing canvas-styles/active-template.html to the new page file, then '
                 f'edit the copy (keep its full <style> block — never retype the template). '
                 f'Never use the old dark default. '


### PR DESCRIPTION
The per-turn `[CANVAS_STYLE:]` injection told agents to read `/app/runtime/canvas-pages/canvas-styles/ACTIVE-STYLE.md` — that path only exists inside the OVU container (and OpenClaw's mount view). The Hermes container sees the same file at `/workspace/canvas-pages/canvas-styles/ACTIVE-STYLE.md`, so hermes-gateway sessions reported 'No ACTIVE-STYLE.md' and improvised page styles instead of using the tenant's chosen design system.

The tag now names both container paths. Verified live on test-dev (hotfixed via docker cp + restart; hermes can read the file at the named path).