### PR TITLE
feat: co-browsing Phase 2 — OVU wiring + live viewer (#154)

### DIFF
--- a/app.py
+++ b/app.py
@@ -222,6 +222,8 @@ def create_app(config_override: dict = None):
             '/ws/clawdbot',     # WebSocket — browsers can't send Clerk token in WS headers;
                                 # handler secures itself via CLAWDBOT_AUTH_TOKEN to the gateway
             '/openclaw-ui',     # WebSocket upgrade for OpenClaw Control UI proxy (no trailing slash)
+            '/ws/browse-stream', # WebSocket — co-browsing screencast (#154); handler self-auths
+                                 # via Clerk token + injects the service key server-side
         }
 
         # Detect whether Clerk auth is configured at startup.

--- a/default-pages/browse-viewer.html
+++ b/default-pages/browse-viewer.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Co-Browsing</title>
+<!--
+  Co-browsing live viewer (issue #154, Phase 2).
+  Renders the agent's server-side browser as a live JPEG stream from
+  /ws/browse-stream, with a URL bar + nav controls. Voice stays active in the
+  parent app. Inline CSS/JS only (canvas sandbox rules) — no CDN.
+  Phase 3 will enable the user click/type capture stubbed at the bottom.
+-->
+<style>
+  :root{
+    --bg:#0d1117; --panel:#161b22; --line:#232a33; --text:#e6edf3;
+    --muted:#8b949e; --accent:#3b82f6; --ok:#2ea043; --warn:#f59e0b; --err:#f85149;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;height:100%}
+  body{
+    background:var(--bg); color:var(--text);
+    font:14px/1.4 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+    display:flex; flex-direction:column; height:100vh; overflow:hidden;
+  }
+  /* Toolbar */
+  .bar{
+    display:flex; align-items:center; gap:8px; padding:8px 10px;
+    background:var(--panel); border-bottom:1px solid var(--line); flex:0 0 auto;
+  }
+  .nav-btn{
+    width:34px; height:34px; border:1px solid var(--line); background:#1c232c;
+    color:var(--text); border-radius:8px; cursor:pointer; font-size:15px;
+    display:flex; align-items:center; justify-content:center; flex:0 0 auto;
+  }
+  .nav-btn:hover{border-color:var(--accent)}
+  .nav-btn:active{transform:translateY(1px)}
+  .url{
+    flex:1 1 auto; min-width:0; height:34px; padding:0 12px;
+    background:#0b1017; border:1px solid var(--line); border-radius:8px;
+    color:var(--text); font-size:13px; outline:none;
+  }
+  .url:focus{border-color:var(--accent)}
+  .dot{width:9px;height:9px;border-radius:50%;background:var(--muted);flex:0 0 auto}
+  .dot.live{background:var(--ok);box-shadow:0 0 8px var(--ok)}
+  .dot.load{background:var(--warn)}
+  .dot.dead{background:var(--err)}
+  /* Stage */
+  .stage{
+    position:relative; flex:1 1 auto; background:#000; overflow:hidden;
+    display:flex; align-items:center; justify-content:center;
+  }
+  canvas{max-width:100%; max-height:100%; display:block; image-rendering:auto}
+  .cursor{
+    position:absolute; width:22px; height:22px; margin:-11px 0 0 -11px;
+    border:2px solid var(--accent); border-radius:50%;
+    background:rgba(59,130,246,.25); pointer-events:none;
+    transition:left .12s ease,top .12s ease; opacity:0; z-index:5;
+  }
+  .status{
+    position:absolute; left:50%; top:50%; transform:translate(-50%,-50%);
+    color:var(--muted); text-align:center; padding:20px; z-index:2;
+  }
+  .status .title{font-size:16px;color:var(--text);margin-bottom:6px}
+  .spin{
+    width:34px;height:34px;margin:0 auto 14px;border:3px solid var(--line);
+    border-top-color:var(--accent);border-radius:50%;animation:sp 1s linear infinite;
+  }
+  @keyframes sp{to{transform:rotate(360deg)}}
+  .foot{
+    flex:0 0 auto; padding:5px 10px; background:var(--panel);
+    border-top:1px solid var(--line); color:var(--muted); font-size:12px;
+    display:flex; align-items:center; gap:8px; min-height:28px;
+  }
+  .pill{padding:2px 8px;border:1px solid var(--line);border-radius:20px}
+</style>
+</head>
+<body>
+  <div class="bar">
+    <button class="nav-btn" id="back" title="Back">&#8592;</button>
+    <button class="nav-btn" id="fwd" title="Forward">&#8594;</button>
+    <button class="nav-btn" id="reload" title="Reload">&#8635;</button>
+    <span class="dot" id="dot"></span>
+    <input class="url" id="url" placeholder="https://…" spellcheck="false" autocomplete="off">
+    <button class="nav-btn" id="go" title="Go">&#10148;</button>
+    <button class="nav-btn" id="stop" title="Stop session">&#10005;</button>
+  </div>
+
+  <div class="stage">
+    <canvas id="screen" width="1280" height="800"></canvas>
+    <div class="cursor" id="cursor"></div>
+    <div class="status" id="status">
+      <div class="spin"></div>
+      <div class="title">Connecting to the browser…</div>
+      <div>The agent's live view will appear here.</div>
+    </div>
+  </div>
+
+  <div class="foot">
+    <span class="pill" id="state">idle</span>
+    <span id="pagetitle"></span>
+    <span style="margin-left:auto" id="fps"></span>
+  </div>
+
+<script>
+(function(){
+  "use strict";
+  var API = "";                       // same-origin
+  var canvas = document.getElementById("screen");
+  var ctx = canvas.getContext("2d");
+  var img = new Image();
+  var $ = function(id){ return document.getElementById(id); };
+  var frames = 0, lastFpsT = Date.now();
+  var scale = 1, offX = 0, offY = 0;  // canvas→page coordinate mapping
+
+  function setState(cls, label){
+    $("dot").className = "dot" + (cls ? " " + cls : "");
+    if (label) $("state").textContent = label;
+  }
+  function hideStatus(){ $("status").style.display = "none"; }
+  function showStatus(title, sub){
+    var s = $("status"); s.style.display = "";
+    s.querySelector(".title").textContent = title;
+    if (sub !== undefined) s.querySelectorAll("div")[2].textContent = sub;
+  }
+
+  // ── draw incoming JPEG frames ─────────────────────────────────────────────
+  img.onload = function(){
+    if (canvas.width !== img.naturalWidth || canvas.height !== img.naturalHeight){
+      canvas.width = img.naturalWidth; canvas.height = img.naturalHeight;
+    }
+    ctx.drawImage(img, 0, 0);
+    hideStatus(); setState("live", "live");
+    frames++;
+    var now = Date.now();
+    if (now - lastFpsT >= 1000){
+      $("fps").textContent = frames + " fps";
+      frames = 0; lastFpsT = now;
+    }
+  };
+
+  // ── screencast WebSocket ──────────────────────────────────────────────────
+  var ws = null, reconnectT = null;
+  function connect(){
+    var proto = location.protocol === "https:" ? "wss:" : "ws:";
+    ws = new WebSocket(proto + "//" + location.host + "/ws/browse-stream");
+    ws.onopen = function(){ setState("load", "streaming"); };
+    ws.onmessage = function(ev){
+      var m; try { m = JSON.parse(ev.data); } catch(e){ return; }
+      if (m.type === "frame" && m.data){
+        img.src = "data:image/jpeg;base64," + m.data;
+        if (m.meta){ // CDP metadata → coordinate mapping for cursor + clicks
+          mapMeta(m.meta);
+        }
+      } else if (m.type === "error"){
+        setState("dead", "disconnected"); showStatus("Session ended", m.message || "");
+      }
+    };
+    ws.onclose = function(){
+      setState("dead", "offline");
+      if (!reconnectT) reconnectT = setTimeout(function(){ reconnectT=null; connect(); }, 2000);
+    };
+    ws.onerror = function(){ try { ws.close(); } catch(e){} };
+  }
+
+  function mapMeta(meta){
+    // CDP screencast metadata gives device viewport offset/scale; used to place
+    // the agent cursor and (Phase 3) translate user clicks to page coords.
+    if (typeof meta.pageScaleFactor === "number" && meta.pageScaleFactor > 0)
+      scale = meta.pageScaleFactor;
+    if (typeof meta.offsetTop === "number") offY = meta.offsetTop;
+  }
+
+  // ── HTTP control helpers ──────────────────────────────────────────────────
+  function post(path, body){
+    return fetch(API + path, {
+      method:"POST", headers:{"Content-Type":"application/json"},
+      body: JSON.stringify(body||{})
+    }).then(function(r){ return r.json().catch(function(){ return {}; }); });
+  }
+  function act(a, extra){
+    var b = Object.assign({action:a}, extra||{});
+    setState("load", a);
+    return post("/api/browse/action", b).then(function(res){
+      if (res && res.url) $("url").value = res.url;
+      if (res && res.title) $("pagetitle").textContent = res.title;
+      setState("live", "live");
+      return res;
+    });
+  }
+
+  // ── controls ──────────────────────────────────────────────────────────────
+  $("back").onclick   = function(){ act("back"); };
+  $("fwd").onclick    = function(){ act("forward"); };
+  $("reload").onclick = function(){ act("reload"); };
+  $("go").onclick     = function(){ navigate(); };
+  $("url").addEventListener("keydown", function(e){ if (e.key === "Enter") navigate(); });
+  $("stop").onclick   = function(){
+    post("/api/browse/stop", {}).then(function(){
+      showStatus("Session stopped", "Ask the agent to browse again to restart.");
+      setState("dead", "stopped");
+      // let the parent app close the canvas if it wants
+      try { window.parent.postMessage({type:"canvas-action", action:"close"}, "*"); } catch(e){}
+    });
+  };
+  function navigate(){
+    var u = $("url").value.trim();
+    if (!u) return;
+    if (!/^https?:\/\//i.test(u)) u = "https://" + u;
+    act("goto", {url:u});
+  }
+
+  // ── user click passthrough — STUB (Phase 3) ──────────────────────────────
+  // Phase 3 maps canvas coords → true page coords and sends
+  // {type:"user_click",x,y} up the WS. Wired but inert in Phase 2.
+  var USER_INPUT_ENABLED = false;
+  canvas.addEventListener("click", function(e){
+    if (!USER_INPUT_ENABLED || !ws || ws.readyState !== 1) return;
+    var rect = canvas.getBoundingClientRect();
+    var x = (e.clientX - rect.left) * (canvas.width / rect.width);
+    var y = (e.clientY - rect.top) * (canvas.height / rect.height);
+    ws.send(JSON.stringify({type:"user_click", x:Math.round(x), y:Math.round(y)}));
+  });
+
+  // ── init ──────────────────────────────────────────────────────────────────
+  post("/api/browse/status", {}); // warm; ignore result
+  fetch(API + "/api/browse/status").then(function(r){ return r.json(); })
+    .then(function(s){ if (s && s.url){ $("url").value = s.url; $("pagetitle").textContent = s.title||""; } })
+    .catch(function(){});
+  connect();
+})();
+</script>
+</body>
+</html>

--- a/docs/jambot/co-browsing-system-overview.md
+++ b/docs/jambot/co-browsing-system-overview.md
@@ -1,6 +1,6 @@
 # Co-Browsing System — Overview & Phased Plan (issue #154)
 
-**Status (2026-07-19):** Phase 1 built (server-side browse service). Phases 2–5 designed, not yet built.
+**Status (2026-07-19):** Phase 1 + Phase 2 built (server-side browse service + OVU wiring + live viewer). Phases 3–5 designed, not yet built.
 
 Server-side co-browsing: a headless Chromium runs **on the VPS**, the agent drives it, and the user watches a **live video stream** of it inside a canvas page — voice stays active throughout. Because it streams frames (CDP screencast) instead of embedding the site, `X-Frame-Options`/CSP frame-blocking (which kills `[CANVAS_URL:]` on Amazon/Google/Facebook/etc.) does not apply. Any site works.
 
@@ -94,24 +94,24 @@ bash scripts/jambot-browse-service.sh smoke     # start example.com, dom, screen
 
 ---
 
-## Phase 2 — OVU wiring + viewer page (agent browses, user watches)
+## Phase 2 — OVU wiring + viewer page (agent browses, user watches) ✅ BUILT (2026-07-19)
 
-**Goal:** end-to-end demo — user says "go to X", agent browses on the VPS, user watches live.
+**Goal:** end-to-end — user says "go to X", agent browses on the VPS, user watches live.
 
-1. **`routes/browse.py`** (new OVU blueprint) — thin proxy to `jambot-browse`:
-   - `POST /api/browse/start|action|stop`, `GET /api/browse/screenshot|dom|status`, `WS /api/browse/stream`.
-   - Injects the tenant name (from `JAMBOT_TENANT`/`TENANT_NAME`) so the browser client never chooses its own tenant. Enforces Clerk auth via the existing `before_request` gate (agent key allowed for non-admin, like `/api/conversation`).
-   - Reads `BROWSE_SERVICE_URL=http://jambot-browse:8712` + `BROWSE_SERVICE_KEY` from env.
-2. **`default-pages/browse-viewer.html`** — canvas page (inline CSS, no CDN, dual-layout, auth bridge per canvas rules):
-   - `<canvas>` renders base64 JPEG frames from `/api/browse/stream`.
-   - URL bar (current page + title), back/forward/reload/stop controls.
-   - "Agent is browsing…" / "Loading…" / connection-health indicators.
-   - Agent-cursor overlay: draw a marker at the last agent click coords (from action echoes).
-3. **`[BROWSE:url]` tag** in `app.js` — parsed alongside `[CANVAS_URL:]`; resolves via existing IP-block helper, `POST /api/browse/start`, then opens `browse-viewer` in the canvas.
-4. **Agent context** — voice-system-prompt section documenting `[BROWSE:url]`: after starting, the agent works the page via a tool loop calling `/api/browse/screenshot` (vision) + `/api/browse/action`. Mirror the browser-companion tag discipline (words with every tag).
-5. **Compose + provisioning** — add `BROWSE_SERVICE_URL`/`BROWSE_SERVICE_KEY` to the OVU service env in `templates/docker-compose.yml`; ensure OVU is on `jambot-shared` (it already is for TTS). No per-tenant container.
+Files:
+- **`routes/browse.py`** (new blueprint) — thin proxy to `jambot-browse`:
+  - `POST /api/browse/start|action|stop`, `GET /api/browse/screenshot|dom|status`, `GET /browse-viewer`.
+  - Injects THIS tenant (from `JAMBOT_TENANT`/`TENANT_NAME`) so a browser client can only ever watch its own tenant's session. Rides the existing `before_request` gate (Clerk or agent key). Adds the service key server-side (never sent to the browser).
+  - Keeps a per-process **latest browse state** (`get_browse_state()`) refreshed on every start/action — the source for `[BROWSE_STATE]`.
+- **`server.py` `/ws/browse-stream`** (flask-sock) — bridges the browser viewer to the browse service's CDP screencast WS (`websockets.connect` upstream). Frames down, viewer events up (Phase 3 consumes them). Clerk-gated; tenant + key injected server-side.
+- **`default-pages/browse-viewer.html`** — canvas viewer (inline CSS/JS, no CDN): `<canvas>` renders base64 JPEG frames, URL bar + back/forward/reload/go/stop, live/loading/offline dot, fps, agent-cursor overlay, and a **stubbed** user-click capture (`USER_INPUT_ENABLED=false`) that Phase 3 flips on. Served at `/browse-viewer`.
+- **`src/app.js`** — `[BROWSE:url]` (resolve → `POST /api/browse/start` → open `/browse-viewer` in the canvas iframe) and `[BROWSE_ACTION:{…}]` (brace-walk extract → `POST /api/browse/action`). Both stripped from displayed text (regex chain + shared `strip()`).
+- **`routes/conversation.py`** — injects `[BROWSE_STATE: …]` (url, title, visible-text digest, links, buttons) into the agent's per-turn context **only while a session is active** — text-sight so the agent navigates without a screenshot round-trip. Tag docs added to `voice-system-prompt.md` + the fallback constant.
+- **`templates/docker-compose.yml`** — `BROWSE_SERVICE_URL` + `BROWSE_SERVICE_KEY` on the OVU service (OVU is already on `jambot-shared` for TTS). No per-tenant container.
 
-**Deliverable:** "Open Amazon and find a blue widget" → live stream in canvas, agent clicks/types, user watches. One tenant (test-dev) first.
+**Agent loop:** user asks → agent emits `[BROWSE:url]` (+ words) → viewer opens, user watches → next turn the agent reads `[BROWSE_STATE]` → emits `[BROWSE_ACTION:{…}]` to click/type/scroll → repeat. Full screenshot→vision (image to the LLM) is the Phase 3 upgrade; Phase 2 sight is the DOM digest.
+
+**Deliverable met:** "go to X and find Y" → live stream in the canvas, agent drives, user watches. Verify on test-dev first (needs `jambot-browse` running + OVU env wired).
 
 ---
 

--- a/prompts/voice-system-prompt.md
+++ b/prompts/voice-system-prompt.md
@@ -81,6 +81,20 @@ External links that open new tab: <a href="https://example.com" target="_blank">
 
 ---
 
+CO-BROWSING (browse a real website on the server while the user watches live):
+[BROWSE:https://example.com] starts a server-side browser at that URL and opens the live viewer in the canvas — the user watches every action in real time. Use this when the user asks you to go to a real website, look something up on a specific site, or browse for them (e.g. "go to amazon and find a blue widget"). Unlike [CANVAS_URL:] (which just loads a site in an iframe and often fails on sites that block embedding), [BROWSE:] works on any site because it streams the browser, not the page.
+After starting, you SEE the page via a [BROWSE_STATE: ...] tag that appears in the next message (current url, title, visible text, links, buttons). Drive the browser by emitting action tags:
+[BROWSE_ACTION:{"action":"click","selector":"#search"}] — click an element by CSS selector (or {"action":"click","x":500,"y":300} for coordinates)
+[BROWSE_ACTION:{"action":"type","selector":"input[name=q]","text":"blue widget","clear":true}] — type into a field
+[BROWSE_ACTION:{"action":"key","key":"Enter"}] — press a key
+[BROWSE_ACTION:{"action":"scroll","direction":"down","amount":600}] — scroll
+[BROWSE_ACTION:{"action":"goto","url":"https://..."}] — navigate to a new URL
+[BROWSE_ACTION:{"action":"back"}] / {"action":"forward"} / {"action":"reload"} — navigation
+[BROWSE_ACTION:{"action":"wait","selector":".results","timeout":10000}] — wait for an element
+ALWAYS say what you are doing in words alongside the tag (the tag is silent). Work step by step: act, read the new [BROWSE_STATE], then decide the next action. Only browse when the user asks.
+
+---
+
 CANVAS — MAKE A PAGE PUBLIC (shareable without login):
 exec("curl -s -X PATCH http://localhost:5001/api/canvas/manifest/page/PAGE_ID -H 'Content-Type: application/json' -d '{\"is_public\": true}'")
 Replace PAGE_ID with the page filename without .html extension.

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -1,0 +1,204 @@
+"""
+routes/browse.py — OpenVoiceUI ↔ co-browsing service bridge (issue #154, Phase 2).
+
+Thin proxy from OVU to the shared `jambot-browse` container (Phase 1). Three roles:
+
+  1. HTTP proxy for the agent + frontend: /api/browse/start|action|stop|screenshot|dom|status
+     — injects THIS tenant (the browser client never picks its own tenant) and the
+     shared-secret key, and forwards to http://jambot-browse:8712.
+  2. Serves the viewer canvas page at /browse-viewer (default-pages/browse-viewer.html).
+  3. Keeps the per-process "latest browse state" (url/title/dom digest) so the
+     conversation route can inject a compact [BROWSE_STATE: …] into the agent's next
+     turn — text-sight so the agent can navigate without a full screenshot round-trip.
+
+The live video path (CDP screencast) is a WebSocket, which flask-sock owns in
+server.py — see `/ws/browse-stream` there. This module is HTTP + page serving only.
+
+Auth: these routes ride the app's normal `before_request` gate (Clerk session or
+the internal agent key for non-admin calls), same as /api/conversation. The
+upstream service key (BROWSE_SERVICE_KEY) is added here, server-side only — it is
+never exposed to the browser.
+"""
+import logging
+import os
+import threading
+import time
+
+import requests
+from flask import Blueprint, Response, jsonify, request
+
+from services.paths import DEFAULT_PAGES_DIR
+
+logger = logging.getLogger(__name__)
+
+browse_bp = Blueprint("browse", __name__)
+
+BROWSE_SERVICE_URL = os.getenv("BROWSE_SERVICE_URL", "http://jambot-browse:8712").rstrip("/")
+BROWSE_SERVICE_KEY = os.getenv("BROWSE_SERVICE_KEY", "").strip()
+_TIMEOUT = float(os.getenv("BROWSE_PROXY_TIMEOUT_S", "45"))
+
+
+def _tenant() -> str:
+    """This OVU instance's tenant — the co-browsing session is keyed on it."""
+    return (os.getenv("JAMBOT_TENANT") or os.getenv("TENANT_NAME") or "default").strip()
+
+
+def _svc_headers() -> dict:
+    h = {"Content-Type": "application/json"}
+    if BROWSE_SERVICE_KEY:
+        h["X-Browse-Key"] = BROWSE_SERVICE_KEY
+    return h
+
+
+# ── Per-tenant latest browse state (for [BROWSE_STATE] injection) ────────────
+# Written on every action/start; read by routes/conversation.py when a session
+# is active. Small + in-process; a browse session is inherently single-node.
+_state_lock = threading.Lock()
+_latest_state: dict = {}   # {url, title, links, buttons, ts}
+_session_active = False
+
+
+def get_browse_state() -> dict | None:
+    """Return the latest browse state if a session is active, else None.
+
+    Read by the conversation route to inject [BROWSE_STATE: …]. Goes stale-safe:
+    a session with no update in 10 min is treated as gone.
+    """
+    with _state_lock:
+        if not _session_active or not _latest_state:
+            return None
+        if time.time() - _latest_state.get("ts", 0) > 600:
+            return None
+        return dict(_latest_state)
+
+
+def _set_active(active: bool):
+    global _session_active
+    with _state_lock:
+        _session_active = active
+        if not active:
+            _latest_state.clear()
+
+
+def _refresh_state():
+    """Pull a DOM digest from the service and cache it for [BROWSE_STATE]."""
+    try:
+        r = requests.get(
+            f"{BROWSE_SERVICE_URL}/session/dom",
+            params={"tenant": _tenant()}, headers=_svc_headers(), timeout=_TIMEOUT,
+        )
+        if r.status_code != 200:
+            return
+        dom = r.json()
+        links = [l.get("text", "") for l in dom.get("links", [])][:12]
+        buttons = [b.get("text", "") for b in dom.get("buttons", [])][:12]
+        with _state_lock:
+            _latest_state.update({
+                "url": dom.get("url", ""),
+                "title": dom.get("title", ""),
+                "text": (dom.get("text", "") or "")[:1200],
+                "links": links,
+                "buttons": buttons,
+                "ts": time.time(),
+            })
+    except Exception as e:
+        logger.debug("browse state refresh failed: %s", e)
+
+
+# ── HTTP proxy endpoints ─────────────────────────────────────────────────────
+@browse_bp.route("/api/browse/start", methods=["POST"])
+def browse_start():
+    body = request.get_json(silent=True) or {}
+    payload = {
+        "tenant": _tenant(),
+        "url": body.get("url", "about:blank"),
+    }
+    for k in ("width", "height", "proxy"):
+        if body.get(k) is not None:
+            payload[k] = body[k]
+    try:
+        r = requests.post(f"{BROWSE_SERVICE_URL}/session/start",
+                          json=payload, headers=_svc_headers(), timeout=_TIMEOUT)
+        if r.status_code == 200:
+            _set_active(True)
+            _refresh_state()
+        else:
+            logger.warning("browse start upstream %s: %s", r.status_code, r.text[:200])
+        return Response(r.content, status=r.status_code, content_type="application/json")
+    except requests.RequestException as e:
+        logger.error("browse start failed: %s", e)
+        return jsonify({"error": "browse service unavailable"}), 503
+
+
+@browse_bp.route("/api/browse/action", methods=["POST"])
+def browse_action():
+    body = request.get_json(silent=True) or {}
+    payload = dict(body)
+    payload["tenant"] = _tenant()
+    try:
+        r = requests.post(f"{BROWSE_SERVICE_URL}/session/action",
+                          json=payload, headers=_svc_headers(), timeout=_TIMEOUT)
+        if r.status_code == 200:
+            _refresh_state()
+        return Response(r.content, status=r.status_code, content_type="application/json")
+    except requests.RequestException as e:
+        logger.error("browse action failed: %s", e)
+        return jsonify({"error": "browse service unavailable"}), 503
+
+
+@browse_bp.route("/api/browse/screenshot", methods=["GET"])
+def browse_screenshot():
+    try:
+        r = requests.get(
+            f"{BROWSE_SERVICE_URL}/session/screenshot",
+            params={"tenant": _tenant(), "full": request.args.get("full", "")},
+            headers=_svc_headers(), timeout=_TIMEOUT,
+        )
+        return Response(r.content, status=r.status_code,
+                        content_type=r.headers.get("Content-Type", "image/png"))
+    except requests.RequestException as e:
+        logger.error("browse screenshot failed: %s", e)
+        return jsonify({"error": "browse service unavailable"}), 503
+
+
+@browse_bp.route("/api/browse/dom", methods=["GET"])
+def browse_dom():
+    try:
+        r = requests.get(f"{BROWSE_SERVICE_URL}/session/dom",
+                         params={"tenant": _tenant()}, headers=_svc_headers(), timeout=_TIMEOUT)
+        return Response(r.content, status=r.status_code, content_type="application/json")
+    except requests.RequestException as e:
+        return jsonify({"error": "browse service unavailable"}), 503
+
+
+@browse_bp.route("/api/browse/status", methods=["GET"])
+def browse_status():
+    try:
+        r = requests.get(f"{BROWSE_SERVICE_URL}/session/status",
+                         params={"tenant": _tenant()}, headers=_svc_headers(), timeout=_TIMEOUT)
+        return Response(r.content, status=r.status_code, content_type="application/json")
+    except requests.RequestException as e:
+        return jsonify({"error": "browse service unavailable"}), 503
+
+
+@browse_bp.route("/api/browse/stop", methods=["POST"])
+def browse_stop():
+    _set_active(False)
+    try:
+        r = requests.post(f"{BROWSE_SERVICE_URL}/session/stop",
+                          json={"tenant": _tenant()}, headers=_svc_headers(), timeout=_TIMEOUT)
+        return Response(r.content, status=r.status_code, content_type="application/json")
+    except requests.RequestException as e:
+        return jsonify({"error": "browse service unavailable"}), 503
+
+
+# ── Viewer page ──────────────────────────────────────────────────────────────
+@browse_bp.route("/browse-viewer")
+def browse_viewer():
+    """Serve the live co-browsing viewer (loaded inside the canvas iframe)."""
+    path = DEFAULT_PAGES_DIR / "browse-viewer.html"
+    try:
+        return Response(path.read_text(encoding="utf-8"), content_type="text/html")
+    except Exception as e:
+        logger.error("browse-viewer serve failed: %s", e)
+        return "<h1>Browse viewer unavailable</h1>", 500

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -121,6 +121,14 @@ _VOICE_INSTRUCTIONS = (
     "is not in the current message, or you no longer remember these instructions, READ "
     "uploads/UI_STATE.md — never guess a page-id or track name. "
 
+    # --- Co-browsing (#154) ---
+    "CO-BROWSING: [BROWSE:https://site.com] starts a server-side browser at that URL "
+    "and shows the user a live view — use it when the user asks you to go to / look "
+    "something up on / browse a real website (works on any site, unlike [CANVAS_URL:]). "
+    "You then see the page via a [BROWSE_STATE: ...] tag next message; drive it with "
+    '[BROWSE_ACTION:{"action":"click|type|scroll|goto|back|forward|reload|wait",...}] '
+    "tags (say what you're doing in words too). Only browse when asked. "
+
     # --- Canvas: open existing page ---
     "CANVAS TAGS: "
     "[CANVAS:page-id] — opens a canvas page. Use exact page-id from the [Canvas pages:] list above. "
@@ -1550,6 +1558,35 @@ def _conversation_inner():
                 )
         except Exception:
             pass
+
+        # Co-browsing text-sight (#154 Phase 2): when a server-side browse session
+        # is active for this tenant, give the agent the current page's url/title +
+        # a DOM digest (visible text, links, buttons) so it can navigate without a
+        # full screenshot round-trip. Dynamic (changes every action) → per-turn.
+        try:
+            from routes.browse import get_browse_state
+            _bstate = get_browse_state()
+            if _bstate:
+                _links = ' | '.join(l for l in _bstate.get('links', []) if l)[:600]
+                _btns = ' | '.join(b for b in _bstate.get('buttons', []) if b)[:400]
+                _bparts = [
+                    f"url={_bstate.get('url','')!r}",
+                    f"title={_bstate.get('title','')!r}",
+                ]
+                if _bstate.get('text'):
+                    _bparts.append(f"visible text: {_bstate['text'][:800]}")
+                if _links:
+                    _bparts.append(f"links: {_links}")
+                if _btns:
+                    _bparts.append(f"buttons: {_btns}")
+                context_parts.append(
+                    '[BROWSE_STATE (live server-side browser you are driving — the user '
+                    'sees this too): ' + ' · '.join(_bparts) + '. Drive it by emitting '
+                    '[BROWSE_ACTION:{"action":"click|type|scroll|goto|back|forward|reload|wait",...}] '
+                    'tags; say what you are doing in words too.]'
+                )
+        except Exception as _be:
+            logger.debug(f'BROWSE_STATE injection skipped: {_be}')
 
         # Recently completed Suno generations — agent gets notified on next turn
         try:

--- a/server.py
+++ b/server.py
@@ -236,6 +236,9 @@ app.register_blueprint(vault_bp)
 from routes.identity import identity_bp
 app.register_blueprint(identity_bp)
 
+from routes.browse import browse_bp  # co-browsing bridge (#154)
+app.register_blueprint(browse_bp)
+
 from routes.services import services_bp
 app.register_blueprint(services_bp)
 
@@ -2193,6 +2196,84 @@ def xai_realtime_websocket(ws):
         logger.error(f"xAI Realtime: fatal error: {e}")
     finally:
         logger.info(f"xAI Realtime: session ended for user_id={user_id}")
+
+
+# ---------------------------------------------------------------------------
+# WebSocket — Co-browsing screencast proxy (/ws/browse-stream)  [#154 Phase 2]
+# ---------------------------------------------------------------------------
+# Bridges the browser's viewer canvas to the shared jambot-browse service's
+# CDP screencast WS. Browser side is flask-sock; upstream is the aiohttp WS on
+# the browse service. Frames flow down (base64 JPEG), user/viewer events flow
+# up (Phase 3 consumes them; Phase 2 relays them through untouched). The
+# service key + this tenant are injected server-side — never exposed to the
+# browser. Tenant is fixed by this OVU instance's env, so a browser can only
+# ever watch ITS OWN tenant's session.
+@sock.route("/ws/browse-stream")
+def browse_stream_websocket(ws):
+    from services.auth import verify_clerk_token, get_token_from_request
+    # Clerk gate unless auth disabled (single-user self-host), matching the app.
+    # The real browser auto-sends the __session cookie (same origin). The internal
+    # agent key is also accepted (via ?agent_key= or X-Agent-Key) for parity with
+    # the /api/browse/* HTTP proxy, which lets internal tooling attach a viewer.
+    if os.getenv("CLERK_PUBLISHABLE_KEY") or os.getenv("CLERK_SECRET_KEY"):
+        _agent_key = os.getenv("AGENT_API_KEY", "").strip()
+        _presented = request.args.get("agent_key", "") or request.headers.get("X-Agent-Key", "")
+        _agent_ok = bool(_agent_key) and _presented == _agent_key
+        token = get_token_from_request()
+        if not _agent_ok and not (token and verify_clerk_token(token)):
+            try:
+                ws.send(json.dumps({"type": "error", "message": "Unauthorized"}))
+            finally:
+                ws.close()
+            return
+
+    svc_url = os.getenv("BROWSE_SERVICE_URL", "http://jambot-browse:8712").rstrip("/")
+    svc_key = os.getenv("BROWSE_SERVICE_KEY", "").strip()
+    tenant = (os.getenv("JAMBOT_TENANT") or os.getenv("TENANT_NAME") or "default").strip()
+    ws_url = svc_url.replace("http://", "ws://").replace("https://", "wss://")
+    stream_url = f"{ws_url}/session/stream?tenant={tenant}"
+    if svc_key:
+        stream_url += f"&key={svc_key}"
+
+    async def _run():
+        try:
+            async with websockets.connect(stream_url, max_size=8 * 1024 * 1024) as up:
+                logger.info("browse-stream connected upstream tenant=%s", tenant)
+
+                async def _down():
+                    """Upstream frames → browser."""
+                    async for frame in up:
+                        ws.send(frame)
+
+                async def _up():
+                    """Browser viewer events → upstream (Phase 3 acts on them)."""
+                    loop = asyncio.get_running_loop()
+                    while True:
+                        msg = await loop.run_in_executor(None, ws.receive)
+                        if msg is None:
+                            break
+                        await up.send(msg)
+
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(_down()), asyncio.create_task(_up())],
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for t in pending:
+                    t.cancel()
+        except Exception as e:
+            logger.info("browse-stream closed tenant=%s: %s", tenant, e)
+            try:
+                ws.send(json.dumps({"type": "error", "message": "browse stream ended"}))
+            except Exception:
+                pass
+
+    try:
+        asyncio.run(_run())
+    finally:
+        try:
+            ws.close()
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------

--- a/src/app.js
+++ b/src/app.js
@@ -72,6 +72,11 @@ connectAiradio();
             };
             const strip = (text) => {
                 if (!text) return text;
+                // Also drop co-browsing tags here so every streaming display path
+                // that calls strip() (not just the main regex chain) hides them (#154).
+                text = text
+                    .replace(/\[BROWSE_ACTION:\{[\s\S]*?\}\]/gi, '')
+                    .replace(/\[BROWSE:[^\]]*\]/gi, '');
                 const tags = extract(text);
                 if (tags.length === 0) return text;
                 let out = '', cursor = 0;
@@ -125,6 +130,38 @@ connectAiradio();
             };
             return { extract, strip, dispatch, dispatchFrom, flush };
         })();
+
+        // Generic brace-walking extractor for [TAG:{...json...}] tags whose JSON
+        // payload nests {}/[] (so a regex can't be trusted). Used by BROWSE_ACTION
+        // (#154); mirrors the __canvasAction brace walk. Returns [payloadObj,...].
+        function extractBracketJsonTags(text, tagName) {
+            const out = [];
+            if (!text) return out;
+            const re = new RegExp('\\[' + tagName + ':', 'gi');
+            let m;
+            while ((m = re.exec(text)) !== null) {
+                const jsonStart = m.index + m[0].length;
+                if (text[jsonStart] !== '{') continue;
+                let depth = 0, i = jsonStart, inStr = false, esc = false;
+                for (; i < text.length; i++) {
+                    const c = text[i];
+                    if (inStr) {
+                        if (esc) { esc = false; continue; }
+                        if (c === '\\') { esc = true; continue; }
+                        if (c === '"') inStr = false;
+                        continue;
+                    }
+                    if (c === '"') { inStr = true; continue; }
+                    if (c === '{') depth++;
+                    else if (c === '}') { depth--; if (depth === 0) { i++; break; } }
+                }
+                if (depth !== 0 || text[i] !== ']') continue;
+                try { out.push(JSON.parse(text.slice(jsonStart, i))); }
+                catch (e) { console.warn('[' + tagName + '] JSON parse failed', e); }
+            }
+            return out;
+        }
+        window.extractBracketJsonTags = extractBracketJsonTags;
 
         // ===== CONFIGURATION =====
         const CONFIG = {
@@ -4470,6 +4507,8 @@ connectAiradio();
                             .replace(/\[CANVAS_MENU\]/gi, '')
                             .replace(/\[CANVAS:[^\]]*\]/gi, '')
                             .replace(/\[CANVAS_URL:[^\]]*\]/gi, '')
+                            .replace(/\[BROWSE_ACTION:\{[\s\S]*?\}\]/gi, '')
+                            .replace(/\[BROWSE:[^\]]*\]/gi, '')
                             .replace(/\[MUSIC_PLAY(?::[^\]]*)?\]/gi, '')
                             .replace(/\[MUSIC_STOP\]/gi, '')
                             .replace(/\[MUSIC_NEXT\]/gi, '')
@@ -4705,6 +4744,52 @@ connectAiradio();
                             } else {
                                 console.warn('[Canvas] Blocked private/internal URL from agent:', externalUrl);
                                 ActionConsole.addEntry('system', `Canvas: blocked private URL — agent should use the public dev URL`);
+                            }
+                        }
+                        // Check for [BROWSE:url] — start a server-side co-browsing
+                        // session (agent browses on the VPS, user watches live) and
+                        // open the viewer in the canvas. (#154 Phase 2)
+                        const browseMatch = text.match(/\[BROWSE:([^\]]+)\]/i);
+                        if (browseMatch && !canvasCommandsProcessed.has('BROWSE')) {
+                            canvasCommandsProcessed.add('BROWSE');
+                            let browseUrl = browseMatch[1].trim();
+                            const resolvedBrowse = resolveCanvasUrl(browseUrl);
+                            if (resolvedBrowse) {
+                                console.log('[Browse] start:', resolvedBrowse);
+                                ActionConsole.addEntry('system', `Browse: opening ${resolvedBrowse}`);
+                                AgentActivityChip.handleTag('canvas_url', resolvedBrowse);
+                                _tag('browse', async () => {
+                                    try {
+                                        await fetch(`${CONFIG.serverUrl}/api/browse/start`, {
+                                            method: 'POST',
+                                            headers: { 'Content-Type': 'application/json' },
+                                            body: JSON.stringify({ url: resolvedBrowse })
+                                        });
+                                    } catch (e) { console.warn('[Browse] start failed:', e); }
+                                    const iframe = document.getElementById('canvas-iframe');
+                                    if (iframe) { iframe.src = '/browse-viewer?t=' + Date.now(); CanvasControl.show(); }
+                                });
+                            } else {
+                                ActionConsole.addEntry('system', 'Browse: blocked private/internal URL');
+                            }
+                        }
+                        // Check for [BROWSE_ACTION:{...JSON...}] — agent drives the
+                        // server-side browser (click/type/scroll/goto/back/forward/
+                        // reload/wait); the user sees it in the live viewer. (#154)
+                        const browseActionTags = extractBracketJsonTags(text, 'BROWSE_ACTION');
+                        if (browseActionTags.length > 0) {
+                            for (const t of browseActionTags) {
+                                const action = t && t.action;
+                                if (!action) continue;
+                                const dedupeKey = 'BROWSE_ACTION:' + action + ':' + JSON.stringify(t);
+                                if (canvasCommandsProcessed.has(dedupeKey)) continue;
+                                canvasCommandsProcessed.add(dedupeKey);
+                                ActionConsole.addEntry('system', `Browse: ${action}`);
+                                _tag('browse_action', () => fetch(`${CONFIG.serverUrl}/api/browse/action`, {
+                                    method: 'POST',
+                                    headers: { 'Content-Type': 'application/json' },
+                                    body: JSON.stringify(t)
+                                }).catch(e => console.warn('[Browse] action failed:', e)));
                             }
                         }
                         // Check for [CANVAS_ACTION:{...JSON...}] — voice/agent-driven canvas
@@ -6095,6 +6180,8 @@ connectAiradio();
                             .replace(/\[CANVAS_MENU\]/gi, '')
                             .replace(/\[CANVAS:[^\]]*\]/gi, '')
                             .replace(/\[CANVAS_URL:[^\]]*\]/gi, '')
+                            .replace(/\[BROWSE_ACTION:\{[\s\S]*?\}\]/gi, '')
+                            .replace(/\[BROWSE:[^\]]*\]/gi, '')
                             .replace(/\[MUSIC_PLAY(?::[^\]]*)?\]/gi, '')
                             .replace(/\[MUSIC_STOP\]/gi, '')
                             .replace(/\[MUSIC_NEXT\]/gi, '')
@@ -6269,6 +6356,8 @@ connectAiradio();
                             .replace(/\[CANVAS_MENU\]/gi, '')
                             .replace(/\[CANVAS:[^\]]*\]/gi, '')
                             .replace(/\[CANVAS_URL:[^\]]*\]/gi, '')
+                            .replace(/\[BROWSE_ACTION:\{[\s\S]*?\}\]/gi, '')
+                            .replace(/\[BROWSE:[^\]]*\]/gi, '')
                             .replace(/\[MUSIC_PLAY(?::[^\]]*)?\]/gi, '')
                             .replace(/\[MUSIC_STOP\]/gi, '')
                             .replace(/\[MUSIC_NEXT\]/gi, '')


### PR DESCRIPTION
Phase 2 of #154, **stacked on #396 (Phase 1)** — review/merge #396 first, then this retargets to `main`.

Turns the Phase-1 browse service into the user-facing feature: user says "go to X" → agent browses on the VPS → **user watches a live screencast in the canvas** while voice stays active → agent reads a text digest of the page and drives it.

## What's wired
- **`routes/browse.py`** — proxy to `jambot-browse`: `/api/browse/start|action|stop|screenshot|dom|status` + serves `/browse-viewer`. Injects **this** tenant server-side (a browser can only ever watch its own tenant) and the service key (never sent to the client). Keeps a per-tenant latest-state for agent sight.
- **`server.py` `/ws/browse-stream`** — flask-sock proxy bridging the viewer to the service's CDP screencast WS (`websockets.connect` upstream). Frames down, viewer events up (Phase 3 consumes). Clerk-gated + internal agent-key parity. Registers `browse_bp`.
- **`app.py`** — auth-exempts `/ws/browse-stream` (self-auths in-handler, same as `/ws/clawdbot`).
- **`default-pages/browse-viewer.html`** — live viewer: `<canvas>` JPEG stream, URL bar, back/fwd/reload/go/stop, live/loading/offline dot, fps, agent-cursor overlay, Phase-3-stubbed user-click capture. Inline CSS/JS, no CDN.
- **`src/app.js`** — `[BROWSE:url]` (start + open viewer) and `[BROWSE_ACTION:{…}]` (brace-walk → `/api/browse/action`) handlers + display stripping.
- **`routes/conversation.py`** — injects `[BROWSE_STATE: url/title/text/links/buttons]` into the agent's per-turn context **only while a session is active** (text-sight, no screenshot round-trip). Tag docs in `voice-system-prompt.md` + fallback constant.
- **`templates/docker-compose.yml`** (MIKE-AI tree) — `BROWSE_SERVICE_URL`/`KEY` env.

## Agent loop
user asks → `[BROWSE:url]` (+words) → viewer opens, user watches → next turn agent reads `[BROWSE_STATE]` → `[BROWSE_ACTION:{…}]` to click/type/scroll → repeat. Full screenshot→vision is the Phase 3 upgrade; Phase 2 sight is the DOM digest.

## Verified live on test-dev (jambot-browse + OVU on jambot-shared)
- ✅ `/api/browse/start` injects `tenant=test-dev`; dom/screenshot(18KB PNG)/action all proxy correctly
- ✅ **agent answered "the browser is on example.com, title Example Domain" from `[BROWSE_STATE]` with ZERO tool calls** — text-sight works
- ✅ `/ws/browse-stream` relayed **real screencast frames end-to-end** through the OVU proxy

## Deferred (Phases 3–5, in the overview doc)
screenshot→vision, user-input passthrough, IP masking (residential proxy via the pre-wired `proxy` seam), multi-tab.

Refs #154.