### PR TITLE
fix(tts): restore Kyle character on tts-v4 — wrap tags + temperature styles

### DIFF
--- a/tts_providers/resemble_provider.py
+++ b/tts_providers/resemble_provider.py
@@ -425,6 +425,7 @@ class ResembleProvider(TTSProvider):
         sample_rate = kwargs.get('sample_rate', 24000)
         precision = kwargs.get('precision', 'PCM_16')
         exaggeration = kwargs.get('exaggeration')
+        temperature = kwargs.get('temperature')
 
         # Per-voice style presets — apply character-specific direction
         # when no explicit exaggeration/model is provided via kwargs.
@@ -432,26 +433,35 @@ class ResembleProvider(TTSProvider):
         style = voice_styles.get(voice_uuid, {})
         if exaggeration is None and 'exaggeration' in style:
             exaggeration = style['exaggeration']
+        if temperature is None and 'temperature' in style:
+            temperature = style['temperature']
         if not model and 'model' in style:
             model = style['model']
         prompt = style.get('prompt', '')
+        # Delivery wrapping tags applied around the whole reply, innermost-last
+        # (e.g. ["slow", "lower-pitch"] → <slow><lower-pitch>text</lower-pitch></slow>).
+        # tts-v4 (2026-07) dropped the prompt acting-direction attr; pacing/register now
+        # comes from these documented wrapping tags: slow/fast, lower-pitch/higher-pitch,
+        # soft/loud/whisper, sing-song. Verified: <slow> +16% duration on the Kyle clone.
+        wrap_tags = style.get('wrap', [])
 
-        # Documented correct format: exaggeration + prompt go as <speak> SSML attributes
-        # inside `data`. They are NOT top-level JSON fields.
-        # model: omit to auto-select chatterbox (base) for cloned voices — this gives
-        # richer emotion than chatterbox-turbo. sample_rate=24000 was working pre-June-3.
-        # NOTE 2026-06-04: Resemble cluster outage is causing 500s on SSML + no-model
-        # requests. When cluster recovers this format restores full Kyle character.
-        # Fast-fail (tts.py) means 500s now fall back to Groq in <1s, not 47s.
+        # exaggeration/temperature/prompt go as <speak> SSML attributes inside `data`.
+        # They are NOT top-level JSON fields (silently ignored there).
+        # model: omit to auto-select chatterbox (tts-v4) for cloned voices.
+        # prompt is inert on tts-v4 (kept for back-compat only — harmless).
         if not text.strip().startswith('<speak'):
+            for tag in reversed(wrap_tags):
+                text = f'<{tag}>{text}</{tag}>'
             attrs = []
             if exaggeration is not None:
                 attrs.append(f'exaggeration="{exaggeration}"')
+            if temperature is not None:
+                attrs.append(f'temperature="{temperature}"')
             if prompt:
                 escaped_prompt = prompt.replace('"', '&quot;')
                 attrs.append(f'prompt="{escaped_prompt}"')
-            if attrs:
-                text = f'<speak {" ".join(attrs)}>{text}</speak>'
+            if attrs or wrap_tags:
+                text = f'<speak {" ".join(attrs)}>{text}</speak>' if attrs else f'<speak>{text}</speak>'
 
         payload = {
             'voice_uuid': voice_uuid,

--- a/tts_providers/resemble_voice_styles.json
+++ b/tts_providers/resemble_voice_styles.json
@@ -1,7 +1,9 @@
 {
   "704cb696": {
-    "exaggeration": 0.6,
-    "prompt": "Speak with a deep low-pitched voice, slow stoner drawl, casual chill energy, amused tone like everything is funny, chuckle and laugh naturally when the text has heheh or hah or laughter"
+    "exaggeration": 0.5,
+    "temperature": 1.0,
+    "wrap": ["slow", "lower-pitch"],
+    "_note": "Kyle Valhalla post-tts-v4-rebuild (2026-07-14). Drawl comes from wrap tags + persona-level text shaping (ellipses/uh/[chuckle]); the old prompt attr is inert on tts-v4. A/B: test-dev /pages/kyle-voice-tuning.html"
   },
   "cabc1397": {
     "exaggeration": 0.7,


### PR DESCRIPTION
Resemble force-rebuilt custom clones onto Chatterbox tts-v4 (2026-07-14): timbre improved but the prompt acting-direction `<speak>` attr is now inert, killing Kyle's slow stoner drawl. tts-v4 replaces it with documented wrapping tags (`<slow>`, `<lower-pitch>`) and inline tags (`[pause]`, `[chuckle]`).

- `resemble_voice_styles.json` grows `wrap` (wrapping tags applied around each reply) and `temperature` per voice
- Kyle `704cb696`: exaggeration 0.5 (0.6 sped speech UP on v4), temperature 1.0, wrap `slow`+`lower-pitch` — verified +16% duration vs baseline on identical text
- Bryce `cabc1397` untouched (needs its own re-tune pass)
- A/B samples: test-dev `/pages/kyle-voice-tuning.html`; revert snapshot in MIKE-AI `docs/jambot/snapshots/kyle-voice-2026-07-14/`