### PR TITLE
feat(suno): sing-along page support + cross-worker duplicate-download fix

### DIFF
--- a/routes/suno.py
+++ b/routes/suno.py
@@ -953,7 +953,21 @@ def _action_status(job_id: str):
                         _is_sfx = job.get('kind') == 'sfx'
                         _dir = GENERATED_SOUNDS_DIR if _is_sfx else GENERATED_MUSIC_DIR
                         _url_base = '/generated_music/sfx' if _is_sfx else '/generated_music'
-                        filename = _unique_filename(_dir, slug)
+                        # Cross-worker dedupe: the webhook callback and this poller
+                        # both download "the first clip" from separate gunicorn
+                        # workers (suno_jobs is per-worker memory), and
+                        # _unique_filename never reuses a name — so the second
+                        # writer saved the SAME clip again as <title>-2.mp3.
+                        # The shared metadata file is the cross-worker truth:
+                        # if this suno_id is already saved, reuse that file.
+                        filename = ''
+                        if song_id and not _is_sfx:
+                            filename = next(
+                                (fn for fn, md in _load_generated_metadata().items()
+                                 if isinstance(md, dict) and md.get('suno_id') == song_id
+                                 and (_dir / fn).exists()), '')
+                        if not filename:
+                            filename = _unique_filename(_dir, slug)
                         save_path = _dir / filename
 
                         if not save_path.exists():
@@ -2376,7 +2390,17 @@ def suno_callback():
                         song_title = 'Generated Track'
                     duration = song.get('duration', 0)
                     slug = _slugify_title(song_title)
-                    filename = _unique_filename(GENERATED_MUSIC_DIR, slug)
+                    # Cross-worker dedupe (mirror of _action_status): if the
+                    # status poller already saved this suno_id, reuse its file
+                    # instead of minting a -2 duplicate of the same clip.
+                    filename = ''
+                    if song_id:
+                        filename = next(
+                            (fn for fn, md in _load_generated_metadata().items()
+                             if isinstance(md, dict) and md.get('suno_id') == song_id
+                             and (GENERATED_MUSIC_DIR / fn).exists()), '')
+                    if not filename:
+                        filename = _unique_filename(GENERATED_MUSIC_DIR, slug)
                     save_path = GENERATED_MUSIC_DIR / filename
 
                     if audio_url and not save_path.exists():

--- a/routes/suno.py
+++ b/routes/suno.py
@@ -443,6 +443,10 @@ def _action_list():
                 'created_date': meta.get('created_date', ''),
                 'url': f'/generated_music/{f.name}',
                 'size_bytes': f.stat().st_size,
+                # Sing-along support: plain lyrics for estimated timing, and
+                # whether Suno per-word timestamps are fetchable (needs both ids).
+                'lyrics': meta.get('lyrics', ''),
+                'has_word_sync': bool(meta.get('task_id') and meta.get('suno_id')),
             })
     return jsonify({
         'action': 'list',


### PR DESCRIPTION
Two changes backing the new Sing Along karaoke canvas page (live on test-dev via hot-patch):

**1. `action=list` exposes `lyrics` + `has_word_sync`** (additive fields) — the page needs plain lyrics for estimated karaoke timing and a flag for whether Suno per-word timestamps are fetchable (both `task_id` + `suno_id` present).

**2. Duplicate-download root-cause fix** — the webhook callback and the status poller both download "the first clip", each deduping by filename only, and `_unique_filename` never returns an existing name. With multi-worker gunicorn, `suno_jobs` is per-worker memory, so callback-on-worker-A + poll-on-worker-B saved the same clip twice as `title.mp3` + `title-2.mp3` (still occurring as of 2026-07-12; ~49 dup pairs on test-dev). Both paths now check the shared `generated_metadata.json` for an already-saved entry with the clip's `suno_id` and reuse that file.

---
**Update (2026-07-17):** two more commits since the original review scope:
- `9f6e09f` — durable Suno task ledger: every submission + every returned clip (incl. the undownloaded 2nd clip) appended to per-tenant `generated_music/suno-task-log.jsonl`. Born after ~150 pre-07-14 tracks lost their task ids unrecoverably.
- `272d987` — **Sing Along promoted to a base canvas page** (`default-pages/sing-along.html`, version-stamped 1.0.0): word-synced karaoke over music-reactive FX, karaoke mode via cached stem separation, shuffle/skip, all UI confined to the OVU shell content column. Proven through ~20 live iterations on test-dev. Seeds to every tenant automatically on container boot after the next image roll.