### PR TITLE
perf(desktop): reuse icon DOM across manifest polls (#235) — kill 30s rebuild stutter

### DIFF
--- a/default-pages/desktop.html
+++ b/default-pages/desktop.html
@@ -1221,7 +1221,14 @@ function getIconName(item) {
 function buildDesktopIcons() {
   const desktop = document.getElementById('desktop');
   bindDesktopIconListeners();
-  desktop.querySelectorAll('.desktop-icon').forEach(el => el.remove());
+  // Reconcile against existing icon nodes keyed by data-id instead of
+  // destroy-all-recreate — at 200+ pages a full rebuild every 30s manifest
+  // poll was a ~500ms stutter. Nodes are reused (safe: listeners are
+  // delegated to #desktop, never per-icon); only new ids get created and
+  // only vanished ids get removed.
+  const existingIcons = new Map();
+  desktop.querySelectorAll('.desktop-icon').forEach(el => existingIcons.set(el.dataset.id, el));
+  const presentIds = new Set();
   const isRightToLeft = currentTheme === 'mac';
   const container = document.getElementById('os-container');
   // ORIGINAL geometry, restored verbatim 2026-07-12 (Mike, 4th ask: NO resizing,
@@ -1247,11 +1254,7 @@ function buildDesktopIcons() {
     const x = saved ? saved.x : (isRightToLeft ? startX - col * cellW : startX + col * cellW);
     const y = saved ? saved.y : startY + row * cellH;
 
-    const el = document.createElement('div');
-    el.className = 'desktop-icon';
-    el.dataset.id = item.id;
-    el.style.left = x + 'px';
-    el.style.top = y + 'px';
+    presentIds.add(item.id);
 
     const recycleIcon = item.id === 'recycle-bin'
       ? (recycleBin.length > 0 ? 'recycle-full' : 'recycle')
@@ -1260,15 +1263,37 @@ function buildDesktopIcons() {
     const iconHtml = item.iconUrl
       ? `<img src="${item.iconUrl}" style="width:100%;height:100%;object-fit:contain;">`
       : getIcon(recycleIcon);
-    el.innerHTML = `<div class="icon-img">${iconHtml}</div><div class="icon-label">${getIconName(item)}</div>`;
-    desktop.appendChild(el);
+    const inner = `<div class="icon-img">${iconHtml}</div><div class="icon-label">${getIconName(item)}</div>`;
+
+    let el = existingIcons.get(item.id);
+    if (el) {
+      // Reuse the node in place. Compare innerHTML against the string we last
+      // set (cached expando) — reading el.innerHTML back can differ from the
+      // authored string after browser serialization, which would force a
+      // rewrite every poll.
+      if (el.style.left !== x + 'px') el.style.left = x + 'px';
+      if (el.style.top !== y + 'px') el.style.top = y + 'px';
+      if (el._ovuInner !== inner) { el.innerHTML = inner; el._ovuInner = inner; }
+    } else {
+      el = document.createElement('div');
+      el.className = 'desktop-icon';
+      el.dataset.id = item.id;
+      el.style.left = x + 'px';
+      el.style.top = y + 'px';
+      el.innerHTML = inner;
+      el._ovuInner = inner;
+      desktop.appendChild(el);
+    }
   });
+  // Remove only icons whose id is no longer present (recycled/deleted pages)
+  existingIcons.forEach((el, id) => { if (!presentIds.has(id)) el.remove(); });
   _lastDesktopH = getDesktopHeight(); // keep the resize-handler height baseline in sync after any rebuild
 }
 
 // Delegated icon listeners — attached once to #desktop, never re-attached on
-// rebuild. buildDesktopIcons() destroys/recreates icon DOM every manifest
-// poll; per-icon listeners would otherwise be re-registered every cycle.
+// rebuild. buildDesktopIcons() reuses icon nodes across manifest polls (and
+// may still create/remove individual nodes); delegation keeps that safe with
+// no per-icon listener bookkeeping.
 let _desktopIconListenersBound = false;
 function bindDesktopIconListeners() {
   if (_desktopIconListenersBound) return;


### PR DESCRIPTION
## Summary
- `buildDesktopIcons()` destroyed and recreated every `.desktop-icon` node on each 30s `fetchManifest()` poll — a ~500ms UI stutter at 200+ pages. It now reconciles against the existing nodes keyed by `data-id`.
- Reused nodes get `style.left`/`style.top` updated only when the computed x/y changed, and `innerHTML` (icon art + label) rewritten only when it changed (compared against a cached copy of the last-set string, since reading `innerHTML` back can differ after browser serialization). New ids are created exactly as before; ids no longer present have just their node removed.
- The layout math is byte-for-byte untouched (`isSmall`, `startX`/`startY`, `colH`, `cellW`/`cellH`, `maxPerCol`, the mac right-to-left branch, `col`/`row`, saved-position lookup) — only the create/destroy mechanism changed. The "ORIGINAL geometry, restored verbatim 2026-07-12" block is preserved verbatim.
- `bindDesktopIconListeners()` is untouched; reuse is safe because listeners are delegated to `#desktop`, never per-icon. Only its (now stale) descriptive comment was updated.
- Part B (server ETag/caching) deliberately excluded — collides with the canvas no-cache rule.

## Verification (live on test-dev, headless Chromium via Playwright against `openvoiceui-test-dev`)
1. **Pixel positions identical** — captured all 55 icon positions before/after the change at desktop width (1280px), narrow width (420px, `<500` branch), and with the mac theme (right-to-left column) at both widths: **byte-identical `style.left`/`style.top` for every icon in all four modes**, zero drift.
2. **Interactions intact** — drag moves an icon and drag-back restores its exact original position (`370px,214px → 530px,374px → 370px,214px`); double-click on a page icon posts the `{action:'navigate'}` canvas message; dragging a page icon onto the recycle bin removes it from the desktop and adds it to `recycleBin`, with the bin's node updated **in place** (same DOM reference).
3. **Nodes are actually reused** — tagged all 55 icon nodes with a marker attribute, ran `fetchManifest(true)` three times: all 55 nodes survived with markers intact (zero recreations). A newly-appearing item id gets a fresh icon; a removed id has only its node pruned; other 55 nodes untouched in both cases.
4. **No duplicates, no orphans** — icon count and unique `data-id` count stayed at 55 across all poll cycles.

Test drag/recycle mutations never persisted (state-write APIs require an authed session the headless browser didn't have); the server-side desktop state blob was confirmed byte-identical to its pre-test snapshot.

Deployed to the `openvoiceui-test-dev` container only (bind-mounted `canvas-pages/desktop.html`, prior copy kept as `desktop.html.pre-domreuse-20260713.bak`) for live review — no image rebuild, no other tenant touched.

refs #235