### PR TITLE
feat: co-browsing Phase 1 — server-side browse service (#154)

### DIFF
--- a/deploy/browse-service/Dockerfile
+++ b/deploy/browse-service/Dockerfile
@@ -1,0 +1,30 @@
+# jambot-browse — server-side co-browsing service (issue #154, Phase 1)
+#
+# One shared headless-Chromium pool for the whole JamBot fleet, isolated
+# per-tenant by BrowserContext. Runs on the jambot-shared docker network,
+# same pattern as supertonic-tts — NOT baked into every OVU image (Chromium
+# is ~450MB; 26 copies would be wasteful).
+#
+# The Playwright base image ships a matching Chromium + all the system libs
+# (fonts, nss, gtk, etc.) so we don't hand-maintain the apt list.
+FROM mcr.microsoft.com/playwright/python:v1.48.0-noble
+
+WORKDIR /app
+
+# Python deps (Chromium itself is already in the base image)
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# The base image bundles browsers under /ms-playwright already; make sure the
+# chromium build our pinned playwright expects is present (no-op if cached).
+RUN python3 -m playwright install chromium
+
+COPY server.py .
+
+# Run as the non-root 'pwuser' the Playwright image provides.
+USER pwuser
+
+EXPOSE 8712
+
+# Single worker on purpose: one process owns the browser pool + session map.
+CMD ["python3", "server.py"]

--- a/deploy/browse-service/requirements.txt
+++ b/deploy/browse-service/requirements.txt
@@ -1,0 +1,3 @@
+aiohttp==3.10.11
+playwright==1.48.0
+psutil==6.1.0

--- a/deploy/browse-service/server.py
+++ b/deploy/browse-service/server.py
@@ -1,0 +1,523 @@
+"""
+jambot-browse — server-side co-browsing service (issue #154, Phase 1).
+
+A single shared headless-Chromium pool for the whole JamBot fleet. Each tenant
+gets its own Playwright BrowserContext (cookie / storage isolation). The agent
+drives a page via an HTTP action API and "sees" it via screenshots + a
+simplified DOM extract; a CDP `Page.startScreencast` feed is relayed to any
+connected WebSocket viewer so the human can watch every action live.
+
+Why a separate container (not baked into OVU):
+  - Chromium + libs is ~450MB; 26 OVU copies would be wasteful.
+  - One process owns the browser pool → clean session accounting, one memory
+    guard, one idle reaper. Mirrors the supertonic-tts shared-container pattern.
+  - Lives on the jambot-shared docker network; OVU's routes/browse.py (Phase 2)
+    is the only thing that talks to it, proxying to the user's canvas viewer.
+
+Security posture (Phase 1):
+  - Shared-secret auth (BROWSE_SERVICE_KEY) on every endpoint — defense in depth
+    even though the port is internal-only to jambot-shared.
+  - SSRF guard: every navigation target is resolved and refused if it points at
+    a private / loopback / link-local / cloud-metadata address. The agent must
+    never be able to make the browser hit 169.254.169.254 or a sibling container.
+  - Per-tenant context isolation; a hard cap on concurrent sessions; a system
+    memory guard that refuses new sessions under pressure.
+
+Endpoints (all require X-Browse-Key):
+  POST /session/start       {tenant, url, [width,height], [proxy]}  → start/replace a session
+  POST /session/action      {tenant, action, ...}                   → click/type/scroll/goto/back/forward/reload/wait
+  GET  /session/screenshot?tenant=..&[full=1]                       → PNG bytes (agent vision)
+  GET  /session/dom?tenant=..                                       → {url,title,text,links,inputs,buttons}
+  GET  /session/status?tenant=..                                    → session metadata
+  POST /session/stop        {tenant}                                → close + free
+  WS   /session/stream?tenant=..                                    → live screencast frames (base64 JPEG) + events
+  GET  /health                                                      → {ok, sessions, mem_percent}  (no auth)
+
+The `proxy` param on /session/start is wired but optional — it is the seam the
+IP-masking phase plugs a residential proxy into (see the phased doc). Phase 1
+ships it as a pass-through to Playwright's per-context proxy so nothing has to
+change in this file later.
+"""
+import asyncio
+import base64
+import ipaddress
+import json
+import logging
+import os
+import socket
+import time
+from urllib.parse import urlparse, urlsplit
+
+import psutil
+from aiohttp import WSMsgType, web
+from playwright.async_api import async_playwright
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [browse] %(message)s",
+)
+logger = logging.getLogger("browse")
+
+# ── Config (env-overridable) ────────────────────────────────────────────────
+PORT = int(os.getenv("BROWSE_PORT", "8712"))
+SERVICE_KEY = os.getenv("BROWSE_SERVICE_KEY", "").strip()
+MAX_SESSIONS = int(os.getenv("BROWSE_MAX_SESSIONS", "6"))
+IDLE_TIMEOUT_S = int(os.getenv("BROWSE_IDLE_TIMEOUT_S", "300"))   # 5 min
+MEM_GUARD_PCT = float(os.getenv("BROWSE_MEM_GUARD_PCT", "85"))
+DEFAULT_W = int(os.getenv("BROWSE_WIDTH", "1280"))
+DEFAULT_H = int(os.getenv("BROWSE_HEIGHT", "800"))
+NAV_TIMEOUT_MS = int(os.getenv("BROWSE_NAV_TIMEOUT_MS", "30000"))
+SCREENCAST_QUALITY = int(os.getenv("BROWSE_SCREENCAST_QUALITY", "60"))
+USER_AGENT = os.getenv(
+    "BROWSE_USER_AGENT",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+)
+
+# ── SSRF guard ──────────────────────────────────────────────────────────────
+_BLOCKED_NETS = [
+    ipaddress.ip_network(n) for n in (
+        "0.0.0.0/8", "10.0.0.0/8", "100.64.0.0/10", "127.0.0.0/8",
+        "169.254.0.0/16", "172.16.0.0/12", "192.0.0.0/24", "192.168.0.0/16",
+        "198.18.0.0/15", "::1/128", "fc00::/7", "fe80::/10",
+    )
+]
+
+
+def _host_is_blocked(host: str) -> bool:
+    """True if `host` resolves to any non-public address (SSRF defense)."""
+    if not host:
+        return True
+    # Resolve every A/AAAA record; block if ANY is private/loopback/link-local.
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return True  # unresolvable → refuse
+    for info in infos:
+        ip_str = info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_str.split("%")[0])
+        except ValueError:
+            return True
+        if any(ip in net for net in _BLOCKED_NETS) or ip.is_multicast or ip.is_reserved:
+            return True
+    return False
+
+
+def _validate_url(url: str) -> tuple[bool, str]:
+    """Return (ok, normalized_or_reason). Only http/https to public hosts."""
+    if not url:
+        return False, "empty url"
+    parsed = urlparse(url if "://" in url else f"https://{url}")
+    if parsed.scheme not in ("http", "https"):
+        return False, f"scheme not allowed: {parsed.scheme}"
+    if not parsed.hostname:
+        return False, "no host"
+    if _host_is_blocked(parsed.hostname):
+        return False, f"host blocked (private/internal): {parsed.hostname}"
+    return True, parsed.geturl()
+
+
+# ── Session model ───────────────────────────────────────────────────────────
+class Session:
+    def __init__(self, tenant: str, context, page, cdp):
+        self.tenant = tenant
+        self.context = context
+        self.page = page
+        self.cdp = cdp
+        self.last_activity = time.time()
+        self.viewers: set[web.WebSocketResponse] = set()
+        self.screencasting = False
+        self.lock = asyncio.Lock()  # serialize actions per session
+
+    def touch(self):
+        self.last_activity = time.time()
+
+    @property
+    def idle_s(self) -> float:
+        return time.time() - self.last_activity
+
+
+class BrowseService:
+    def __init__(self):
+        self.pw = None
+        self.browser = None
+        self.sessions: dict[str, Session] = {}
+        self._start_lock = asyncio.Lock()
+
+    async def startup(self):
+        self.pw = await async_playwright().start()
+        self.browser = await self.pw.chromium.launch(
+            headless=True,
+            args=[
+                "--no-sandbox",
+                "--disable-dev-shm-usage",
+                "--disable-blink-features=AutomationControlled",
+            ],
+        )
+        logger.info("chromium launched; max_sessions=%d idle_timeout=%ds",
+                    MAX_SESSIONS, IDLE_TIMEOUT_S)
+
+    async def shutdown(self):
+        for tenant in list(self.sessions):
+            await self.stop_session(tenant)
+        if self.browser:
+            await self.browser.close()
+        if self.pw:
+            await self.pw.stop()
+
+    # ── lifecycle ───────────────────────────────────────────────────────────
+    async def start_session(self, tenant, url, width, height, proxy):
+        async with self._start_lock:
+            # Replace any existing session for this tenant (one per tenant).
+            if tenant in self.sessions:
+                await self.stop_session(tenant)
+
+            if len(self.sessions) >= MAX_SESSIONS:
+                # Evict the most-idle session to make room.
+                victim = max(self.sessions.values(), key=lambda s: s.idle_s)
+                logger.info("session cap hit — evicting idle tenant=%s (%.0fs)",
+                            victim.tenant, victim.idle_s)
+                await self.stop_session(victim.tenant)
+
+            ctx_kwargs = dict(
+                viewport={"width": width, "height": height},
+                user_agent=USER_AGENT,
+            )
+            if proxy:
+                # Seam for the IP-masking phase: {"server","username","password"}
+                ctx_kwargs["proxy"] = proxy
+
+            context = await self.browser.new_context(**ctx_kwargs)
+            context.set_default_navigation_timeout(NAV_TIMEOUT_MS)
+            page = await context.new_page()
+            cdp = await context.new_cdp_session(page)
+            sess = Session(tenant, context, page, cdp)
+            self.sessions[tenant] = sess
+
+            # Relay CDP screencast frames to viewers.
+            def _on_frame(params):
+                asyncio.create_task(self._dispatch_frame(sess, params))
+            cdp.on("Page.screencastFrame", _on_frame)
+
+            await self._navigate(sess, url)
+            return sess
+
+    async def stop_session(self, tenant):
+        sess = self.sessions.pop(tenant, None)
+        if not sess:
+            return
+        for ws in list(sess.viewers):
+            try:
+                await ws.close()
+            except Exception:
+                pass
+        try:
+            await sess.context.close()
+        except Exception as e:
+            logger.debug("context close error tenant=%s: %s", tenant, e)
+        logger.info("session stopped tenant=%s", tenant)
+
+    # ── navigation + actions ──────────────────────────────────────────────────
+    async def _navigate(self, sess: Session, url: str):
+        ok, norm = _validate_url(url)
+        if not ok:
+            raise web.HTTPBadRequest(reason=f"navigation refused: {norm}")
+        await sess.page.goto(norm, wait_until="domcontentloaded")
+        sess.touch()
+
+    async def do_action(self, sess: Session, body: dict):
+        action = (body.get("action") or "").lower()
+        page = sess.page
+        async with sess.lock:
+            if action == "goto":
+                await self._navigate(sess, body.get("url", ""))
+            elif action == "click":
+                if body.get("selector"):
+                    await page.click(body["selector"], timeout=NAV_TIMEOUT_MS)
+                elif "x" in body and "y" in body:
+                    await page.mouse.click(float(body["x"]), float(body["y"]))
+                else:
+                    raise web.HTTPBadRequest(reason="click needs selector or x/y")
+            elif action == "type":
+                sel = body.get("selector")
+                text = body.get("text", "")
+                if sel:
+                    if body.get("clear"):
+                        await page.fill(sel, "")
+                    await page.type(sel, text, delay=20)
+                else:
+                    await page.keyboard.type(text, delay=20)
+            elif action == "key":
+                await page.keyboard.press(body.get("key", "Enter"))
+            elif action == "scroll":
+                amount = int(body.get("amount", 500))
+                if body.get("direction") == "up":
+                    amount = -amount
+                await page.mouse.wheel(0, amount)
+            elif action == "back":
+                await page.go_back(wait_until="domcontentloaded")
+            elif action == "forward":
+                await page.go_forward(wait_until="domcontentloaded")
+            elif action == "reload":
+                await page.reload(wait_until="domcontentloaded")
+            elif action == "wait":
+                if body.get("selector"):
+                    await page.wait_for_selector(
+                        body["selector"], timeout=int(body.get("timeout", 10000)))
+                else:
+                    await page.wait_for_timeout(int(body.get("ms", 1000)))
+            else:
+                raise web.HTTPBadRequest(reason=f"unknown action: {action}")
+            sess.touch()
+        return {"ok": True, "url": page.url, "title": await page.title()}
+
+    async def extract_dom(self, sess: Session):
+        """Simplified page model for the agent: text + links + inputs + buttons."""
+        sess.touch()
+        return await sess.page.evaluate(
+            """() => {
+                const clip = (s, n) => (s || '').trim().slice(0, n);
+                const vis = el => {
+                    const r = el.getBoundingClientRect();
+                    return r.width > 0 && r.height > 0;
+                };
+                const links = [...document.querySelectorAll('a[href]')]
+                    .filter(vis).slice(0, 60).map((a, i) => ({
+                        text: clip(a.innerText, 80), href: a.href, index: i + 1,
+                    })).filter(l => l.text);
+                const inputs = [...document.querySelectorAll('input,textarea,select')]
+                    .filter(vis).slice(0, 40).map(el => ({
+                        type: el.type || el.tagName.toLowerCase(),
+                        id: el.id || null, name: el.name || null,
+                        placeholder: el.placeholder || null,
+                    }));
+                const btnSel = el => el.id ? '#' + CSS.escape(el.id)
+                    : (el.name ? `[name="${el.name}"]` : null);
+                const buttons = [...document.querySelectorAll(
+                        'button,[role=button],input[type=submit],input[type=button]')]
+                    .filter(vis).slice(0, 40).map(el => ({
+                        text: clip(el.innerText || el.value, 60),
+                        selector: btnSel(el),
+                    })).filter(b => b.text);
+                return {
+                    url: location.href,
+                    title: document.title,
+                    text: clip(document.body ? document.body.innerText : '', 8000),
+                    links, inputs, buttons,
+                };
+            }"""
+        )
+
+    async def screenshot(self, sess: Session, full: bool):
+        sess.touch()
+        return await sess.page.screenshot(full_page=full, type="png")
+
+    # ── screencast relay ──────────────────────────────────────────────────────
+    async def _dispatch_frame(self, sess: Session, params: dict):
+        data = params.get("data")
+        session_id = params.get("sessionId")
+        # ACK so Chromium keeps sending frames.
+        try:
+            await sess.cdp.send("Page.screencastFrameAck", {"sessionId": session_id})
+        except Exception:
+            return
+        if not sess.viewers:
+            return
+        payload = json.dumps({
+            "type": "frame", "data": data,
+            "meta": params.get("metadata", {}),
+        })
+        dead = []
+        for ws in sess.viewers:
+            try:
+                await ws.send_str(payload)
+            except Exception:
+                dead.append(ws)
+        for ws in dead:
+            sess.viewers.discard(ws)
+
+    async def start_screencast(self, sess: Session):
+        if sess.screencasting:
+            return
+        await sess.cdp.send("Page.startScreencast", {
+            "format": "jpeg", "quality": SCREENCAST_QUALITY,
+            "maxWidth": DEFAULT_W, "maxHeight": DEFAULT_H, "everyNthFrame": 1,
+        })
+        sess.screencasting = True
+
+    async def stop_screencast(self, sess: Session):
+        if not sess.screencasting:
+            return
+        try:
+            await sess.cdp.send("Page.stopScreencast")
+        except Exception:
+            pass
+        sess.screencasting = False
+
+    # ── reaper ────────────────────────────────────────────────────────────────
+    async def reaper_loop(self):
+        while True:
+            await asyncio.sleep(30)
+            for tenant, sess in list(self.sessions.items()):
+                if sess.idle_s > IDLE_TIMEOUT_S:
+                    logger.info("reaping idle session tenant=%s idle=%.0fs",
+                                tenant, sess.idle_s)
+                    await self.stop_session(tenant)
+
+
+svc = BrowseService()
+
+
+# ── HTTP layer ──────────────────────────────────────────────────────────────
+def _auth_ok(request) -> bool:
+    if not SERVICE_KEY:
+        return True  # unset → open (single-node/dev); prod sets the key
+    return request.headers.get("X-Browse-Key", "") == SERVICE_KEY
+
+
+def _require_auth(request):
+    if not _auth_ok(request):
+        raise web.HTTPUnauthorized(reason="bad or missing X-Browse-Key")
+
+
+def _get_session(tenant: str) -> Session:
+    sess = svc.sessions.get(tenant)
+    if not sess:
+        raise web.HTTPNotFound(reason=f"no active session for tenant {tenant}")
+    return sess
+
+
+async def h_health(request):
+    return web.json_response({
+        "ok": True,
+        "sessions": len(svc.sessions),
+        "max_sessions": MAX_SESSIONS,
+        "mem_percent": psutil.virtual_memory().percent,
+    })
+
+
+async def h_start(request):
+    _require_auth(request)
+    body = await request.json()
+    tenant = (body.get("tenant") or "").strip()
+    if not tenant:
+        raise web.HTTPBadRequest(reason="tenant required")
+    if psutil.virtual_memory().percent > MEM_GUARD_PCT and tenant not in svc.sessions:
+        raise web.HTTPServiceUnavailable(reason="server memory pressure — try later")
+    ok, norm = _validate_url(body.get("url", "about:blank")
+                             if body.get("url") else "about:blank")
+    url = body.get("url") or "about:blank"
+    width = int(body.get("width", DEFAULT_W))
+    height = int(body.get("height", DEFAULT_H))
+    proxy = body.get("proxy") or None
+    sess = await svc.start_session(tenant, url, width, height, proxy)
+    return web.json_response({
+        "ok": True, "tenant": tenant,
+        "url": sess.page.url, "title": await sess.page.title(),
+    })
+
+
+async def h_action(request):
+    _require_auth(request)
+    body = await request.json()
+    sess = _get_session((body.get("tenant") or "").strip())
+    return web.json_response(await svc.do_action(sess, body))
+
+
+async def h_screenshot(request):
+    _require_auth(request)
+    sess = _get_session(request.query.get("tenant", "").strip())
+    png = await svc.screenshot(sess, full=request.query.get("full") == "1")
+    return web.Response(body=png, content_type="image/png")
+
+
+async def h_dom(request):
+    _require_auth(request)
+    sess = _get_session(request.query.get("tenant", "").strip())
+    return web.json_response(await svc.extract_dom(sess))
+
+
+async def h_status(request):
+    _require_auth(request)
+    sess = _get_session(request.query.get("tenant", "").strip())
+    return web.json_response({
+        "tenant": sess.tenant, "url": sess.page.url,
+        "title": await sess.page.title(),
+        "idle_s": round(sess.idle_s, 1),
+        "viewers": len(sess.viewers),
+        "screencasting": sess.screencasting,
+    })
+
+
+async def h_stop(request):
+    _require_auth(request)
+    body = await request.json()
+    await svc.stop_session((body.get("tenant") or "").strip())
+    return web.json_response({"ok": True})
+
+
+async def h_stream(request):
+    # Auth via header OR ?key= (WebSocket clients can't always set headers).
+    if SERVICE_KEY and request.query.get("key", "") != SERVICE_KEY \
+            and request.headers.get("X-Browse-Key", "") != SERVICE_KEY:
+        raise web.HTTPUnauthorized(reason="bad or missing key")
+    tenant = request.query.get("tenant", "").strip()
+    sess = _get_session(tenant)
+    ws = web.WebSocketResponse(heartbeat=20)
+    await ws.prepare(request)
+    sess.viewers.add(ws)
+    await svc.start_screencast(sess)
+    logger.info("viewer connected tenant=%s viewers=%d", tenant, len(sess.viewers))
+    try:
+        async for msg in ws:
+            if msg.type == WSMsgType.TEXT:
+                # Phase 2 (user-input passthrough) parses viewer events here.
+                # Phase 1 accepts + ignores them so the socket stays symmetric.
+                try:
+                    evt = json.loads(msg.data)
+                    if evt.get("type") == "ping":
+                        await ws.send_str(json.dumps({"type": "pong"}))
+                except Exception:
+                    pass
+            elif msg.type == WSMsgType.ERROR:
+                break
+    finally:
+        sess.viewers.discard(ws)
+        if not sess.viewers:
+            await svc.stop_screencast(sess)
+        logger.info("viewer gone tenant=%s viewers=%d", tenant, len(sess.viewers))
+    return ws
+
+
+async def on_startup(app):
+    await svc.startup()
+    app["reaper"] = asyncio.create_task(svc.reaper_loop())
+
+
+async def on_cleanup(app):
+    app["reaper"].cancel()
+    await svc.shutdown()
+
+
+def make_app():
+    app = web.Application(client_max_size=8 * 1024 * 1024)
+    app.add_routes([
+        web.get("/health", h_health),
+        web.post("/session/start", h_start),
+        web.post("/session/action", h_action),
+        web.get("/session/screenshot", h_screenshot),
+        web.get("/session/dom", h_dom),
+        web.get("/session/status", h_status),
+        web.post("/session/stop", h_stop),
+        web.get("/session/stream", h_stream),
+    ])
+    app.on_startup.append(on_startup)
+    app.on_cleanup.append(on_cleanup)
+    return app
+
+
+if __name__ == "__main__":
+    if not SERVICE_KEY:
+        logger.warning("BROWSE_SERVICE_KEY unset — running OPEN (dev mode)")
+    web.run_app(make_app(), host="0.0.0.0", port=PORT)

--- a/docs/jambot/co-browsing-system-overview.md
+++ b/docs/jambot/co-browsing-system-overview.md
@@ -1,0 +1,194 @@
+# Co-Browsing System — Overview & Phased Plan (issue #154)
+
+**Status (2026-07-19):** Phase 1 built (server-side browse service). Phases 2–5 designed, not yet built.
+
+Server-side co-browsing: a headless Chromium runs **on the VPS**, the agent drives it, and the user watches a **live video stream** of it inside a canvas page — voice stays active throughout. Because it streams frames (CDP screencast) instead of embedding the site, `X-Frame-Options`/CSP frame-blocking (which kills `[CANVAS_URL:]` on Amazon/Google/Facebook/etc.) does not apply. Any site works.
+
+## Why this exists — the three browsing lanes
+
+| Lane | Where the browser is | Who drives | Who watches | Needs install | Frame-block immune |
+|---|---|---|---|---|---|
+| **Browser Companion** (`[NAVIGATE:]`, `[CLICK:]`, `[START_TASK:]`) | user's **real** Chrome | agent, in the user's session | user (their own tabs) | Chrome extension | n/a (real browser) |
+| **`[CANVAS_URL:]` iframe** | user's browser iframe | user | user | none | ❌ blocked by most sites |
+| **Co-browsing (#154)** | **VPS** headless Chromium | agent | user (live stream) | **none** | ✅ yes |
+
+Co-browsing is the only lane that is both **zero-install for the user** (works from a phone) and **immune to frame-blocking**. It complements the extension (agent in *your* browser) by giving the agent *its own* browser you can watch from anywhere.
+
+Related upstream research (see "Alternatives considered" below): Steel Browser, Neko, Browserless — all self-hostable; we build a thin purpose-fit service instead of adopting a heavier framework, but the seams are there to swap later.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────┐
+│  User's browser (phone/desktop, no install)  │
+│   OpenVoiceUI — voice active                  │
+│   Canvas page: browse-viewer.html   [Phase 2] │
+│    <canvas> ← live JPEG frames                │
+│    URL bar · back/fwd/reload · agent cursor   │
+└───────────────┬─────────────────────────────┘
+                │ WSS  (frames ↓ · user events ↑)
+                ▼
+┌─────────────────────────────────────────────┐
+│  OVU container  routes/browse.py   [Phase 2]  │
+│   proxies /api/browse/* → jambot-browse       │
+│   injects tenant, enforces Clerk auth         │
+└───────────────┬─────────────────────────────┘
+                │ http (jambot-shared net)
+                ▼
+┌─────────────────────────────────────────────┐
+│  jambot-browse  container        [Phase 1 ✅] │
+│   aiohttp :8712                               │
+│   Playwright → headless Chromium              │
+│   1 BrowserContext per tenant (isolation)     │
+│   CDP Page.startScreencast → viewers          │
+│   SSRF guard · idle reaper · mem guard        │
+│   per-context proxy seam →  [Phase 4 masking] │
+└─────────────────────────────────────────────┘
+```
+
+**Deployment model:** singleton shared container on `jambot-shared`, exactly like `supertonic-tts` — NOT baked into each OVU image (Chromium is ~450MB; 26 copies is waste). Per-tenant isolation is by Playwright `BrowserContext` (separate cookies/storage), not separate containers.
+
+---
+
+## Phase 1 — Browse service container ✅ BUILT (2026-07-19)
+
+Files (in the OVU repo):
+- `deploy/browse-service/Dockerfile` — `mcr.microsoft.com/playwright/python:v1.48.0-noble` base (Chromium + libs bundled).
+- `deploy/browse-service/server.py` — aiohttp service, the whole Phase-1 surface.
+- `deploy/browse-service/requirements.txt`
+- `scripts/jambot-browse-service.sh` — `build|start|stop|restart|status|logs|smoke` (mirrors `jambot-supertonic.sh`).
+
+**API (all endpoints require `X-Browse-Key`; `/health` is open):**
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/session/start` | `{tenant,url,[width,height],[proxy]}` — start/replace a tenant's session |
+| POST | `/session/action` | `{tenant,action,...}` — `goto·click·type·key·scroll·back·forward·reload·wait` |
+| GET | `/session/screenshot?tenant=&[full=1]` | PNG bytes for agent vision |
+| GET | `/session/dom?tenant=` | `{url,title,text,links,inputs,buttons}` simplified page model |
+| GET | `/session/status?tenant=` | url, title, idle_s, viewers, screencasting |
+| POST | `/session/stop` | `{tenant}` — close context, free memory |
+| WS | `/session/stream?tenant=&key=` | live base64-JPEG frames + events (auth via `?key=` since WS can't set headers) |
+| GET | `/health` | `{ok,sessions,max_sessions,mem_percent}` |
+
+**Guards baked in Phase 1:**
+- **SSRF** — every navigation URL is DNS-resolved; refused if any A/AAAA record is private/loopback/link-local/reserved/multicast (blocks `169.254.169.254` cloud-metadata and sibling containers). http/https only.
+- **Session cap** (`BROWSE_MAX_SESSIONS`, default 6) — new session over cap evicts the most-idle one.
+- **Idle reaper** (`BROWSE_IDLE_TIMEOUT_S`, default 300s) — background task closes stale contexts.
+- **Memory guard** (`BROWSE_MEM_GUARD_PCT`, default 85) — refuses *new* tenants under system memory pressure.
+- **Auth** — shared secret `BROWSE_SERVICE_KEY` (from `.platform-keys.env`); runs OPEN only if unset (dev).
+- **Per-tenant lock** — actions on one session serialize; one session per tenant (starting a new one replaces the old).
+
+**The `proxy` seam:** `/session/start` accepts an optional `proxy` object `{server,username,password}` passed straight to `browser.new_context(proxy=…)`. Phase 4 (IP masking) populates it per-tenant; **nothing in `server.py` changes** — the seam already exists.
+
+**Run it:**
+```bash
+bash scripts/jambot-browse-service.sh build
+bash scripts/jambot-browse-service.sh start
+bash scripts/jambot-browse-service.sh smoke     # start example.com, dom, screenshot, stop
+```
+
+**Not in Phase 1 (by design):** no OVU wiring, no canvas page, no `[BROWSE:]` tag, no user-input-into-stream, no multi-tab, no proxy provider. Those are Phases 2–5. Phase 1 is independently testable via the `smoke` subcommand.
+
+---
+
+## Phase 2 — OVU wiring + viewer page (agent browses, user watches)
+
+**Goal:** end-to-end demo — user says "go to X", agent browses on the VPS, user watches live.
+
+1. **`routes/browse.py`** (new OVU blueprint) — thin proxy to `jambot-browse`:
+   - `POST /api/browse/start|action|stop`, `GET /api/browse/screenshot|dom|status`, `WS /api/browse/stream`.
+   - Injects the tenant name (from `JAMBOT_TENANT`/`TENANT_NAME`) so the browser client never chooses its own tenant. Enforces Clerk auth via the existing `before_request` gate (agent key allowed for non-admin, like `/api/conversation`).
+   - Reads `BROWSE_SERVICE_URL=http://jambot-browse:8712` + `BROWSE_SERVICE_KEY` from env.
+2. **`default-pages/browse-viewer.html`** — canvas page (inline CSS, no CDN, dual-layout, auth bridge per canvas rules):
+   - `<canvas>` renders base64 JPEG frames from `/api/browse/stream`.
+   - URL bar (current page + title), back/forward/reload/stop controls.
+   - "Agent is browsing…" / "Loading…" / connection-health indicators.
+   - Agent-cursor overlay: draw a marker at the last agent click coords (from action echoes).
+3. **`[BROWSE:url]` tag** in `app.js` — parsed alongside `[CANVAS_URL:]`; resolves via existing IP-block helper, `POST /api/browse/start`, then opens `browse-viewer` in the canvas.
+4. **Agent context** — voice-system-prompt section documenting `[BROWSE:url]`: after starting, the agent works the page via a tool loop calling `/api/browse/screenshot` (vision) + `/api/browse/action`. Mirror the browser-companion tag discipline (words with every tag).
+5. **Compose + provisioning** — add `BROWSE_SERVICE_URL`/`BROWSE_SERVICE_KEY` to the OVU service env in `templates/docker-compose.yml`; ensure OVU is on `jambot-shared` (it already is for TTS). No per-tenant container.
+
+**Deliverable:** "Open Amazon and find a blue widget" → live stream in canvas, agent clicks/types, user watches. One tenant (test-dev) first.
+
+---
+
+## Phase 3 — User input passthrough (user acts in the stream)
+
+**Goal:** user can click/type into the live view; agent sees the result.
+
+- `browse-viewer.html`: capture canvas clicks → map display coords → true page coords (account for scale) → send `{type:"user_click",x,y}` up the WS. Capture keystrokes when focused → `{type:"user_type",text}`.
+- `server.py` `h_stream`: parse those viewer events (Phase 1 already accepts+ignores them) → apply via `page.mouse.click` / `page.keyboard.type`. Rate-limit + same per-session lock so agent + user actions don't interleave mid-action.
+- Turn-taking indicator in the viewer ("You have control" / "Agent is acting").
+- Agent is notified of user-initiated navigation on its next turn (URL/title delta in context).
+
+---
+
+## Phase 4 — IP masking / residential egress (anti-block)
+
+**Goal:** the VPS's datacenter IP is the #1 reason real sites (Cloudflare, retail, social) block or captcha a server-side browser. Route egress through a residential/ISP IP so co-browsing behaves like a real user.
+
+The Phase-1 `proxy` seam makes this a **config + provider** change, not a rewrite. See the dedicated research section below for provider choice. Plan:
+- Add `BROWSE_PROXY_*` config; when set, `routes/browse.py` passes a per-tenant `proxy` object to `/session/start`.
+- Prefer **sticky sessions** (same exit IP for a session's lifetime) so multi-step flows don't trip mid-task IP changes.
+- Pair with a stealth profile (see research) — a clean residential IP with stock headless Chromium still fails automation-protocol fingerprint checks on the hardest targets. Realistic scope: works everywhere for "watch the agent read a page"; the hardest bot-walled flows (login-gated retail checkout) remain best-effort.
+- **Directory/citation policy still applies** (memory `feedback_never_touch_google_business_profiles`): masking is for *browsing/rendering*, never for touching banned identity platforms (GMB, Facebook, Yelp, BBB…).
+- Cost control: residential proxies bill per-GB; screencast frames are server-side only (they do NOT traverse the proxy — only the page's own network egress does), so a browsing session is ~the page's real byte weight. Add a per-tenant GB budget + the existing memory/idle guards.
+
+---
+
+## Phase 5 — Multi-tab + polish
+
+- Server browser supports multiple pages per context; viewer gets a tab strip; `[BROWSE_TAB:]` / action `{action:"new_tab"|"switch_tab"|"close_tab"}`.
+- Download capture (agent grabs a file the page serves) → land in the tenant's uploads, same as extension `[DOWNLOAD_IMAGE]`.
+- Screencast tuning: adaptive quality/FPS on the memory guard; pause screencast when no viewer is attached (Phase 1 already stops the cast when the last viewer disconnects).
+- Health wired into JamFlow + `jambot-health-monitor.sh` (container up + `/health` sessions count), and a node on the JamFlow board.
+
+---
+
+## Alternatives considered (research 2026-07-19)
+
+Instead of building `server.py` we could adopt an existing self-hostable browser-as-a-service. Evaluated:
+
+| Option | What it is | Fit | Why we didn't adopt (yet) |
+|---|---|---|---|
+| **[Steel Browser](https://github.com/steel-dev/steel-browser)** (Apache-2.0) | Batteries-included browser API for AI agents: session mgmt, CDP over WS, `/scrape`·`/screenshot`·`/pdf`, **built-in live session viewer**, stealth/fingerprint options, self-host Docker (`:3000` API, `:5173` UI, `:9223` CDP). | **Strong.** Closest to #154 out of the box — the live viewer + CDP + anti-detect are exactly Phases 1/3/4. | Heavier surface than we need per-tenant; its viewer is a debug UI, not our canvas UX. **Revisit as the Phase-1 engine swap** if our thin service hits limits — our `routes/browse.py` proxy boundary means we could point it at Steel with little churn. |
+| **[Neko](https://github.com/m1k1o/neko)** | Self-hosted virtual browser streamed via **WebRTC**, multi-user shared control. | Good for *human* watch-party co-browsing. | WebRTC is heavier than CDP JPEG for our "agent drives, user watches" model; agent-control API is not its focus. |
+| **Browserless** | Headless Chrome farm, CDP/WS, connection pooling. | Good engine. | No live viewer; more scraping-farm than co-browse; commercial tilt. |
+| **Custom (chosen)** | Thin aiohttp + Playwright, CDP screencast. | Exact-fit, ~450 LOC, no extra moving parts, our auth/SSRF/tenant model native. | We own it — but the proxy + engine seams keep Steel/Neko swappable. |
+
+**Recommendation:** ship the custom service (done, Phase 1). If Phase 4 anti-detection proves hard, adopt **Steel Browser** as the engine behind the same `routes/browse.py` proxy rather than hand-rolling stealth.
+
+### IP-masking / residential-proxy research (for Phase 4)
+
+Datacenter IP is the core blocker. Pay-as-you-go residential proxy pricing, May–July 2026:
+
+| Provider | PAYG $/GB | Notes |
+|---|---|---|
+| **[DataImpulse](https://dataimpulse.com)** | **~$1/GB** | cheapest first-party residential, non-expiring traffic — best budget entry |
+| **[IPRoyal](https://iproyal.com)** | ~$1.75/GB (sub) | efficient for bursty mid-volume |
+| **[Decodo](https://decodo.com)** (ex-Smartproxy) | ~$4/GB | best price/quality in benchmarks, rivals top tier |
+| **Bright Data** | $4/GB (promo, list $8) | largest pool, SLAs, enterprise add-ons |
+| **Oxylabs** | $6→$2.50/GB (tiered) | enterprise, big pool |
+
+**Stealth layer** (IP alone isn't enough — clean IP + stock headless still fails the hardest checks). 2026 benchmark leaders:
+- **[Camoufox](https://camoufox.com)** — Firefox fork, C++-level stealth patches, ~0% headless-detection on standard tests. Best fingerprint stealth; but it's Firefox (not our Chromium/Playwright-Chromium path).
+- **[Patchright](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright)** — undetected Playwright/Chromium fork, CDP-leak patches; **drop-in for our Playwright code**. Best fit for a Chromium-based swap.
+- **rebrowser-playwright** — Playwright fork with CDP-leak patches (older Chromium).
+
+Key finding: *"a rebrowser/Patchright session from a clean residential IP passes more checks than a stock session from a datacenter IP"* — so **residential proxy first, stealth-fork second**. For our use (agent reads/browses a page the user watches) residential egress alone clears the vast majority; reserve Patchright/Camoufox for specific bot-walled targets.
+
+**Phase-4 starter recommendation:** DataImpulse or IPRoyal PAYG (~$1–1.75/GB) with **sticky sessions**, wired through the existing `proxy` seam; add Patchright only if stock Chromium + residential IP still trips a target we need.
+
+---
+
+## Operational notes
+
+- **Container:** `jambot-browse` on `jambot-shared`, `jambot/browse:latest`, 3GB / 1.5 CPU / 1GB shm cap.
+- **Reach:** fleet → `http://jambot-browse:8712` (internal only; not nginx-exposed).
+- **Restart/manage:** `bash scripts/jambot-browse-service.sh {start|stop|restart|status|logs|smoke}`.
+- **Auth key:** `BROWSE_SERVICE_KEY` in `/mnt/system/base/.platform-keys.env` (add before any non-dev exposure).
+- **Disk:** image is ~1.8GB (Playwright base). Counts toward `/mnt/system` — prune build cache after building (`docker builder prune -af`, playbook pb-20260715-001).
+- **Update this doc** in the same commit as any co-browsing change (per the overview-doc rule in CLAUDE.md).


### PR DESCRIPTION
Phase 1 of #154. Server-side co-browsing engine — the missing third browsing lane.

## Why
Two lanes exist today and neither does what #154 needs: the Chrome-extension **Browser Companion** (`[NAVIGATE:]`/`[CLICK:]`) drives the *user's* browser but needs the extension installed and the user's machine on; `[CANVAS_URL:]` iframe embedding is **frame-blocked** by most real sites (Amazon/Google/Facebook send `X-Frame-Options`/CSP). This adds the lane that is both **zero-install** (works from a phone) and **frame-block-immune**: a headless Chromium on the VPS the agent drives, streamed live to the user as CDP screencast frames.

## What's in Phase 1 (`deploy/browse-service/`)
Standalone shared container (`jambot/browse`), singleton on `jambot-shared`, same pattern as `supertonic-tts` — **not** baked into each OVU image (Chromium ~450MB × 26 = waste). Per-tenant isolation via Playwright `BrowserContext`.

- `server.py` — aiohttp API: `POST /session/start|action|stop`, `GET /session/screenshot|dom|status`, `WS /session/stream` (base64 JPEG screencast relay).
- Guards: **SSRF** (DNS-resolves every nav target, refuses private/loopback/link-local/reserved incl. `169.254.169.254` cloud-metadata), session cap + most-idle eviction, idle reaper, system-memory guard, shared-secret auth, per-tenant action lock.
- **`proxy` seam** pre-wired (`browser.new_context(proxy=…)`) so Phase 4 IP-masking is config-only — no `server.py` change later.
- `Dockerfile` (Playwright base) + `requirements.txt`. Managed by `scripts/jambot-browse-service.sh` (build/start/stop/status/logs/smoke, in the MIKE-AI ops repo).

## Verification (live, this session)
Built `jambot/browse:latest`, started the container, ran functional + adversarial smoke:
- ✅ real headless browse of example.com → `title: Example Domain`
- ✅ DOM extract (text/links/inputs/buttons), 18KB valid PNG screenshot, scroll action
- ✅ live screencast WS delivered a real 16KB JPEG frame (the co-browsing core)
- ✅ all three SSRF attacks refused 400: `169.254.169.254`, `127.0.0.1`, `10.0.0.5`

## Not in this PR (by design — see the overview doc)
No OVU wiring, `[BROWSE:]` tag, viewer canvas page, user-input passthrough, IP masking, or multi-tab — those are Phases 2–5, fully specced in `docs/jambot/co-browsing-system-overview.md`, which also carries the alternatives matrix (Steel Browser / Neko / Browserless — Steel flagged as the drop-in engine swap behind our proxy boundary) and the residential-proxy + stealth-fork research for Phase 4.

Phase 1 is independently testable via `bash scripts/jambot-browse-service.sh smoke`.

Refs #154.