### PR TITLE
feat(suno): custom-voice/persona passthrough + edit models to V5_5

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,6 @@
 </head>
 <body>
     <!-- App entry point: injects DOM shell + initializes all modules -->
-    <script type="module" src="src/app.js?v=28"></script>
+    <script type="module" src="src/app.js?v=29"></script>
 </body>
 </html>

--- a/routes/suno.py
+++ b/routes/suno.py
@@ -410,6 +410,12 @@ def _action_generate(_q, body: dict):
     lyrics = _q('lyrics') or body.get('lyrics', '')
     instrumental = (_q('instrumental') or str(body.get('instrumental', 'false'))).lower() == 'true'
     vocal_gender = _q('vocal_gender') or body.get('vocal_gender', 'm')
+    # Persona / custom-voice passthrough (2026-07-14). personaId can be a STYLE
+    # persona (from generate-persona) or a cloned VOICE id (from the Suno Voice
+    # API). personaModel: 'style_persona' (default) or 'voice_persona' (a cloned
+    # voice — REQUIRES custom mode, i.e. lyrics). Accept snake_case or camelCase.
+    persona_id = (_q('persona_id') or body.get('persona_id') or body.get('personaId') or '').strip()
+    persona_model = (_q('persona_model') or body.get('persona_model') or body.get('personaModel') or '').strip()
 
     if not prompt and not lyrics and not style:
         return jsonify({'action': 'error', 'response': 'Need a prompt, lyrics, or style — tell me what kind of song to make.'})
@@ -448,6 +454,16 @@ def _action_generate(_q, body: dict):
             'model': 'V5_5',
             'vocalGender': vocal_gender,
         }
+
+    # Attach persona / cloned-voice if provided. voice_persona only works in
+    # custom mode — if a cloned voice was requested in description mode, promote
+    # to custom mode (song_prompt then acts as the lyrics) so the voiceId is honored.
+    if persona_id:
+        request_body['personaId'] = persona_id
+        request_body['personaModel'] = persona_model or 'style_persona'
+        if request_body['personaModel'] == 'voice_persona' and not request_body.get('customMode'):
+            request_body['customMode'] = True
+        logger.info(f'Suno generate: persona {request_body["personaModel"]} id={persona_id[:12]}…')
 
     if SUNO_CALLBACK_URL:
         request_body['callBackUrl'] = SUNO_CALLBACK_URL
@@ -1143,7 +1159,7 @@ def _action_extend(_q, body: dict):
     prompt = (_q('prompt') or body.get('prompt', '')).strip()
     style = (_q('style') or body.get('style', '')).strip() or src['style'] or 'Same style as original'
     title = (_q('title') or body.get('title', '')).strip() or src['title'] or 'Extended Track'
-    model = (_q('model') or body.get('model', '')).strip() or 'V5'
+    model = (_q('model') or body.get('model', '')).strip() or 'V5_5'
 
     continue_at_raw = _q('continue_at') or body.get('continue_at', '')
     request_body = {
@@ -1183,7 +1199,7 @@ def _action_cover(_q, body: dict):
     prompt = (_q('prompt') or body.get('prompt', '')).strip()
     style = (_q('style') or body.get('style', '')).strip()
     title = (_q('title') or body.get('title', '')).strip() or (f"{src['title']} (Cover)" if src['title'] else 'Cover')
-    model = (_q('model') or body.get('model', '')).strip() or 'V5'
+    model = (_q('model') or body.get('model', '')).strip() or 'V5_5'
     instrumental_raw = _q('instrumental') or body.get('instrumental', False)
     instrumental = instrumental_raw if isinstance(instrumental_raw, bool) else str(instrumental_raw).lower() in ('true', '1', 'yes')
 
@@ -1222,7 +1238,7 @@ def _action_add_vocals(_q, body: dict):
         return jsonify({'action': 'error', 'response': 'Describe the vocals/lyrics to add (prompt is required).'})
     style = (_q('style') or body.get('style', '')).strip() or src['style'] or 'Pop'
     title = (_q('title') or body.get('title', '')).strip() or (f"{src['title']} (Vocals)" if src['title'] else 'Vocal Version')
-    model = (_q('model') or body.get('model', '')).strip() or 'V5'
+    model = (_q('model') or body.get('model', '')).strip() or 'V5_5'
     vocal_gender = (_q('vocal_gender') or body.get('vocal_gender', '')).strip().lower()
 
     request_body = {
@@ -1253,7 +1269,7 @@ def _action_add_instrumental(_q, body: dict):
 
     tags = (_q('tags') or body.get('tags', '')).strip() or (_q('style') or body.get('style', '')).strip() or src['style'] or 'instrumental backing'
     title = (_q('title') or body.get('title', '')).strip() or (f"{src['title']} (Instrumental)" if src['title'] else 'Instrumental Version')
-    model = (_q('model') or body.get('model', '')).strip() or 'V5'
+    model = (_q('model') or body.get('model', '')).strip() or 'V5_5'
 
     request_body = {
         'uploadUrl': src['upload_url'],

--- a/routes/suno.py
+++ b/routes/suno.py
@@ -416,6 +416,27 @@ def _action_generate(_q, body: dict):
     # voice — REQUIRES custom mode, i.e. lyrics). Accept snake_case or camelCase.
     persona_id = (_q('persona_id') or body.get('persona_id') or body.get('personaId') or '').strip()
     persona_model = (_q('persona_model') or body.get('persona_model') or body.get('personaModel') or '').strip()
+    # Voice-track flag: the frontend [SUNO_GENERATE:...|voice] tag (or voice=1)
+    # asks to sing in THIS tenant's cloned voice. The voiceId lives server-side
+    # in the active profile (voice_persona_id) so the browser never handles it —
+    # we attach it here. This lets a voice track ride the normal frontend popup /
+    # player / "your track is ready" flow instead of a bare direct API call.
+    use_voice = str(_q('voice') or body.get('voice', '')).lower() in ('1', 'true', 'yes')
+    if use_voice and not persona_id:
+        try:
+            import json as _jv
+            from routes.profiles import _active_profile_id as _apid
+            _pf = f'/app/runtime/profiles/{_apid}.json'
+            if os.path.exists(_pf):
+                _pc = _jv.load(open(_pf))
+                _vpid = (_pc.get('voice_persona_id')
+                         or (_pc.get('conversation') or {}).get('voice_persona_id') or '').strip()
+                if _vpid:
+                    persona_id = _vpid
+                    persona_model = 'voice_persona'
+                    logger.info(f'Suno generate: voice flag → profile {_apid} voiceId {_vpid[:12]}…')
+        except Exception as _ve:
+            logger.warning(f'Suno voice-flag profile lookup failed: {_ve}')
 
     if not prompt and not lyrics and not style:
         return jsonify({'action': 'error', 'response': 'Need a prompt, lyrics, or style — tell me what kind of song to make.'})
@@ -423,6 +444,13 @@ def _action_generate(_q, body: dict):
     # Determine mode: custom (explicit lyrics) vs description (Suno writes lyrics)
     if lyrics:
         song_prompt = lyrics
+        has_lyrics = True
+    elif (use_voice or persona_model == 'voice_persona') and prompt:
+        # Voice track: the prompt IS the lyrics to sing in the cloned voice — go
+        # straight to custom mode (do NOT munge it into a description). Lets the
+        # frontend tag pass plain-line lyrics (structural [Verse] tags can't ride
+        # the [SUNO_GENERATE:...] tag — bracket collision — so plain lines only).
+        song_prompt = prompt
         has_lyrics = True
     elif '[Verse' in prompt or '[Chorus' in prompt or '[Hook' in prompt or '[Bridge' in prompt:
         song_prompt = prompt

--- a/src/app.js
+++ b/src/app.js
@@ -1897,16 +1897,20 @@ connectAiradio();
                 console.log('[Suno] Generating:', prompt);
                 this._showStatus('🎵 Suno: submitting song request...');
 
-                // Parse optional fields from prompt: "prompt | style:hip hop | title:My Song"
+                // Parse optional fields from prompt: "prompt | style:hip hop | title:My Song | voice"
+                // The bare "voice" flag = sing in this tenant's cloned voice (the server
+                // attaches the active profile's voiceId). Rides the normal popup/player flow.
                 let actualPrompt = prompt;
                 let style = '';
                 let title = '';
+                let useVoice = false;
                 const parts = prompt.split('|').map(s => s.trim());
                 if (parts.length > 1) {
                     actualPrompt = parts[0];
                     for (const part of parts.slice(1)) {
                         if (part.toLowerCase().startsWith('style:')) style = part.slice(6).trim();
                         else if (part.toLowerCase().startsWith('title:')) title = part.slice(6).trim();
+                        else if (part.toLowerCase() === 'voice' || part.toLowerCase() === 'myvoice') useVoice = true;
                     }
                 }
 
@@ -1914,6 +1918,7 @@ connectAiradio();
                     const params = new URLSearchParams({ action: 'generate', prompt: actualPrompt });
                     if (style) params.set('style', style);
                     if (title) params.set('title', title);
+                    if (useVoice) params.set('voice', '1');
 
                     const resp = await fetch(`${CONFIG.serverUrl}/api/suno?${params}`);
                     const data = await resp.json();


### PR DESCRIPTION
Part of the 2026-07-14 Suno refresh (skill/reference/baseline already updated under skills/suno-music/).

- **generate** now accepts `persona_id`+`persona_model` → passes through as `personaId`/`personaModel`. `voice_persona` (a cloned voice) auto-promotes to customMode so the voiceId is honored. Unlocks Suno **custom voices** + style personas for all voice agents.
- Edit endpoints (extend/cover/add_vocals/add_instrumental) default model **V5 → V5_5**. Songs already V5_5; **jingles stay V5** (short-form); **sounds stays V5_5** (deliberate, proven better than docs' V5-only enum).
- Baseline of prior defaults frozen at `skills/suno-music/BASELINE-2026-07-14-pre-update.md` for revert.

**Proven live on bhb:** Kyle's cloned voiceId rendered a real track in his voice (kyle-voice-test-2.mp3, 330K, HTTP 200). Follow-up (separate PR): full multi-stem split, generate-persona, the Suno Voice cloning flow, and the File Upload API wrapper.