### PR TITLE
feat(suno): durable task ledger — log every submission + clip to suno-task-log.jsonl

### DIFF
--- a/routes/suno.py
+++ b/routes/suno.py
@@ -110,6 +110,27 @@ def _provider_receipt(op: str, units: str = '1') -> None:
     except Exception:
         pass
 
+
+def _task_log(event: str, **fields) -> None:
+    """Durable append-only Suno task ledger — generated_music/suno-task-log.jsonl.
+
+    Every submission gets a 'submitted' row (task_id + op + prompt/title) and
+    every completion a 'clip' row PER CLIP Suno returns — including the second
+    clip we don't download — so task_id ↔ suno_id ↔ filename is always
+    recoverable from disk. Born 2026-07-17 after ~150 pre-07-14 tracks lost
+    their task ids forever (container logs rotate, metadata never stored them,
+    sunoapi.org has no listing API). Rows may duplicate across the callback and
+    poller workers — dedupe on read, never on write. Fire-and-forget.
+    """
+    try:
+        row = {'ts': datetime.now(timezone.utc).isoformat(timespec='seconds'),
+               'event': event}
+        row.update({k: v for k, v in fields.items() if v not in (None, '')})
+        with open(GENERATED_MUSIC_DIR / 'suno-task-log.jsonl', 'a') as f:
+            f.write(json.dumps(row) + '\n')
+    except Exception:  # never let telemetry touch the generation path
+        pass
+
 # ---------------------------------------------------------------------------
 # Jingle style presets — proven 2026-05-05. The recipe is:
 #   customMode: false
@@ -575,6 +596,8 @@ def _action_generate(_q, body: dict):
                     'created_at': time.time(),
                 }
                 _provider_receipt('song')   # live Watch pulse — task accepted, credits committed
+                _task_log('submitted', op='song', task_id=task_id, title=title,
+                          style=style, prompt=(prompt or '')[:300])
                 return jsonify({
                     'action': 'generating',
                     'job_id': job_id,
@@ -677,6 +700,8 @@ def _action_sfx(_q, body: dict):
                     'created_at': time.time(),
                 }
                 _provider_receipt('sfx')   # live Watch pulse — task accepted, credits committed
+                _task_log('submitted', op='sfx', task_id=task_id,
+                          title=title or prompt[:60], prompt=(prompt or '')[:300])
                 return jsonify({
                     'action': 'generating',
                     'job_id': job_id,
@@ -826,6 +851,8 @@ def _action_jingle(_q, body: dict):
             'repeat': repeat,
         }
         _provider_receipt('jingle')   # live Watch pulse — task accepted, credits committed
+        _task_log('submitted', op='jingle', task_id=task_id, title=f'{brand} Jingle',
+                  style=style_descriptor, prompt=(jingle_prompt or '')[:300])
         return jsonify({
             'action': 'generating',
             'job_id': job_id,
@@ -930,6 +957,12 @@ def _action_status(job_id: str):
 
                 if gen_status == 'SUCCESS':
                     songs = status_data.get('response', {}).get('sunoData', [])
+                    # Durable ledger: record EVERY clip id (incl. the second one
+                    # we don't download) so task_id ↔ suno_id never gets lost.
+                    for _clip in songs:
+                        _task_log('clip', task_id=task_id, suno_id=_clip.get('id', ''),
+                                  title=_clip.get('title', ''),
+                                  duration=_clip.get('duration', 0), leg='poller')
                     # Suno returns 2 clips per generation — only take the first one
                     songs = songs[:1] if songs else []
                     for song in songs:
@@ -1234,6 +1267,9 @@ def _submit_suno_job(endpoint: str, request_body: dict, kind: str,
             job.update(job_extra)
         suno_jobs[job_id] = job
         _provider_receipt(op or kind)
+        _task_log('submitted', op=op or kind, task_id=task_id,
+                  title=job.get('title', ''), style=job.get('style', ''),
+                  prompt=(job.get('prompt', '') or '')[:300])
         return jsonify({
             'action': 'generating',
             'job_id': job_id,
@@ -1972,6 +2008,9 @@ def _submit_process_job(endpoint: str, request_body: dict, kind: str,
             'process_only': True,  # status poller won't try to download as music
         }
         _provider_receipt(op or kind)
+        _task_log('submitted', op=op or kind, task_id=task_id,
+                  src_task_id=request_body.get('taskId', ''),
+                  src_audio_id=request_body.get('audioId', ''))
         return jsonify({
             'action': 'generating',
             'job_id': job_id,
@@ -2375,6 +2414,12 @@ def suno_callback():
                 callback_type not in ('text', 'first', 'second') and data.get('data', {}).get('data')
             ):
                 songs = data.get('data', {}).get('data', [])
+                # Durable ledger: record EVERY clip id (incl. the second one
+                # we don't download) so task_id ↔ suno_id never gets lost.
+                for _clip in songs:
+                    _task_log('clip', task_id=task_id, suno_id=_clip.get('id', ''),
+                              title=_clip.get('title', ''),
+                              duration=_clip.get('duration', 0), leg='callback')
                 # Suno returns 2 clips per generation — only take the first one
                 # (user asked for 1 song, not 2 variations)
                 songs = songs[:1] if songs else []


### PR DESCRIPTION
Lands commit `9f6e09f` (clone-host's durable task-ledger fix), which was pushed to `feat/sing-along-suno` **after** PR #385 had already merged — leaving it dangling on the branch, in no PR, and absent from main. Without this, the next image roll would ship without the ledger and everyone would believe the task-id-loss fix was in.

## What it does
`routes/suno.py _task_log()` — appends every Suno submission + every returned clip (including the undownloaded 2nd clip) to per-tenant `generated_music/suno-task-log.jsonl`. This is the durable prevention for the task-id loss that required tonight's 132-id dashboard-export recovery.

Already hot-patched + verified healthy on openvoiceui-test-dev and openvoiceui-bhb; fleet gets it via the owed image roll once this is in main.