### PR TITLE
perf(voice): cap first TTS chunk at 60 chars for fast first-audio

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1567,6 +1567,12 @@ def _conversation_inner():
     # Inject active profile's custom system_prompt (admin editor → runtime)
     # Also read min_sentence_chars for TTS sentence extraction.
     _min_sentence_chars = 40  # default — prevents choppy short TTS fragments
+    # First-audio latency cap (2026-07-16): the reply's FIRST spoken chunk is
+    # extracted at min(_min_sentence_chars, this) so audio starts fast even on
+    # profiles with large character-pacing minimums (kyle's 200-char min made
+    # the first Resemble chunk 200-310 chars = 6-10s of synthesis while the
+    # text was already on screen). Later chunks keep the profile minimum.
+    _first_chunk_min_chars = 60
     _parallel_sentences = True  # default — fire all TTS in parallel threads
     _inter_sentence_gap_ms = 0  # default — no gap between audio chunks
     _prof = None  # default — referenced again in __session_start__ greeting branch below
@@ -2216,7 +2222,12 @@ def _conversation_inner():
                             )
                             # Fire TTS for complete sentences as they arrive
                             if not _is_system_text and not _has_open_tag(_tts_buf):
-                                sentence, _tts_buf = _extract_sentence(_tts_buf, min_len=_min_sentence_chars)
+                                _eff_min = (
+                                    min(_min_sentence_chars, _first_chunk_min_chars)
+                                    if (_chunks_sent == 0 and not _tts_pending)
+                                    else _min_sentence_chars
+                                )
+                                sentence, _tts_buf = _extract_sentence(_tts_buf, min_len=_eff_min)
                                 if sentence:
                                     logger.info(f"### TTS sentence (streaming): {sentence[:80]}")
                                     _tts_pending.append(_fire_tts(sentence))


### PR DESCRIPTION
Ports the 2026-07-16 bhb container hot patch into source so the next image roll doesn't drop it.

Profiles with large `min_sentence_chars` (kyle-hermes uses 200) made the first Resemble chunk 200-310 chars = 6-10s of synthesis before any audio played. The first extracted sentence is now capped at `min(profile_min, 60)`; later chunks keep the profile's pacing minimum.

Verified live on bhb 2026-07-17 00:38Z (Kyle Valhalla voice turn): first chunk flushed at exactly 60 chars, generate 2.2s vs 4.2-6.8s for the later 185-292 char chunks; no tracebacks over the monitored window. Repo file is byte-identical to the running container's patched file.