### PR TITLE
security: fix F-5 (upload XSS), F-6 (OAuth CSRF), F-7 (auth fail-open)

### DIFF
--- a/app.py
+++ b/app.py
@@ -125,18 +125,39 @@ def create_app(config_override: dict = None):
         # Local / self-hosted installs (no CANVAS_REQUIRE_AUTH) keep the documented
         # open-access behaviour.
         if os.getenv('CANVAS_REQUIRE_AUTH', '').strip().lower() == 'true':
-            logger.error('CANVAS_REQUIRE_AUTH=true but no Clerk key — admin surface fail-closed')
+            logger.error('CANVAS_REQUIRE_AUTH=true but no Clerk key — FAILING CLOSED (all non-public routes)')
+
+            # F-7 (2026-07-15): fail CLOSED for the WHOLE app, not just admin. When a
+            # hosted tenant requires auth (CANVAS_REQUIRE_AUTH=true) but Clerk is
+            # unconfigured (missing/blank key — e.g. a broken .platform-keys.env mount),
+            # `require_auth` below is never registered, so PREVIOUSLY only /admin was
+            # blocked and every other protected route (voice/canvas/session RPC/vault)
+            # was served unauthenticated. Nobody can log in in this state anyway, so we
+            # deny every non-public path (deny-by-default) and serve only the minimal
+            # shell needed to render the login/error page + health probes. This is an
+            # emergency degraded posture; the real fix is restoring the Clerk key.
+            _UNCONF_PUBLIC_EXACT = {
+                '/', '/pi', '/health', '/health/live', '/health/ready',
+                '/favicon.ico', '/sw.js', '/manifest.json',
+                '/api/config', '/api/version', '/api/auth/check',
+            }
+            _UNCONF_PUBLIC_PREFIXES = ('/src/', '/static/', '/images/', '/plugins/')
 
             @app.before_request
-            def block_admin_unconfigured():
+            def fail_closed_unconfigured():
                 path = request.path
-                if (path == '/admin' or path.startswith('/admin/')
-                        or path == '/src/admin.html'
-                        or any(path.startswith(p) for p in _ADMIN_ONLY_PREFIXES)):
+                if path in _UNCONF_PUBLIC_EXACT:
+                    return
+                # /src/admin.html is the admin shell — never public even here
+                if path != '/src/admin.html' and any(path.startswith(p) for p in _UNCONF_PUBLIC_PREFIXES):
+                    return
+                # everything else is denied: JSON 401 for APIs, redirect to the login shell for pages
+                if path.startswith('/api/') or request.headers.get('X-Requested-With'):
                     return jsonify({
-                        'error': 'Admin surface disabled: auth required but Clerk is not configured',
-                        'code': 'admin_auth_unconfigured',
+                        'error': 'Auth required but Clerk is not configured — service unavailable',
+                        'code': 'auth_unconfigured',
                     }), 503
+                return redirect('/')
     else:
         # Routes that never require authentication:
         _PUBLIC_PREFIXES = (

--- a/routes/static_files.py
+++ b/routes/static_files.py
@@ -470,6 +470,23 @@ def serve_upload(filename):
     if not upload_path.exists():
         return jsonify({"error": "File not found"}), 404
     resp = send_file(upload_path)
+    # F-5 (2026-07-15): neutralize STORED XSS. Uploads are user/agent-supplied; an
+    # .html or .svg served with a rendering content-type executes in OUR origin and can
+    # steal the Clerk session. Serve only known-safe media types inline with their real
+    # mime; serve EVERYTHING else (html, svg, xml, js, ...) as a non-rendering
+    # text/plain attachment. Agent code-file uploads still store + download fine — they
+    # just never execute in-browser. nosniff + a locked-down CSP are belt-and-suspenders.
+    _ext = upload_path.suffix.lower()
+    _SAFE_INLINE = {
+        '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico', '.avif',
+        '.mp4', '.webm', '.ogg', '.mov', '.mp3', '.wav', '.m4a', '.pdf',
+    }
+    if _ext not in _SAFE_INLINE:
+        resp.headers['Content-Type'] = 'text/plain; charset=utf-8'
+        resp.headers['Content-Disposition'] = (
+            'attachment; filename="%s"' % Path(filename).name.replace('"', ''))
+    resp.headers['X-Content-Type-Options'] = 'nosniff'
+    resp.headers['Content-Security-Policy'] = "default-src 'none'; sandbox; frame-ancestors 'none'"
     resp.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
     resp.headers['Pragma'] = 'no-cache'
     resp.headers['Expires'] = '0'

--- a/routes/vault.py
+++ b/routes/vault.py
@@ -211,7 +211,7 @@ def oauth_callback(provider):
     This endpoint is hit by the OAuth provider after user consent.
     Returns HTML that closes the popup and notifies the parent window.
     """
-    from services.vault import exchange_oauth_code
+    from services.vault import exchange_oauth_code, verify_oauth_nonce
 
     code = request.args.get('code', '')
     state_raw = request.args.get('state', '{}')
@@ -233,6 +233,12 @@ def oauth_callback(provider):
 
     if not username:
         return _oauth_callback_html(False, 'Missing username in state')
+
+    # F-6 (2026-07-15): verify the single-use CSRF state nonce BEFORE exchanging the code.
+    # Without this an attacker could forge this callback and connect their own account
+    # into the victim's vault (OAuth login/connection CSRF).
+    if not verify_oauth_nonce(username, cred_id, state.get('nonce', '')):
+        return _oauth_callback_html(False, 'Invalid or expired OAuth state (CSRF check failed) — please retry the connection.')
 
     result = exchange_oauth_code(cred_id, code, username)
 

--- a/services/vault.py
+++ b/services/vault.py
@@ -1276,6 +1276,72 @@ def set_oauth_app(provider: str, client_id: str, client_secret: str, redirect_ur
     _write_json(_PLATFORM_OAUTH_PATH, apps)
 
 
+# ── F-6 (2026-07-15): OAuth CSRF state nonce ─────────────────────────────────────
+# The OAuth `state` param previously carried only {cred_id, username} — no unguessable,
+# session-bound token — so an attacker could forge the callback (login/connection CSRF,
+# e.g. connecting the attacker's account into the victim's vault). We now mint a random
+# nonce per authorize request, persist it server-side (per-user, 10-min TTL, single-use),
+# and require the callback's state.nonce to match before exchanging the code.
+_OAUTH_NONCE_TTL_SEC = 600
+
+
+def _oauth_nonce_path(username: str) -> Path:
+    return _vault_dir(username) / 'oauth-nonces.json'
+
+
+def _mint_oauth_nonce(username: str, cred_id: str) -> str:
+    import secrets
+    nonce = secrets.token_urlsafe(24)
+    p = _oauth_nonce_path(username)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        store = {}
+        if p.exists():
+            try:
+                store = json.loads(p.read_text())
+            except Exception:
+                store = {}
+        now = time.time()
+        # prune expired while we're here
+        store = {k: v for k, v in store.items()
+                 if isinstance(v, dict) and (now - v.get('ts', 0)) < _OAUTH_NONCE_TTL_SEC}
+        store[nonce] = {'cred_id': cred_id, 'ts': now}
+        tmp = p.with_suffix('.json.tmp')
+        tmp.write_text(json.dumps(store))
+        tmp.replace(p)
+    except Exception as e:
+        logger.warning(f'oauth nonce store failed for {username}: {e}')
+    return nonce
+
+
+def verify_oauth_nonce(username: str, cred_id: str, nonce: str) -> bool:
+    """Single-use, TTL-bound verification of an OAuth state nonce. Consumes on success."""
+    if not nonce:
+        return False
+    p = _oauth_nonce_path(username)
+    try:
+        if not p.exists():
+            return False
+        store = json.loads(p.read_text())
+    except Exception:
+        return False
+    entry = store.get(nonce)
+    ok = (isinstance(entry, dict)
+          and entry.get('cred_id') == cred_id
+          and (time.time() - entry.get('ts', 0)) < _OAUTH_NONCE_TTL_SEC)
+    # consume (single-use) regardless of ok, and prune expired
+    now = time.time()
+    store = {k: v for k, v in store.items()
+             if k != nonce and isinstance(v, dict) and (now - v.get('ts', 0)) < _OAUTH_NONCE_TTL_SEC}
+    try:
+        tmp = p.with_suffix('.json.tmp')
+        tmp.write_text(json.dumps(store))
+        tmp.replace(p)
+    except Exception:
+        pass
+    return ok
+
+
 def build_oauth_url(cred_id: str, username: str, domain: str) -> Optional[str]:
     """
     Build the OAuth authorization URL for a credential.
@@ -1304,7 +1370,12 @@ def build_oauth_url(cred_id: str, username: str, domain: str) -> Optional[str]:
         'redirect_uri': app_creds['redirect_uri'],
         'response_type': 'code',
         'scope': ' '.join(oauth_cfg.get('scopes', [])),
-        'state': json.dumps({'cred_id': cred_id, 'username': username}),
+        # F-6: state carries a single-use, server-persisted CSRF nonce verified on callback
+        'state': json.dumps({
+            'cred_id': cred_id,
+            'username': username,
+            'nonce': _mint_oauth_nonce(username, cred_id),
+        }),
     }
     # Extra params (e.g. access_type=offline for Google)
     params.update(oauth_cfg.get('extra_params', {}))


### PR DESCRIPTION
Three HIGH findings from the Fable security audit (deadline 2026-07-16 18:00Z), all fixed on this branch.

## F-7 — auth fail-open on missing Clerk config
`app.py` `require_auth` returned OPEN whenever `CLERK_PUBLISHABLE_KEY` was empty — even for hosted tenants with `CANVAS_REQUIRE_AUTH=true`. A tenant with a missing/blank key served the whole app (incl `/admin`, vault creds, session RPC) unauthenticated. Now fails **CLOSED** when auth is required but Clerk is unconfigured (public/exempt paths still allowed). Self-hosted open mode unchanged. Verified: `/admin` + `/api/vault` return denied (not 200) under misconfig.

## F-5 — /api/upload stored XSS
Uploads served from `/uploads/` with a rendering content-type let an `.html`/`.svg` execute in our origin and steal the Clerk session. The **serve** side now emits safe media types inline; everything else → `text/plain` + `Content-Disposition: attachment` + `nosniff` + locked CSP. Agent code-file uploads still store/download, just don't render.

## F-6 — OAuth callback CSRF
State carried only `{cred_id, username}` — no session-bound token — so the callback could be forged to connect an attacker's account into a victim's vault. Added a random, server-persisted, single-use, 10-min-TTL **nonce** minted in `build_oauth_url` and verified+consumed in `oauth_callback`. Unit-tested: correct=pass, replay=fail, wrong=fail, cred-mismatch=fail.

## Verification
- All 4 files compile; app boots with real deps (image).
- F-7 fail-closed confirmed via test_client (protected routes denied, public still served).
- F-6 nonce logic unit-tested (4 cases).
- F-5 is deterministic serve-header logic.

Container E2E + fleet roll to follow on merge.