### PR TITLE
feat(voice-studio): register Pocket TTS as $0 local voice-clone provider

### DIFF
--- a/default-pages/voice-studio.html
+++ b/default-pages/voice-studio.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- openvoiceui-version: 2026-07-16-pocket-provider -->
 <html lang="en">
 <head>
 <meta charset="UTF-8">
@@ -669,6 +670,19 @@ body {
         </div>
       </div>
 
+      <div class="platform-card" data-provider="pocket" onclick="togglePlatform(this)" style="display:none">
+        <div class="platform-check">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+        </div>
+        <div class="platform-name">Pocket TTS</div>
+        <div class="platform-sub">Local · Free · Reusable voice</div>
+        <div class="platform-time">~2-3 seconds</div>
+        <div class="platform-status" id="status-pocket">
+          <span class="status-dot" id="dot-pocket"></span>
+          <span id="statusText-pocket">Checking...</span>
+        </div>
+      </div>
+
       <div class="platform-card" data-provider="qwen3" onclick="togglePlatform(this)">
         <div class="platform-check">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
@@ -968,7 +982,7 @@ body {
       if (Array.isArray(providers)) {
         providers.forEach(function(p) {
           var pid = p.provider_id || p.name || '';
-          if (pid === 'qwen3' || pid === 'qwen3-local' || pid === 'elevenlabs' || pid === 'resemble') {
+          if (pid === 'qwen3' || pid === 'qwen3-local' || pid === 'pocket' || pid === 'elevenlabs' || pid === 'resemble') {
             var available = p.status === 'active';
             providerStatus[pid] = available;
             var dot = $('dot-' + pid);
@@ -989,7 +1003,7 @@ body {
               card.classList.add('unavailable');
               card.classList.remove('selected');
               // hide self-hosted providers when offline — no point showing them
-              if (pid === 'qwen3-local') card.style.display = 'none';
+              if (pid === 'qwen3-local' || pid === 'pocket') card.style.display = 'none';
             }
           }
         });
@@ -1004,9 +1018,9 @@ body {
       updateCloneButton();
     }).catch(function() {
       // If providers endpoint fails, assume qwen3 is available (it has been working)
-      ['qwen3', 'qwen3-local', 'elevenlabs', 'resemble'].forEach(function(pid) {
-        $('statusText-' + pid).textContent = 'Unknown';
-        $('dot-' + pid).classList.add('err');
+      ['qwen3', 'qwen3-local', 'pocket', 'elevenlabs', 'resemble'].forEach(function(pid) {
+        var t = $('statusText-' + pid); if (t) t.textContent = 'Unknown';
+        var d = $('dot-' + pid); if (d) d.classList.add('err');
       });
     });
   }
@@ -1054,12 +1068,12 @@ body {
   };
 
   function platformLabel(pid) {
-    var labels = { 'qwen3-local': 'Qwen3 Local', qwen3: 'Qwen3', elevenlabs: 'ElevenLabs', resemble: 'Resemble' };
+    var labels = { 'qwen3-local': 'Qwen3 Local', qwen3: 'Qwen3', pocket: 'Pocket TTS', elevenlabs: 'ElevenLabs', resemble: 'Resemble' };
     return labels[pid] || pid;
   }
 
   function estimatedTime(pid) {
-    var times = { 'qwen3-local': 15000, qwen3: 40000, elevenlabs: 12000, resemble: 180000 };
+    var times = { 'qwen3-local': 15000, qwen3: 40000, pocket: 5000, elevenlabs: 12000, resemble: 180000 };
     return times[pid] || 60000;
   }
 

--- a/tts_providers/providers_config.json
+++ b/tts_providers/providers_config.json
@@ -1,5 +1,30 @@
 {
   "providers": {
+    "pocket": {
+      "name": "Pocket TTS",
+      "provider_id": "pocket",
+      "cost_per_minute": 0.0,
+      "quality": "high",
+      "latency": "very-fast",
+      "voices": [],
+      "features": [
+        "voice-cloning",
+        "local-processing",
+        "no-api-key-required",
+        "reusable-voice-state",
+        "free"
+      ],
+      "requires_api_key": false,
+      "status": "inactive",
+      "description": "Pocket TTS (Kyutai) — $0 local voice cloning on the macdaddy video/voice node. Clones a per-client brand voice from a ~10-20s reference clip into a reusable .safetensors state, then generates VO clips (~2-3s each). Client-facing via this Voice Cloning Studio canvas; jobs route to mac-claude@mesh over the Syncthing Dropzone bridge.",
+      "documentation_url": "https://github.com/kyutai-labs/pocket-tts",
+      "languages": ["en"],
+      "max_characters": 600,
+      "notes": "Self-hosted on the macdaddy node (handle_voice_clone). status=inactive until the OVU->mesh Dropzone bridge (POST /api/voice-clone/submit + result ingest) is wired; the studio card stays hidden while inactive, then auto-reveals like qwen3-local. Guardrail: dedicated deterministic handler, source-allowlisted host@mesh, NOT the permissionless claude path.",
+      "requires_microphone": false,
+      "requires_websocket": false,
+      "mode": "tts-only"
+    },
     "hume": {
       "name": "Hume Octave",
       "provider_id": "hume",


### PR DESCRIPTION
Folds mac-claude's **Pocket TTS** (Kyutai) engine into the existing fleet-wide **Voice Cloning Studio** canvas (`voice-studio.html`) instead of shipping a separate page — per Mike's call to add it to the canvas that already exists for all clients.

## What
- **`tts_providers/providers_config.json`** — new `pocket` provider entry. $0 local voice cloning on the macdaddy video/voice node: clones a per-client brand voice from a ~10–20s reference clip into a reusable `.safetensors` state, then generates VO clips (~2–3s each). `status: inactive` until the OVU→mesh Dropzone bridge (`POST /api/voice-clone/submit` + result ingest) is wired.
- **`default-pages/voice-studio.html`** — Pocket provider card following the existing self-hosted pattern: hidden while inactive, auto-reveals like `qwen3-local` when the registry reports it active. Wired into `checkProviders`/labels/times + added an `openvoiceui-version` marker so existing tenants re-seed on next roll.

## Why inactive
The Pocket engine runs on the macdaddy node (`handle_voice_clone`, staged + tested by mac-claude). The card stays hidden and offers no broken option until the host-side bridge is built — no fake functionality shipped.

## Guardrail
Jobs route to a **dedicated deterministic handler**, source-allowlisted `host@mesh` — NOT the permissionless `claude --dangerously-skip-permissions` path (the one booted after the GBP incident).

Already live on the test-dev sandbox tenant (mounted volume). Reaches the rest of the fleet on the next OVU image roll (alongside the pending unbaked items).