### PR TITLE
chore(deps): reconcile dev dependency bumps onto main + point dependabot at main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   # Python dependencies
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "dev"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -21,7 +21,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "dev"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -37,7 +37,7 @@ updates:
   # Docker (if using docker-compose.yml or Dockerfile)
   - package-ecosystem: "docker"
     directory: "/"
-    target-branch: "dev"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,7 +3,7 @@
 # Without it, those file types still upload successfully — the AI just can't read their contents.
 #
 # Install: pip install -r requirements-docs.txt
-pypdf>=6.13.0
+pypdf>=6.13.3
 python-docx>=1.2.0
 openpyxl>=3.1.5
 python-pptx>=1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Python 3.10+ required
 # Core framework
 Flask==3.1.3
-flask-cors==6.0.4
+flask-cors==6.0.5
 flask-limiter==4.1.1
 flask-sock==0.7.0
 
@@ -17,7 +17,7 @@ psutil==7.2.2
 
 # Image processing (icon generation, uploads)
 Pillow>=12.2.0
-pillow-heif>=1.3.0
+pillow-heif>=1.4.0
 PyYAML>=6.0.3
 
 # Speech-to-text (optional — adds ~200MB for onnxruntime + ctranslate2)
@@ -26,11 +26,11 @@ PyYAML>=6.0.3
 # faster-whisper==1.2.1
 
 # TTS providers
-groq==1.4.0                 # Groq Orpheus TTS (required if using groq provider)
+groq==1.5.0                 # Groq Orpheus TTS (required if using groq provider)
 
 # Auth (Clerk JWT — optional, only if CANVAS_REQUIRE_AUTH=true)
 PyJWT==2.13.0
-cryptography==48.0.0
+cryptography==49.0.0
 
 # Face recognition (optional — adds ~700MB for TensorFlow)
 # Installs on first use if not present. To pre-install:


### PR DESCRIPTION
Brings the 5 dependabot bumps merged into the stale `dev` branch (103 behind main, never promoted) onto `main` so they ship on the next roll: flask-cors 6.0.5, pillow-heif 1.4.0, groq 1.5.0, cryptography 49.0.0, pypdf 6.13.3.

Root cause: dependabot `target-branch: dev` while the fleet builds from `main` — every bump landed on a dead branch. Repointed all 3 ecosystems to main.