### PR TITLE
feat: migrate UI state context to workspace file (#94)

### DIFF
--- a/prompts/voice-system-prompt.md
+++ b/prompts/voice-system-prompt.md
@@ -37,6 +37,9 @@ BAD: [CANVAS:page-id]  GOOD: Here is your dashboard. [CANVAS:page-id]
 BAD: [MUSIC_PLAY]  GOOD: Playing something for you now. [MUSIC_PLAY]
 Tags are invisible to the user — they only hear your words and see your words.
 
+UI STATE FILE (uploads/UI_STATE.md):
+A full, always-current copy of these instructions plus the live UI state (canvas page list, track lists, current user, open canvas page, music state) is auto-written to uploads/UI_STATE.md in your workspace before every turn. To save tokens these instructions and the page/track lists are NOT repeated in every message — a short pointer is sent instead. If you need a page-id or track title that is not in the current message, or your history was compacted and you no longer remember these instructions, READ uploads/UI_STATE.md with your read tool. Never guess a page-id or track name — read the file.
+
 ---
 
 CANVAS — OPEN EXISTING PAGE:

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -114,6 +114,13 @@ _VOICE_INSTRUCTIONS = (
     "BAD: [MUSIC_PLAY]  GOOD: Playing something for you now. [MUSIC_PLAY] "
     "Tags are invisible to the user — they only hear your words. "
 
+    # --- UI state file (#94) ---
+    "UI STATE FILE: a full always-current copy of these instructions plus live UI state "
+    "(canvas page list, track lists, current user, open page, music state) is auto-written "
+    "to uploads/UI_STATE.md in your workspace before every turn. If a page-id or track title "
+    "is not in the current message, or you no longer remember these instructions, READ "
+    "uploads/UI_STATE.md — never guess a page-id or track name. "
+
     # --- Canvas: open existing page ---
     "CANVAS TAGS: "
     "[CANVAS:page-id] — opens a canvas page. Use exact page-id from the [Canvas pages:] list above. "
@@ -389,21 +396,30 @@ _double_empty_window_start: float = 0
 _DOUBLE_EMPTY_MAX_RESTARTS: int = 2       # max restart flags per window
 _DOUBLE_EMPTY_WINDOW_SECONDS: float = 300  # 5-minute sliding window
 
-#: ── Context-bloat guard (2026-07-13, bhb session overflow) ────────────────
+#: ── Context-bloat guard (2026-07-13, bhb session overflow; #94 2026-07-19) ─
 #: The STATIC instruction blocks (voice action-tag instructions, canvas page
-#: list, track list, DJ sounds, profile instructions, canvas style) used to be
-#: re-sent verbatim on EVERY turn (~17KB/turn). The gateway session keeps full
+#: list, track list, DJ sounds, profile instructions, canvas style,
+#: CURRENT_USER/office briefing, latest generated song) used to be re-sent
+#: verbatim on EVERY turn (~17KB/turn). The gateway session keeps full
 #: history, so after a day of voice chat the duplicated blocks alone overflowed
 #: GLM-5's context window (bhb 2026-07-13: 199-message session, repeated
 #: 'Context overflow' + a wedged ReplyRunAlreadyActive run → UI stuck in
-#: 'Connection lost — retrying'). Now the full static block is sent only when
-#: its CONTENT CHANGES (hash), on __session_start__, or as a periodic refresh
-#: so openclaw auto-compaction can never silently strip it from history;
-#: otherwise a one-line pointer is sent. Dynamic parts (face recognition,
-#: canvas open/closed, music state, Suno events, CURRENT_USER) stay per-turn.
+#: 'Connection lost — retrying'). The full static block is sent only when
+#: its CONTENT CHANGES (hash), on __session_start__, or as a periodic refresh;
+#: otherwise a one-line pointer is sent.
+#:
+#: Issue #94 (2026-07-19): the same static block is now ALSO mirrored to
+#: uploads/UI_STATE.md in the agent workspace on every turn (atomic,
+#: hash-skipped — see services/ui_state.py). That durable on-disk copy is why
+#: the periodic resend cadence below is 3x longer than the original 10-turn/
+#: 15-min guard: if openclaw auto-compaction strips the block from history,
+#: the per-turn pointer names the file and the agent can recover the full
+#: instructions with one read instead of waiting for the next resend.
+#: Truly per-turn parts (face recognition, camera vision, canvas open/closed,
+#: music now-playing, Suno event announcements) stay inline every turn.
 _ctx_static_cache: dict = {}        # "<session_id>:<voice_key>" -> {hash, ts, skips}
-_CTX_STATIC_RESEND_TURNS = 10       # resend full block at least every N turns
-_CTX_STATIC_RESEND_SECS = 900       # ...or after 15 minutes, whichever first
+_CTX_STATIC_RESEND_TURNS = 30       # resend full block at least every N turns
+_CTX_STATIC_RESEND_SECS = 2700      # ...or after 45 minutes, whichever first
 _CTX_STATIC_CACHE_MAX = 300         # prune guard for the in-process cache
 
 # ---------------------------------------------------------------------------
@@ -1299,6 +1315,8 @@ def _conversation_inner():
     context_parts = []   # dynamic — changes turn to turn, always sent
     static_parts = []    # static — identical between turns; deduped by the
                          # context-bloat guard below (sent on change/periodic)
+    _ui_state_lines = []  # plain-text state summary mirrored to UI_STATE.md
+                          # (issue #94) — canvas/music state only, no ephemera
 
     # Inject face recognition identity
     if identified_person and identified_person.get('name') and identified_person.get('name') != 'unknown':
@@ -1470,8 +1488,10 @@ def _conversation_inner():
                          .replace('.html', '')
                          .replace('-', ' '))
             context_parts.append(f'[Canvas OPEN: {page_name}]')
+            _ui_state_lines.append(f'Canvas OPEN: {page_name}')
         elif not ui_context.get('canvasVisible'):
             context_parts.append('[Canvas CLOSED]')
+            _ui_state_lines.append('Canvas CLOSED')
         if ui_context.get('canvasMenuOpen'):
             context_parts.append('[Canvas menu visible to user]')
         # Canvas JS errors — auto-injected from browser error buffer
@@ -1486,12 +1506,15 @@ def _conversation_inner():
         if _srv_playing and _srv_track:
             _track_name = _srv_track.get('title') or _srv_track.get('name', 'unknown')
             context_parts.append(f'[Music PLAYING: {_track_name}]')
+            _ui_state_lines.append(f'Music PLAYING: {_track_name}')
         elif _srv_track:
             _track_name = _srv_track.get('title') or _srv_track.get('name', 'unknown')
             context_parts.append(f'[Music PAUSED/STOPPED — last track: {_track_name}]')
+            _ui_state_lines.append(f'Music PAUSED/STOPPED — last track: {_track_name}')
         elif ui_context.get('musicPlaying'):
             track = ui_context.get('musicTrack', 'unknown')
             context_parts.append(f'[Music PLAYING: {track}]')
+            _ui_state_lines.append(f'Music PLAYING: {track}')
 
         # Available music tracks (so agent can use [MUSIC_PLAY:exact name])
         # Names come from a 10s TTL cache (_cached_music_names) so a full
@@ -1513,11 +1536,14 @@ def _conversation_inner():
         # mtime (created_date metadata is date-only and useless for recency).
         # Gives the agent the exact filename + a ready-to-send download link so
         # it never guesses or hands out a broken /music/ URL.
+        # STATIC (#94): only changes when a new song lands — the hash-change
+        # resend in the context-bloat guard delivers it then, instead of
+        # repeating ~150 chars on every turn of the session.
         try:
             from routes.music import get_latest_generated_track
             _latest = get_latest_generated_track()
             if _latest:
-                context_parts.append(
+                static_parts.append(
                     f"[Latest generated song: {_latest['title']!r} "
                     f"(file: {_latest['filename']}) — "
                     f"download link: /generated_music/{_latest['filename']}?download=1]"
@@ -1616,6 +1642,10 @@ def _conversation_inner():
     # right now (regardless of which tenant account they're using). When Mike
     # the developer pops into a client tenant to debug, the agent should treat
     # him as a peer collaborator, not a client. See services/identity.py.
+    # STATIC (#94): the tag + office briefing are stable within a session for
+    # a given Clerk user — they used to repeat ~300-800 chars on EVERY turn
+    # (the exact accumulation PR #297 was called out for in issue #94). A user
+    # switch or briefing change flips the static-blob hash → full resend.
     try:
         from flask import g as _flask_g
         from services.identity import get_current_user_tag as _get_current_user_tag
@@ -1623,7 +1653,7 @@ def _conversation_inner():
         _tenant = os.getenv('JAMBOT_TENANT') or os.getenv('TENANT_NAME') or None
         _user_tag = _get_current_user_tag(_clerk_uid, _tenant)
         if _user_tag:
-            context_parts.append(_user_tag)
+            static_parts.append(_user_tag)
             logger.info(f'### CURRENT_USER injected: clerk_uid={_clerk_uid} tenant={_tenant}')
 
         # Mesh-access gate — refresh the .mesh-admin-session marker on every
@@ -1676,6 +1706,20 @@ def _conversation_inner():
     # __session_start__, or as a periodic refresh; otherwise a 1-line pointer.
     if static_parts:
         _static_blob = ' '.join(static_parts)
+
+        # #94: mirror the full static block + current canvas/music state to
+        # uploads/UI_STATE.md in the agent workspace (atomic, hash-skipped).
+        # This durable copy is what makes the pointer below recoverable after
+        # openclaw auto-compaction strips old history — see services/ui_state.py.
+        # Gated on ui_context: turns without browser UI state (API/proactive)
+        # build a listless static blob and must not clobber the good file.
+        if ui_context:
+            try:
+                from services.paths import UPLOADS_DIR as _ui_uploads_dir
+                from services.ui_state import write_ui_state as _write_ui_state
+                _write_ui_state(_ui_uploads_dir, _static_blob, _ui_state_lines)
+            except Exception as _us_e:
+                logger.warning(f'UI_STATE.md mirror failed (non-fatal): {_us_e}')
         try:
             import hashlib as _hl
             _ctx_key = f'{session_id}:{get_voice_session_key()}'
@@ -1700,8 +1744,10 @@ def _conversation_inner():
                 _rec['skips'] = _rec.get('skips', 0) + 1
                 context_parts.append(
                     '[Standing instructions (voice action tags, canvas page list, track list, '
-                    'profile instructions, canvas style) were already provided earlier this '
-                    'session, are UNCHANGED, and still apply.]'
+                    'profile instructions, canvas style, current user) were already provided '
+                    'earlier this session, are UNCHANGED, and still apply. A full always-current '
+                    'copy lives at uploads/UI_STATE.md in your workspace — re-read it if you no '
+                    'longer remember them.]'
                 )
                 logger.info(f'### CONTEXT DEDUP: skipped {len(_static_blob)} static chars '
                             f'(skip {_rec["skips"]}/{_CTX_STATIC_RESEND_TURNS})')

--- a/services/ui_state.py
+++ b/services/ui_state.py
@@ -1,0 +1,150 @@
+"""
+UI state workspace file — issue #94.
+
+Writes the agent-facing UI state (standing instructions, canvas page list,
+track list, current user, canvas/music state) to ``uploads/UI_STATE.md`` so
+the agent always has a durable, current copy OUTSIDE conversation history.
+
+Why this exists
+---------------
+Per-turn context prefixes accumulate in the gateway session history and waste
+tokens through compaction (issue #94; PR #297 made it worse by adding
+CURRENT_USER + OFFICE_BRIEFING prefixes). The context-bloat guard in
+routes/conversation.py already dedupes the static block within a session, but
+it still had to periodically RESEND the full ~17KB block so openclaw
+auto-compaction could never silently strip the voice action-tag instructions
+from history. This file is the durable copy that makes aggressive dedup safe:
+the per-turn pointer names this file, so an agent that lost the instructions
+to compaction can always recover them with one read.
+
+Injection reality check (verified 2026-07-19 against openclaw docs):
+openclaw injects bootstrap files (AGENTS.md, SOUL.md, TOOLS.md, ...) into the
+system prompt on the FIRST turn of a session only, from a fixed file list.
+An arbitrary workspace file is NOT auto-injected and NOT re-read per turn.
+So this file is a read-on-demand recovery source + always-fresh reference,
+not an automatic per-turn injection channel. The inline static block still
+goes out on session start and whenever its content changes.
+
+Where the agent sees it
+-----------------------
+Flask writes ``UPLOADS_DIR / 'UI_STATE.md'`` (= /app/runtime/uploads/ in the
+openvoiceui container). The tenant compose mounts that same host dir into the
+agent container:
+  - OpenClaw: /home/node/.openclaw/workspace/uploads/UI_STATE.md
+  - Hermes:   /workspace/uploads/UI_STATE.md
+Both resolve as ``uploads/UI_STATE.md`` relative to the agent workspace.
+
+Design constraints
+------------------
+- Atomic write (tmp + os.replace) — the agent may read mid-write otherwise.
+- Content-hash skip — most turns change nothing; no disk churn.
+- Fail-open — a write failure must NEVER cost a turn. Callers ignore result.
+- Zero Flask imports — standalone module, unit-testable without the app.
+"""
+import hashlib
+import logging
+import os
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Filename inside the uploads dir (agent sees it at workspace/uploads/).
+UI_STATE_FILENAME = 'UI_STATE.md'
+
+#: Agent-relative path used in prompts/pointers — identical for both gateways.
+UI_STATE_AGENT_PATH = 'uploads/UI_STATE.md'
+
+# Last-written content hash; skip the write when nothing changed.
+_last_hash_lock = threading.Lock()
+_last_hash: str | None = None
+
+
+def build_ui_state_doc(static_blob: str, dynamic_lines: list[str]) -> str:
+    """Compose the UI_STATE.md document.
+
+    ``static_blob``    — the joined standing-instruction block (voice action
+                         tags, canvas page list, track list, profile
+                         instructions, canvas style, current user).
+    ``dynamic_lines``  — small per-turn state lines (canvas open/closed,
+                         music playing). Ephemeral per-turn context (camera
+                         vision, uploaded-image analysis, browser-extension
+                         page dumps, Suno event announcements) is deliberately
+                         EXCLUDED — it belongs to the turn, not to state.
+    """
+    ts = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
+    parts = [
+        '# UI STATE — OpenVoiceUI live state',
+        '',
+        f'_Auto-written by OpenVoiceUI before each agent turn (last: {ts})._',
+        '_This file is always current. If conversation history was compacted',
+        'and you no longer remember the voice action-tag instructions, the',
+        'canvas page list, or the track list — re-read THIS file. Never guess',
+        'a page-id or track name from memory when you can read it here._',
+        '',
+        '## Current state',
+        '',
+    ]
+    if dynamic_lines:
+        parts.extend(f'- {line}' for line in dynamic_lines)
+    else:
+        parts.append('- (no UI state reported this turn)')
+    parts += [
+        '',
+        '## Standing instructions + catalogs',
+        '',
+        static_blob.strip(),
+        '',
+    ]
+    return '\n'.join(parts)
+
+
+def write_ui_state(uploads_dir: Path, static_blob: str,
+                   dynamic_lines: list[str]) -> bool:
+    """Atomically write UI_STATE.md into ``uploads_dir``.
+
+    Returns True if the file was (re)written, False if skipped (unchanged)
+    or failed. Fail-open: never raises.
+    """
+    global _last_hash
+    try:
+        doc = build_ui_state_doc(static_blob, dynamic_lines)
+        # Hash everything EXCEPT the timestamp line so an otherwise-unchanged
+        # doc doesn't rewrite every turn just because the clock moved.
+        hash_src = '\n'.join(
+            l for l in doc.splitlines() if not l.startswith('_Auto-written')
+        )
+        digest = hashlib.sha1(hash_src.encode('utf-8', 'replace')).hexdigest()
+        with _last_hash_lock:
+            if digest == _last_hash:
+                return False
+
+        uploads_dir = Path(uploads_dir)
+        uploads_dir.mkdir(parents=True, exist_ok=True)
+        target = uploads_dir / UI_STATE_FILENAME
+        # Atomic: write to a tmp file in the SAME dir, then rename over.
+        fd, tmp_path = tempfile.mkstemp(
+            prefix='.UI_STATE.', suffix='.tmp', dir=str(uploads_dir))
+        try:
+            with os.fdopen(fd, 'w', encoding='utf-8') as f:
+                f.write(doc)
+            os.replace(tmp_path, target)
+        except Exception:
+            # Best-effort tmp cleanup — never leave droppings in uploads/.
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        try:
+            os.chmod(target, 0o664)
+        except OSError:
+            pass
+        with _last_hash_lock:
+            _last_hash = digest
+        return True
+    except Exception as e:  # noqa: BLE001 — fail-open by contract
+        logger.warning(f'UI_STATE.md write failed (non-fatal): {e}')
+        return False

--- a/tests/test_ui_state.py
+++ b/tests/test_ui_state.py
@@ -1,0 +1,93 @@
+"""
+Tests for services/ui_state.py — the UI_STATE.md workspace mirror (issue #94).
+
+The module is deliberately Flask-free, so these tests run without the app.
+"""
+import os
+import sys
+
+import pytest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+import services.ui_state as ui_state  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_hash_cache():
+    """Each test starts with a clean last-written-hash cache."""
+    with ui_state._last_hash_lock:
+        ui_state._last_hash = None
+    yield
+    with ui_state._last_hash_lock:
+        ui_state._last_hash = None
+
+
+def test_build_doc_contains_sections_and_content():
+    doc = ui_state.build_ui_state_doc(
+        '[Canvas pages: home, dashboard] [OPENVOICEUI SYSTEM INSTRUCTIONS: ...]',
+        ['Canvas OPEN: dashboard', 'Music PLAYING: Test Track'],
+    )
+    assert '# UI STATE' in doc
+    assert '## Current state' in doc
+    assert '- Canvas OPEN: dashboard' in doc
+    assert '- Music PLAYING: Test Track' in doc
+    assert '## Standing instructions + catalogs' in doc
+    assert '[Canvas pages: home, dashboard]' in doc
+
+
+def test_build_doc_no_dynamic_lines():
+    doc = ui_state.build_ui_state_doc('[static]', [])
+    assert '(no UI state reported this turn)' in doc
+
+
+def test_write_creates_file_atomically(tmp_path):
+    wrote = ui_state.write_ui_state(tmp_path, '[static blob]', ['Canvas CLOSED'])
+    assert wrote is True
+    target = tmp_path / ui_state.UI_STATE_FILENAME
+    assert target.is_file()
+    text = target.read_text(encoding='utf-8')
+    assert '[static blob]' in text
+    assert '- Canvas CLOSED' in text
+    # No tmp droppings left behind
+    leftovers = [p for p in tmp_path.iterdir() if p.name != ui_state.UI_STATE_FILENAME]
+    assert leftovers == []
+
+
+def test_write_skips_unchanged_content(tmp_path):
+    assert ui_state.write_ui_state(tmp_path, '[static]', ['Canvas CLOSED']) is True
+    target = tmp_path / ui_state.UI_STATE_FILENAME
+    mtime1 = target.stat().st_mtime_ns
+    # Identical content (timestamp line excluded from the hash) → skip
+    assert ui_state.write_ui_state(tmp_path, '[static]', ['Canvas CLOSED']) is False
+    assert target.stat().st_mtime_ns == mtime1
+
+
+def test_write_rewrites_on_dynamic_change(tmp_path):
+    assert ui_state.write_ui_state(tmp_path, '[static]', ['Canvas CLOSED']) is True
+    assert ui_state.write_ui_state(tmp_path, '[static]', ['Canvas OPEN: x']) is True
+    text = (tmp_path / ui_state.UI_STATE_FILENAME).read_text(encoding='utf-8')
+    assert '- Canvas OPEN: x' in text
+    assert '- Canvas CLOSED' not in text
+
+
+def test_write_rewrites_on_static_change(tmp_path):
+    assert ui_state.write_ui_state(tmp_path, '[pages: a]', []) is True
+    assert ui_state.write_ui_state(tmp_path, '[pages: a, b]', []) is True
+    text = (tmp_path / ui_state.UI_STATE_FILENAME).read_text(encoding='utf-8')
+    assert '[pages: a, b]' in text
+
+
+def test_write_fail_open_on_bad_dir(tmp_path):
+    """A write failure returns False and raises nothing (fail-open contract)."""
+    blocker = tmp_path / 'not-a-dir'
+    blocker.write_text('file, not dir')
+    assert ui_state.write_ui_state(blocker, '[static]', []) is False
+
+
+def test_creates_missing_uploads_dir(tmp_path):
+    nested = tmp_path / 'uploads'
+    assert ui_state.write_ui_state(nested, '[static]', []) is True
+    assert (nested / ui_state.UI_STATE_FILENAME).is_file()


### PR DESCRIPTION
Closes #94. Top item on the #302 release tracker.

## Problem
Per-turn context prefixes (canvas, music, tracks, pages, CURRENT_USER, OFFICE_BRIEFING) accumulate in gateway session history and waste tokens through compaction. PR #297 compounded it by adding two more per-turn prefixes.

## Reality check on the proposed mechanism
The issue proposed writing `workspace/UI_STATE.md` and relying on openclaw bootstrap injection to refresh it "naturally". Verified against openclaw docs: bootstrap files are injected on the **first turn of a session only**, from a **fixed file list** — an arbitrary workspace file is never auto-injected nor re-read per turn. Additionally, the openclaw workspace root is mounted read-only into openvoiceui on live tenants. So this PR lands the issue's intent through channels that actually exist.

## Changes
- **`services/ui_state.py` (new)** — atomic (tmp + `os.replace`), content-hash-skipped writer mirroring the full static instruction block + live canvas/music state to `uploads/UI_STATE.md`. That dir is mounted into the agent container in both gateway flavors (OpenClaw `workspace/uploads/`, Hermes `/workspace/uploads/`), so the agent always has a durable, current copy outside conversation history. Flask-free and fail-open; gated on `ui_context` so API/proactive turns can't clobber the file with a listless snapshot.
- **`routes/conversation.py`** — `[CURRENT_USER]`/`[OFFICE_BRIEFING]` and `[Latest generated song]` move from per-turn dynamic parts into the hash-deduped static block (user switch / new song flips the hash → full resend). Context-bloat guard cadence relaxed from 10 turns/15 min to 30 turns/45 min — the on-disk copy + per-turn pointer now provide the compaction-recovery path the aggressive periodic resend existed for. The dedup pointer names the file explicitly.
- **`prompts/voice-system-prompt.md` + fallback constant** — new UI STATE FILE section: read `uploads/UI_STATE.md` when a page-id/track title isn't in the current message or history was compacted; never guess.
- **`tests/test_ui_state.py` (new)** — 8 tests: doc structure, atomicity (no tmp droppings), unchanged-skip, rewrite-on-change (static + dynamic), fail-open on bad dir, dir auto-create.

## Steady-state effect
Unchanged turns now carry ~180 chars of pointer instead of ~800+ chars of repeated identity/song tags, and the 18.5KB static block re-enters history 3x less often — verified live on test-dev (`CONTEXT DEDUP: skipped 18533 static chars (skip 1/30)`), including the agent successfully reading `uploads/UI_STATE.md` and reporting its contents on request. Full suite: 513 passed.

## Rollout
Code ships in the next image rebuild + fleet roll (#302 release sequence). test-dev is running this branch hot-patched for validation; no config or compose changes required.