### PR TITLE
feat: co-browsing Phase 3 — user input passthrough (#154)

### DIFF
--- a/default-pages/browse-viewer.html
+++ b/default-pages/browse-viewer.html
@@ -98,6 +98,7 @@
 
   <div class="foot">
     <span class="pill" id="state">idle</span>
+    <span class="pill" id="control" title="Click the view to take control">agent</span>
     <span id="pagetitle"></span>
     <span style="margin-left:auto" id="fps"></span>
   </div>
@@ -210,16 +211,52 @@
     act("goto", {url:u});
   }
 
-  // ── user click passthrough — STUB (Phase 3) ──────────────────────────────
-  // Phase 3 maps canvas coords → true page coords and sends
-  // {type:"user_click",x,y} up the WS. Wired but inert in Phase 2.
-  var USER_INPUT_ENABLED = false;
-  canvas.addEventListener("click", function(e){
-    if (!USER_INPUT_ENABLED || !ws || ws.readyState !== 1) return;
+  // ── user input passthrough (#154 Phase 3) ────────────────────────────────
+  // The human can click/type/scroll into the live view; events map from canvas
+  // display coords → true page coords and go up the WS to drive the server
+  // browser. Turn indicator flips to "you" while the user is interacting.
+  var USER_INPUT_ENABLED = true;
+  var controlEl = $("control");
+  var controlT = null;
+  function markUser(){
+    controlEl.textContent = "you"; controlEl.style.borderColor = "var(--accent)";
+    controlEl.style.color = "var(--accent)";
+    if (controlT) clearTimeout(controlT);
+    controlT = setTimeout(function(){
+      controlEl.textContent = "agent"; controlEl.style.borderColor = "";
+      controlEl.style.color = "";
+    }, 2500);
+  }
+  // Canvas pixel → page coordinate. The frame IS the page bitmap at CDP scale,
+  // so canvas-internal pixels already equal page CSS px / pageScaleFactor.
+  function toPage(e){
     var rect = canvas.getBoundingClientRect();
-    var x = (e.clientX - rect.left) * (canvas.width / rect.width);
-    var y = (e.clientY - rect.top) * (canvas.height / rect.height);
-    ws.send(JSON.stringify({type:"user_click", x:Math.round(x), y:Math.round(y)}));
+    var cx = (e.clientX - rect.left) * (canvas.width / rect.width);
+    var cy = (e.clientY - rect.top) * (canvas.height / rect.height);
+    return { x: Math.round(cx / (scale || 1)), y: Math.round(cy / (scale || 1)) };
+  }
+  function sendEvt(o){
+    if (!USER_INPUT_ENABLED || !ws || ws.readyState !== 1) return;
+    ws.send(JSON.stringify(o)); markUser();
+  }
+  canvas.setAttribute("tabindex", "0");  // focusable so it can capture keys
+  canvas.addEventListener("click", function(e){
+    var p = toPage(e); sendEvt({type:"user_click", x:p.x, y:p.y}); canvas.focus();
+  });
+  var wheelT = 0;
+  canvas.addEventListener("wheel", function(e){
+    e.preventDefault();
+    var now = Date.now(); if (now - wheelT < 40) return; wheelT = now;
+    sendEvt({type:"user_scroll", dy: Math.round(e.deltaY)});
+  }, {passive:false});
+  canvas.addEventListener("keydown", function(e){
+    // Named keys go as key presses; printable chars go as typed text.
+    var named = {Enter:1,Backspace:1,Tab:1,Delete:1,ArrowUp:1,ArrowDown:1,
+                 ArrowLeft:1,ArrowRight:1,Escape:1,Home:1,End:1,PageUp:1,PageDown:1};
+    if (named[e.key]){ e.preventDefault(); sendEvt({type:"user_key", key:e.key}); }
+    else if (e.key.length === 1 && !e.ctrlKey && !e.metaKey){
+      e.preventDefault(); sendEvt({type:"user_type", text:e.key});
+    }
   });
 
   // ── init ──────────────────────────────────────────────────────────────────

--- a/deploy/browse-service/server.py
+++ b/deploy/browse-service/server.py
@@ -313,6 +313,35 @@ class BrowseService:
         sess.touch()
         return await sess.page.screenshot(full_page=full, type="png")
 
+    # ── user input passthrough (#154 Phase 3) ─────────────────────────────────
+    async def apply_user_event(self, sess: Session, evt: dict):
+        """Apply a viewer-originated input event to the page.
+
+        The human watching the live stream can click/type/scroll into it; those
+        events arrive on the viewer WS and land here. Runs under the SAME
+        per-session lock as agent actions so a user click and an agent action
+        never interleave mid-operation. Coordinates are already page-space
+        (the viewer maps canvas→page using the CDP screencast metadata).
+        Rate-limited by the caller. Fail-soft: a bad event never kills the WS.
+        """
+        etype = evt.get("type", "")
+        page = sess.page
+        async with sess.lock:
+            if etype == "user_click":
+                x, y = float(evt.get("x", 0)), float(evt.get("y", 0))
+                await page.mouse.click(x, y)
+            elif etype == "user_move":
+                await page.mouse.move(float(evt.get("x", 0)), float(evt.get("y", 0)))
+            elif etype == "user_type":
+                await page.keyboard.type(str(evt.get("text", ""))[:2000], delay=10)
+            elif etype == "user_key":
+                await page.keyboard.press(str(evt.get("key", "Enter"))[:24])
+            elif etype == "user_scroll":
+                await page.mouse.wheel(0, int(evt.get("dy", 0)))
+            else:
+                return
+            sess.touch()
+
     # ── screencast relay ──────────────────────────────────────────────────────
     async def _dispatch_frame(self, sess: Session, params: dict):
         data = params.get("data")
@@ -469,17 +498,32 @@ async def h_stream(request):
     sess.viewers.add(ws)
     await svc.start_screencast(sess)
     logger.info("viewer connected tenant=%s viewers=%d", tenant, len(sess.viewers))
+    # Rate-limit user input so a mash of events can't peg the browser or starve
+    # the agent's own actions (they share the per-session lock). ~25 events/s.
+    _last_evt = 0.0
+    _MIN_EVT_GAP = 0.04
     try:
         async for msg in ws:
             if msg.type == WSMsgType.TEXT:
-                # Phase 2 (user-input passthrough) parses viewer events here.
-                # Phase 1 accepts + ignores them so the socket stays symmetric.
+                # Viewer events: ping (keepalive) + user input passthrough (#154 P3).
                 try:
                     evt = json.loads(msg.data)
-                    if evt.get("type") == "ping":
-                        await ws.send_str(json.dumps({"type": "pong"}))
                 except Exception:
-                    pass
+                    continue
+                etype = evt.get("type", "")
+                if etype == "ping":
+                    await ws.send_str(json.dumps({"type": "pong"}))
+                elif etype.startswith("user_"):
+                    now = time.time()
+                    # Always allow type/key (never drop keystrokes); throttle
+                    # only high-frequency pointer events.
+                    if etype in ("user_move", "user_scroll") and now - _last_evt < _MIN_EVT_GAP:
+                        continue
+                    _last_evt = now
+                    try:
+                        await svc.apply_user_event(sess, evt)
+                    except Exception as e:
+                        logger.debug("user event %s failed: %s", etype, e)
             elif msg.type == WSMsgType.ERROR:
                 break
     finally:

--- a/docs/jambot/co-browsing-system-overview.md
+++ b/docs/jambot/co-browsing-system-overview.md
@@ -1,6 +1,6 @@
 # Co-Browsing System — Overview & Phased Plan (issue #154)
 
-**Status (2026-07-19):** Phase 1 + Phase 2 built (server-side browse service + OVU wiring + live viewer). Phases 3–5 designed, not yet built.
+**Status (2026-07-19):** Phases 1–3 built (browse service + OVU wiring + live viewer + user input passthrough). Phases 4–5 designed, not yet built.
 
 Server-side co-browsing: a headless Chromium runs **on the VPS**, the agent drives it, and the user watches a **live video stream** of it inside a canvas page — voice stays active throughout. Because it streams frames (CDP screencast) instead of embedding the site, `X-Frame-Options`/CSP frame-blocking (which kills `[CANVAS_URL:]` on Amazon/Google/Facebook/etc.) does not apply. Any site works.
 
@@ -115,14 +115,16 @@ Files:
 
 ---
 
-## Phase 3 — User input passthrough (user acts in the stream)
+## Phase 3 — User input passthrough (user acts in the stream) ✅ BUILT (2026-07-19)
 
-**Goal:** user can click/type into the live view; agent sees the result.
+**Goal:** the human can click/type/scroll into the live view; the agent sees the result.
 
-- `browse-viewer.html`: capture canvas clicks → map display coords → true page coords (account for scale) → send `{type:"user_click",x,y}` up the WS. Capture keystrokes when focused → `{type:"user_type",text}`.
-- `server.py` `h_stream`: parse those viewer events (Phase 1 already accepts+ignores them) → apply via `page.mouse.click` / `page.keyboard.type`. Rate-limit + same per-session lock so agent + user actions don't interleave mid-action.
-- Turn-taking indicator in the viewer ("You have control" / "Agent is acting").
-- Agent is notified of user-initiated navigation on its next turn (URL/title delta in context).
+- **`browse-viewer.html`** — `USER_INPUT_ENABLED=true`. Canvas is focusable; click → map display→canvas→page coords (`/ pageScaleFactor` from CDP metadata) → `{type:"user_click",x,y}`; wheel → `{type:"user_scroll",dy}` (40ms throttle, `preventDefault`); keydown → named keys (`Enter`, arrows, `Backspace`…) as `{type:"user_key",key}`, printable chars as `{type:"user_type",text}`. Turn indicator pill flips **agent → you** for 2.5s on any user input.
+- **`deploy/browse-service/server.py`** — `h_stream` parses `user_*` events → `apply_user_event()` runs them (`page.mouse.click` / `keyboard.type` / `keyboard.press` / `mouse.wheel`) under the **same per-session lock** as agent actions, so a user click and an agent action never interleave. Rate-limited (~25/s; pointer events throttled, keystrokes never dropped). Fail-soft.
+- **`routes/browse.py`** — `get_browse_state()` refreshes the DOM digest when the cache is >4s stale, so **user-driven navigation** (which goes straight to the service over the viewer WS, bypassing the OVU action proxy) is reflected in the agent's `[BROWSE_STATE]` on its next turn. Bounded: ≤1 extra DOM call per agent turn, only during an active session.
+- The OVU `/ws/browse-stream` proxy already relays viewer events upstream (Phase 2's `_up()` coroutine) — no change needed.
+
+**Result:** agent and user share one browser. Agent drives via `[BROWSE_ACTION]`; user clicks/types/scrolls directly in the stream; both see the same live view; the agent picks up whatever the user did on its next turn.
 
 ---
 

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -21,13 +21,11 @@ never exposed to the browser.
 """
 import logging
 import os
-import threading
-import time
 
 import requests
 from flask import Blueprint, Response, jsonify, request
 
-from services.paths import DEFAULT_PAGES_DIR
+from services.paths import DEFAULT_PAGES_DIR, UPLOADS_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -50,59 +48,62 @@ def _svc_headers() -> dict:
     return h
 
 
-# ── Per-tenant latest browse state (for [BROWSE_STATE] injection) ────────────
-# Written on every action/start; read by routes/conversation.py when a session
-# is active. Small + in-process; a browse session is inherently single-node.
-_state_lock = threading.Lock()
-_latest_state: dict = {}   # {url, title, links, buttons, ts}
-_session_active = False
-
-
-def get_browse_state() -> dict | None:
-    """Return the latest browse state if a session is active, else None.
-
-    Read by the conversation route to inject [BROWSE_STATE: …]. Goes stale-safe:
-    a session with no update in 10 min is treated as gone.
-    """
-    with _state_lock:
-        if not _session_active or not _latest_state:
-            return None
-        if time.time() - _latest_state.get("ts", 0) > 600:
-            return None
-        return dict(_latest_state)
+# ── Browse-active marker + state (worker-safe) ───────────────────────────────
+# OVU runs multiple gunicorn workers, so in-process state is NOT shared across
+# them (a browser can hit worker A on /api/browse/start and worker B on the next
+# conversation turn). So: a filesystem marker (shared by all workers on the same
+# volume) records "a session is active", and the browse SERVICE is the single
+# shared source of truth for the live page — get_browse_state() queries it
+# directly each turn. That also means USER-driven navigation (which goes to the
+# service over the viewer WS, bypassing this proxy) is always reflected: we read
+# the service, not a local cache.
+_MARKER = UPLOADS_DIR / ".browse-active"
 
 
 def _set_active(active: bool):
-    global _session_active
-    with _state_lock:
-        _session_active = active
-        if not active:
-            _latest_state.clear()
+    try:
+        if active:
+            UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+            _MARKER.write_text(_tenant(), encoding="utf-8")
+        elif _MARKER.exists():
+            _MARKER.unlink()
+    except Exception as e:
+        logger.debug("browse marker update failed: %s", e)
 
 
-def _refresh_state():
-    """Pull a DOM digest from the service and cache it for [BROWSE_STATE]."""
+def get_browse_state() -> dict | None:
+    """Return the live page digest if a browse session is active, else None.
+
+    Worker-safe: gated on the filesystem marker (cheap stat, shared across
+    workers), then reads the browse SERVICE directly so the value always
+    reflects reality — including USER-driven navigation. Read by the
+    conversation route to inject [BROWSE_STATE: …]. One DOM call per agent turn,
+    only while a session is active. Self-heals: if the service reports no
+    session, the marker is cleared.
+    """
+    if not _MARKER.exists():
+        return None
     try:
         r = requests.get(
             f"{BROWSE_SERVICE_URL}/session/dom",
             params={"tenant": _tenant()}, headers=_svc_headers(), timeout=_TIMEOUT,
         )
+        if r.status_code == 404:
+            _set_active(False)  # service says no session — clear stale marker
+            return None
         if r.status_code != 200:
-            return
+            return None
         dom = r.json()
-        links = [l.get("text", "") for l in dom.get("links", [])][:12]
-        buttons = [b.get("text", "") for b in dom.get("buttons", [])][:12]
-        with _state_lock:
-            _latest_state.update({
-                "url": dom.get("url", ""),
-                "title": dom.get("title", ""),
-                "text": (dom.get("text", "") or "")[:1200],
-                "links": links,
-                "buttons": buttons,
-                "ts": time.time(),
-            })
+        return {
+            "url": dom.get("url", ""),
+            "title": dom.get("title", ""),
+            "text": (dom.get("text", "") or "")[:1200],
+            "links": [l.get("text", "") for l in dom.get("links", [])][:12],
+            "buttons": [b.get("text", "") for b in dom.get("buttons", [])][:12],
+        }
     except Exception as e:
-        logger.debug("browse state refresh failed: %s", e)
+        logger.debug("browse state read failed: %s", e)
+        return None
 
 
 # ── HTTP proxy endpoints ─────────────────────────────────────────────────────
@@ -121,7 +122,6 @@ def browse_start():
                           json=payload, headers=_svc_headers(), timeout=_TIMEOUT)
         if r.status_code == 200:
             _set_active(True)
-            _refresh_state()
         else:
             logger.warning("browse start upstream %s: %s", r.status_code, r.text[:200])
         return Response(r.content, status=r.status_code, content_type="application/json")
@@ -138,8 +138,6 @@ def browse_action():
     try:
         r = requests.post(f"{BROWSE_SERVICE_URL}/session/action",
                           json=payload, headers=_svc_headers(), timeout=_TIMEOUT)
-        if r.status_code == 200:
-            _refresh_state()
         return Response(r.content, status=r.status_code, content_type="application/json")
     except requests.RequestException as e:
         logger.error("browse action failed: %s", e)


### PR DESCRIPTION
Phase 3 of #154 (builds on merged #396/#397). The human watching the live stream can now **click/type/scroll into it** and drive the same server-side browser the agent drives. One shared browser; the agent picks up whatever the user did on its next turn.

## Changes
- **`default-pages/browse-viewer.html`** — `USER_INPUT_ENABLED`. Canvas focusable; click → display→canvas→page coord map (÷ pageScaleFactor from CDP metadata) → `{user_click}`; wheel → `{user_scroll}` (40ms throttle); keydown → named keys (`Enter`, arrows…) as `{user_key}`, printable chars as `{user_type}`. Turn pill flips **agent→you** for 2.5s on user input.
- **`deploy/browse-service/server.py`** — `h_stream` parses `user_*` events → `apply_user_event()` under the **same per-session lock** as agent actions (no interleave). Rate-limited ~25/s; keystrokes never dropped, pointer events throttled. Fail-soft.
- **`routes/browse.py`** — **worker-safe browse state.** OVU runs multiple gunicorn workers, so the old in-process cache wasn't shared (start → worker A, conversation turn → worker B → agent saw empty state). Now a filesystem marker gates "active" and `get_browse_state()` reads the browse **service** directly each turn — the single shared source of truth. Makes `[BROWSE_STATE]` reliable across workers **and** reflects user-driven navigation (which bypasses the action proxy). Self-heals on service 404.
- OVU `/ws/browse-stream` already relays viewer events upstream (Phase 2) — no change.

## Verified live on test-dev
- ✅ `user_click` at the link's real coords navigated the server browser **example.com → iana.org** (raw service + OVU dom both confirm)
- ✅ user scroll/key/type all applied without crashing the session (under the shared lock)
- ✅ after the user navigated, the agent reported **"the server browser is on iana.org"** from `[BROWSE_STATE]` with zero tool calls — worker-safe read confirmed (this is the bug the refactor fixes; the pre-fix run wrongly said example.com)

## Remaining
Phase 4 (IP masking via the pre-wired `proxy` seam), Phase 5 (multi-tab) — see `docs/jambot/co-browsing-system-overview.md`.

Refs #154.