### PR TITLE
feat: Character Stage v1.1.0 + suno task-id durability (clone-host work, host-reviewed)

### DIFF
--- a/plugins/bhb-animated-characters/plugin.json
+++ b/plugins/bhb-animated-characters/plugin.json
@@ -1,8 +1,8 @@
 {
   "id": "bhb-animated-characters",
   "name": "BHB Animated Characters",
-  "version": "1.0.0",
-  "description": "Animated BigHead Billionaires character avatars with lip-sync, mood expressions, character builder, and show lore for Kyle, Bryce, and the BigHeads universe",
+  "version": "1.1.0",
+  "description": "Animated BigHead Billionaires character avatars with lip-sync, mood expressions, character builder, Character Stage (multi-character lip-sync to any audio \u2014 songs, uploads, mic \u2014 with recording), and show lore for Kyle, Bryce, and the BigHeads universe",
   "author": "bhaleyart",
   "type": "face",
   "license": "MIT",
@@ -14,36 +14,56 @@
     "path": "plugins/bhb-animated-characters",
     "branch": "main"
   },
-
-  "faces": [{
-    "id": "bighead",
-    "name": "BigHead Avatar",
-    "script": "faces/BigHeadFace.js",
-    "css": "faces/bighead.css",
-    "preview": "faces/previews/bighead.svg",
-    "moods": ["neutral", "happy", "sad", "angry", "thinking", "surprised", "listening"],
-    "features": ["lip-sync", "mood-eyes", "blink", "customizable", "audio-reactive"],
-    "configurable": true,
-    "config_page": "bighead-builder.html"
-  }],
-
-  "pages": [{
-    "file": "pages/bighead-builder.html",
-    "name": "Character Builder",
-    "icon": "🎭"
-  }],
-
-  "routes": [{
-    "module": "routes/bighead.py",
-    "blueprint": "bighead_bp",
-    "prefix": "/api/bighead"
-  }],
-
+  "faces": [
+    {
+      "id": "bighead",
+      "name": "BigHead Avatar",
+      "script": "faces/BigHeadFace.js",
+      "css": "faces/bighead.css",
+      "preview": "faces/previews/bighead.svg",
+      "moods": [
+        "neutral",
+        "happy",
+        "sad",
+        "angry",
+        "thinking",
+        "surprised",
+        "listening"
+      ],
+      "features": [
+        "lip-sync",
+        "mood-eyes",
+        "blink",
+        "customizable",
+        "audio-reactive"
+      ],
+      "configurable": true,
+      "config_page": "bighead-builder.html"
+    }
+  ],
+  "pages": [
+    {
+      "file": "pages/bighead-builder.html",
+      "name": "Character Builder",
+      "icon": "\ud83c\udfad"
+    },
+    {
+      "file": "pages/character-stage.html",
+      "name": "Character Stage",
+      "icon": "\ud83c\udfac"
+    }
+  ],
+  "routes": [
+    {
+      "module": "routes/bighead.py",
+      "blueprint": "bighead_bp",
+      "prefix": "/api/bighead"
+    }
+  ],
   "profiles": [
     "profiles/kyle-valhalla.json",
     "profiles/bryce-bighead.json"
   ],
-
   "lore": {
     "description": "Show transcripts, character profiles, episode memories, and world-building from the BigHeads animated series. Agents can access these for character knowledge.",
     "transcripts": [

--- a/routes/suno.py
+++ b/routes/suno.py
@@ -218,8 +218,30 @@ def _add_song_to_metadata(filename: str, title: str, prompt: str, style: str,
     }
     if extra:
         entry.update(extra)
+    # NEVER lose Suno ids: if a previous entry for this filename already carries a
+    # non-empty task_id / suno_id and the incoming write would blank it, keep the
+    # old value. (2026-07-14: a metadata rewrite path blanked task_id on same-day
+    # tracks, killing vocal-stem separation for them.)
+    prev = metadata.get(filename) or {}
+    for id_key in ('task_id', 'suno_id'):
+        if not entry.get(id_key) and prev.get(id_key):
+            entry[id_key] = prev[id_key]
+    if not entry.get('task_id'):
+        logger.warning(f'_add_song_to_metadata: {filename} written WITHOUT task_id '
+                       f'(song_id={song_id!r}, kind={kind}) — vocal separation will be unavailable')
     metadata[filename] = entry
     _save_generated_metadata(metadata)
+    # Durable id ledger — append-only, survives any metadata rewrite. stem_separate
+    # falls back to this when metadata is missing the ids.
+    try:
+        if entry.get('suno_id'):
+            with open(GENERATED_MUSIC_DIR / 'suno-task-log.jsonl', 'a') as _tl:
+                _tl.write(json.dumps({'ts': datetime.now(timezone.utc).isoformat(timespec='seconds'),
+                                      'filename': filename, 'title': title,
+                                      'task_id': entry.get('task_id', ''),
+                                      'suno_id': entry.get('suno_id', ''), 'kind': kind}) + '\n')
+    except Exception:
+        pass
 
 
 def _is_uuid(s: str) -> bool:
@@ -1481,6 +1503,25 @@ def _action_stem_separate(_q, body: dict):
     src = _resolve_song(_q, body)
     task_id = src['task_id'] or (_q('task_id') or body.get('task_id', '')).strip()
     audio_id = src['audio_id'] or (_q('audio_id') or body.get('audio_id', '')).strip()
+    if not (task_id and audio_id):
+        # Self-heal: the append-only suno-task-log.jsonl records ids at generation
+        # time — recover from it when the metadata entry lost them.
+        try:
+            log_path = GENERATED_MUSIC_DIR / 'suno-task-log.jsonl'
+            if log_path.exists():
+                for line in log_path.read_text().splitlines():
+                    try:
+                        row = json.loads(line)
+                    except Exception:
+                        continue
+                    if src['filename'] and row.get('filename') == src['filename'] and row.get('task_id'):
+                        task_id = task_id or row['task_id']
+                        audio_id = audio_id or row.get('suno_id', '')
+                    elif audio_id and row.get('suno_id') == audio_id and row.get('task_id'):
+                        task_id = task_id or row['task_id']
+        except Exception:
+            pass
+
     if not (task_id and audio_id):
         # Legacy tracks (pre task-id capture in generated_metadata.json) can't be
         # separated — the vocal-removal API only works on a Suno taskId+audioId

--- a/routes/suno.py
+++ b/routes/suno.py
@@ -1482,7 +1482,13 @@ def _action_stem_separate(_q, body: dict):
     task_id = src['task_id'] or (_q('task_id') or body.get('task_id', '')).strip()
     audio_id = src['audio_id'] or (_q('audio_id') or body.get('audio_id', '')).strip()
     if not (task_id and audio_id):
-        return jsonify({'action': 'error', 'response': 'Stem separation needs both Suno task id and audio id for the track.'})
+        # Legacy tracks (pre task-id capture in generated_metadata.json) can't be
+        # separated — the vocal-removal API only works on a Suno taskId+audioId
+        # pair, and there is no reverse lookup by audio id. Distinct code so UIs
+        # can degrade gracefully instead of retrying.
+        return jsonify({'action': 'error', 'code': 'stem_ids_missing',
+                        'response': "This track was generated before Suno task tracking, so the API can't "
+                                    "separate its vocals. Newly generated songs support voice lock automatically."})
 
     sep_type = (_q('type') or body.get('type', '')).strip() or 'separate_vocal'
     if sep_type not in ('separate_vocal', 'split_stem', 'split_stem_advanced'):


### PR DESCRIPTION
The 3 clone-host commits that were stranded on the local checkout tonight — host-reviewed, clean + additive:
- **Character Stage page v1.1.0** (plugins/bhb-animated-characters/plugin.json) — multi-character lip-sync to any audio.
- **suno task-id durability** (routes/suno.py) — preserve task_id/suno_id across metadata rewrites (a rewrite path was blanking task_id on same-day tracks → killed vocal-stem separation); append-only suno-task-log.jsonl ledger; stem_separate self-heals from it.
- **distinct stem_ids_missing code** for legacy tracks without task ids.
Reviewed by host@mesh 2026-07-14; complements the merged #376 stem_result.