### PR TITLE
fix(bulk-uploader): video thumbnails render a poster frame (#t=0.1)

### DIFF
--- a/default-pages/bulk-image-uploader.html
+++ b/default-pages/bulk-image-uploader.html
@@ -462,11 +462,13 @@ function render(){
     // can play right in the feed (muted+preload=metadata so 20+ clips don't all download at once),
     // audio renders a compact inline <audio> player. event.stopPropagation keeps play/scrub controls
     // from bubbling up to the card's lightbox onclick — clicking the card elsewhere still opens the lightbox.
+    // The #t=0.1 media fragment forces the browser to seek+paint the frame at 0.1s as the visible
+    // poster — WITHOUT it, preload=metadata only loads dimensions/duration and the card stays black.
     let thumb;
     if(isImg){
       thumb=`<img src="${f.url}" loading="lazy" alt="">`;
     }else if(f.cat==='vid'){
-      thumb=`<video src="${f.url}" muted playsinline preload="metadata" controls onclick="event.stopPropagation()" style="width:100%;height:100%;object-fit:cover;background:#000"></video>`;
+      thumb=`<video src="${f.url}#t=0.1" muted playsinline preload="metadata" controls onclick="event.stopPropagation()" style="width:100%;height:100%;object-fit:cover;background:#000"></video>`;
     }else if(f.cat==='aud'){
       thumb=`<div class="ct-ic" style="width:100%;padding:0 10px">${IC.aud.replace(/stroke-width="[^"]*"/,'stroke-width="1.4"').replace(/<svg/,`<svg style="stroke:${COLORS.aud}"`)}<audio src="${f.url}" controls preload="none" onclick="event.stopPropagation()" style="width:100%;max-width:130px"></audio></div>`;
     }else{


### PR DESCRIPTION
Canvas bulk-image-uploader showed videos as a black `<video>` box — `preload=metadata` loads dimensions/duration but never seeks to a frame. Appending `#t=0.1` forces the browser to seek+paint the 0.1s frame as the visible poster. `/uploads` serves video with HTTP 206 + Accept-Ranges so the seek works.

Diagnosed + fleet-rolled to all 26 client canvas-pages by host-clone (2026-07-19, non-destructive with .old backups); this lands the OVU source so future provisions + fleet-syncs ship it. Roll script in MIKE-AI: `scripts/roll-bulk-uploader-video-thumb-fix.sh`.