### PR TITLE
feat(suno): sing-along list fields + cross-worker download dedupe

### DIFF
--- a/routes/suno.py
+++ b/routes/suno.py
@@ -953,7 +953,21 @@ def _action_status(job_id: str):
                         _is_sfx = job.get('kind') == 'sfx'
                         _dir = GENERATED_SOUNDS_DIR if _is_sfx else GENERATED_MUSIC_DIR
                         _url_base = '/generated_music/sfx' if _is_sfx else '/generated_music'
-                        filename = _unique_filename(_dir, slug)
+                        # Cross-worker dedupe: the webhook callback and this poller
+                        # both download "the first clip" from separate gunicorn
+                        # workers (suno_jobs is per-worker memory), and
+                        # _unique_filename never reuses a name — so the second
+                        # writer saved the SAME clip again as <title>-2.mp3.
+                        # The shared metadata file is the cross-worker truth:
+                        # if this suno_id is already saved, reuse that file.
+                        filename = ''
+                        if song_id and not _is_sfx:
+                            filename = next(
+                                (fn for fn, md in _load_generated_metadata().items()
+                                 if isinstance(md, dict) and md.get('suno_id') == song_id
+                                 and (_dir / fn).exists()), '')
+                        if not filename:
+                            filename = _unique_filename(_dir, slug)
                         save_path = _dir / filename
 
                         if not save_path.exists():
@@ -2376,7 +2390,17 @@ def suno_callback():
                         song_title = 'Generated Track'
                     duration = song.get('duration', 0)
                     slug = _slugify_title(song_title)
-                    filename = _unique_filename(GENERATED_MUSIC_DIR, slug)
+                    # Cross-worker dedupe (mirror of _action_status): if the
+                    # status poller already saved this suno_id, reuse its file
+                    # instead of minting a -2 duplicate of the same clip.
+                    filename = ''
+                    if song_id:
+                        filename = next(
+                            (fn for fn, md in _load_generated_metadata().items()
+                             if isinstance(md, dict) and md.get('suno_id') == song_id
+                             and (GENERATED_MUSIC_DIR / fn).exists()), '')
+                    if not filename:
+                        filename = _unique_filename(GENERATED_MUSIC_DIR, slug)
                     save_path = GENERATED_MUSIC_DIR / filename
 
                     if audio_url and not save_path.exists():

--- a/routes/suno.py
+++ b/routes/suno.py
@@ -443,6 +443,10 @@ def _action_list():
                 'created_date': meta.get('created_date', ''),
                 'url': f'/generated_music/{f.name}',
                 'size_bytes': f.stat().st_size,
+                # Sing-along support: plain lyrics for estimated timing, and
+                # whether Suno per-word timestamps are fetchable (needs both ids).
+                'lyrics': meta.get('lyrics', ''),
+                'has_word_sync': bool(meta.get('task_id') and meta.get('suno_id')),
             })
     return jsonify({
         'action': 'list',


### PR DESCRIPTION
Moves two commits off the VPS-local `main` onto a reviewable branch — they were committed directly to local `main`, which is protected on origin (direct push rejected), leaving local main 2-ahead with provenance drift vs GitHub.

## Commits (unchanged, original authorship/timestamps preserved)
- `9eddbbc` **feat(suno): expose `lyrics` + `has_word_sync` in `action=list`** — sing-along canvas page support: plain lyrics for estimated timing, and whether Suno per-word timestamps are fetchable (needs both `task_id` + `suno_id`). +4 lines in `routes/suno.py`.
- `a37a0f7` **fix(suno): dedupe downloads by `suno_id` across workers** — stops duplicate `<title>-2.mp3` files when multiple workers race the same track. +26/-2 in `routes/suno.py`.

After merge, the VPS working copy fast-forwards cleanly (`git pull --ff-only`) since local main is an ancestor of the merge — no reset needed on the shared tree.

Note for the author-agent: local `main` is a protected branch on origin — future work should go straight to a feature branch.