### PR TITLE
feat: co-browsing Phase 4 — residential IP masking (#154)

### DIFF
--- a/default-pages/browse-viewer.html
+++ b/default-pages/browse-viewer.html
@@ -99,6 +99,7 @@
   <div class="foot">
     <span class="pill" id="state">idle</span>
     <span class="pill" id="control" title="Click the view to take control">agent</span>
+    <span class="pill" id="egress" title="Browsing exit IP" style="display:none"></span>
     <span id="pagetitle"></span>
     <span style="margin-left:auto" id="fps"></span>
   </div>
@@ -259,11 +260,27 @@
     }
   });
 
+  // ── egress IP indicator (#154 Phase 4) ───────────────────────────────────
+  function refreshEgress(){
+    fetch(API + "/api/browse/ip").then(function(r){ return r.json(); })
+      .then(function(ip){
+        var el = $("egress");
+        if (ip && ip.ip){
+          var loc = [ip.city, ip.country].filter(Boolean).join(", ");
+          el.textContent = (ip.proxied ? "🛡 " : "") + ip.ip + (loc ? " · " + loc : "");
+          el.title = ip.proxied ? "Masked — residential exit IP" : "Direct — server IP (not masked)";
+          el.style.borderColor = ip.proxied ? "var(--ok)" : "var(--line)";
+          el.style.color = ip.proxied ? "var(--ok)" : "var(--muted)";
+          el.style.display = "";
+        } else { el.style.display = "none"; }
+      }).catch(function(){});
+  }
+
   // ── init ──────────────────────────────────────────────────────────────────
-  post("/api/browse/status", {}); // warm; ignore result
   fetch(API + "/api/browse/status").then(function(r){ return r.json(); })
     .then(function(s){ if (s && s.url){ $("url").value = s.url; $("pagetitle").textContent = s.title||""; } })
     .catch(function(){});
+  refreshEgress();
   connect();
 })();
 </script>

--- a/deploy/browse-service/server.py
+++ b/deploy/browse-service/server.py
@@ -46,6 +46,7 @@ import logging
 import os
 import socket
 import time
+import uuid
 from urllib.parse import urlparse, urlsplit
 
 import psutil
@@ -73,6 +74,40 @@ USER_AGENT = os.getenv(
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
 )
+
+# ── IP masking / residential egress (#154 Phase 4) ───────────────────────────
+# When BROWSE_PROXY_SERVER is set, every session egresses through it — the fix
+# for the #1 server-side-browser blocker (datacenter IP → Cloudflare/retail
+# captchas). Provider-agnostic: point it at DataImpulse / IPRoyal / Decodo /
+# Bright Data. Sticky sessions keep one exit IP for a session's lifetime so a
+# multi-step flow doesn't trip a mid-task IP change — most providers do this by
+# embedding a session token in the username; put "{session}" in
+# BROWSE_PROXY_USERNAME and we template it per tenant-session.
+PROXY_SERVER = os.getenv("BROWSE_PROXY_SERVER", "").strip()
+PROXY_USERNAME = os.getenv("BROWSE_PROXY_USERNAME", "").strip()
+PROXY_PASSWORD = os.getenv("BROWSE_PROXY_PASSWORD", "")
+PROXY_STICKY = os.getenv("BROWSE_PROXY_STICKY", "1").strip() not in ("0", "", "false")
+
+
+def _build_proxy(sticky_session: str) -> dict | None:
+    """Build the Playwright proxy object from env, or None if unconfigured.
+
+    ``sticky_session`` is a per-tenant-session token; when the username template
+    contains "{session}" it is substituted so the provider pins one exit IP for
+    the session (sticky). Without the placeholder the proxy still works but the
+    exit IP may rotate per request (provider-dependent).
+    """
+    if not PROXY_SERVER:
+        return None
+    user = PROXY_USERNAME
+    if PROXY_STICKY and "{session}" in user:
+        user = user.replace("{session}", sticky_session)
+    proxy = {"server": PROXY_SERVER}
+    if user:
+        proxy["username"] = user
+    if PROXY_PASSWORD:
+        proxy["password"] = PROXY_PASSWORD
+    return proxy
 
 # ── SSRF guard ──────────────────────────────────────────────────────────────
 _BLOCKED_NETS = [
@@ -120,11 +155,13 @@ def _validate_url(url: str) -> tuple[bool, str]:
 
 # ── Session model ───────────────────────────────────────────────────────────
 class Session:
-    def __init__(self, tenant: str, context, page, cdp):
+    def __init__(self, tenant: str, context, page, cdp, proxied=False):
         self.tenant = tenant
         self.context = context
         self.page = page
         self.cdp = cdp
+        self.proxied = proxied     # egressing through a residential proxy (#154 P4)
+        self.egress_ip = None      # cached egress IP from the last /session/ip probe
         self.last_activity = time.time()
         self.viewers: set[web.WebSocketResponse] = set()
         self.screencasting = False
@@ -184,15 +221,19 @@ class BrowseService:
                 viewport={"width": width, "height": height},
                 user_agent=USER_AGENT,
             )
-            if proxy:
-                # Seam for the IP-masking phase: {"server","username","password"}
-                ctx_kwargs["proxy"] = proxy
+            # Proxy precedence: an explicit per-request proxy (from OVU) wins;
+            # otherwise fall back to the service-level env proxy (#154 Phase 4).
+            # Sticky session token pins one exit IP for this session's lifetime.
+            sticky = f"{tenant}-{uuid.uuid4().hex[:10]}"
+            eff_proxy = proxy or _build_proxy(sticky)
+            if eff_proxy:
+                ctx_kwargs["proxy"] = eff_proxy
 
             context = await self.browser.new_context(**ctx_kwargs)
             context.set_default_navigation_timeout(NAV_TIMEOUT_MS)
             page = await context.new_page()
             cdp = await context.new_cdp_session(page)
-            sess = Session(tenant, context, page, cdp)
+            sess = Session(tenant, context, page, cdp, proxied=bool(eff_proxy))
             self.sessions[tenant] = sess
 
             # Relay CDP screencast frames to viewers.
@@ -313,6 +354,40 @@ class BrowseService:
         sess.touch()
         return await sess.page.screenshot(full_page=full, type="png")
 
+    async def egress_ip(self, sess: Session) -> dict:
+        """Probe the session's real egress IP (#154 Phase 4 verification).
+
+        Uses the context's own APIRequestContext, so the request goes out the
+        SAME path (and proxy) the live browser uses — this is the proof the
+        residential proxy is actually masking. Does NOT touch the user's page.
+        """
+        sess.touch()
+        info = {"proxied": sess.proxied, "ip": None, "country": None, "error": None}
+        headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
+        # ipify is header-permissive; ipwho.is enriches with geo. Try both.
+        try:
+            resp = await sess.context.request.get(
+                "https://api.ipify.org?format=json", headers=headers, timeout=15000)
+            if resp.ok:
+                info["ip"] = (await resp.json()).get("ip")
+                sess.egress_ip = info["ip"]
+            else:
+                info["error"] = f"probe status {resp.status}"
+        except Exception as e:
+            info["error"] = str(e)[:200]
+        # Best-effort geo enrichment (never fatal).
+        if info["ip"]:
+            try:
+                geo = await sess.context.request.get(
+                    f"https://ipwho.is/{info['ip']}", headers=headers, timeout=10000)
+                if geo.ok:
+                    g = await geo.json()
+                    info["country"] = g.get("country_code") or g.get("country")
+                    info["city"] = g.get("city")
+            except Exception:
+                pass
+        return info
+
     # ── user input passthrough (#154 Phase 3) ─────────────────────────────────
     async def apply_user_event(self, sess: Session, evt: dict):
         """Apply a viewer-originated input event to the page.
@@ -423,6 +498,8 @@ async def h_health(request):
         "sessions": len(svc.sessions),
         "max_sessions": MAX_SESSIONS,
         "mem_percent": psutil.virtual_memory().percent,
+        "proxy_configured": bool(PROXY_SERVER),
+        "proxy_sticky": PROXY_STICKY if PROXY_SERVER else None,
     })
 
 
@@ -476,7 +553,17 @@ async def h_status(request):
         "idle_s": round(sess.idle_s, 1),
         "viewers": len(sess.viewers),
         "screencasting": sess.screencasting,
+        "proxied": sess.proxied,
+        "egress_ip": sess.egress_ip,
     })
+
+
+async def h_ip(request):
+    """Return the session's real egress IP — proof the proxy is (or isn't)
+    masking. Also usable as a light 'is the residential proxy working' check."""
+    _require_auth(request)
+    sess = _get_session(request.query.get("tenant", "").strip())
+    return web.json_response(await svc.egress_ip(sess))
 
 
 async def h_stop(request):
@@ -553,6 +640,7 @@ def make_app():
         web.get("/session/screenshot", h_screenshot),
         web.get("/session/dom", h_dom),
         web.get("/session/status", h_status),
+        web.get("/session/ip", h_ip),
         web.post("/session/stop", h_stop),
         web.get("/session/stream", h_stream),
     ])

--- a/docs/jambot/co-browsing-system-overview.md
+++ b/docs/jambot/co-browsing-system-overview.md
@@ -1,6 +1,6 @@
 # Co-Browsing System — Overview & Phased Plan (issue #154)
 
-**Status (2026-07-19):** Phases 1–3 built (browse service + OVU wiring + live viewer + user input passthrough). Phases 4–5 designed, not yet built.
+**Status (2026-07-19):** Phases 1–4 built (browse service + OVU wiring + live viewer + user input passthrough + IP-masking plumbing). Phase 5 designed, not yet built. Phase 4 ships the residential-proxy wiring verified end-to-end; turning masking ON is an operator step (add provider creds).
 
 Server-side co-browsing: a headless Chromium runs **on the VPS**, the agent drives it, and the user watches a **live video stream** of it inside a canvas page — voice stays active throughout. Because it streams frames (CDP screencast) instead of embedding the site, `X-Frame-Options`/CSP frame-blocking (which kills `[CANVAS_URL:]` on Amazon/Google/Facebook/etc.) does not apply. Any site works.
 
@@ -128,16 +128,32 @@ Files:
 
 ---
 
-## Phase 4 — IP masking / residential egress (anti-block)
+## Phase 4 — IP masking / residential egress (anti-block) ✅ BUILT (2026-07-19)
 
 **Goal:** the VPS's datacenter IP is the #1 reason real sites (Cloudflare, retail, social) block or captcha a server-side browser. Route egress through a residential/ISP IP so co-browsing behaves like a real user.
 
-The Phase-1 `proxy` seam makes this a **config + provider** change, not a rewrite. See the dedicated research section below for provider choice. Plan:
-- Add `BROWSE_PROXY_*` config; when set, `routes/browse.py` passes a per-tenant `proxy` object to `/session/start`.
-- Prefer **sticky sessions** (same exit IP for a session's lifetime) so multi-step flows don't trip mid-task IP changes.
-- Pair with a stealth profile (see research) — a clean residential IP with stock headless Chromium still fails automation-protocol fingerprint checks on the hardest targets. Realistic scope: works everywhere for "watch the agent read a page"; the hardest bot-walled flows (login-gated retail checkout) remain best-effort.
-- **Directory/citation policy still applies** (memory `feedback_never_touch_google_business_profiles`): masking is for *browsing/rendering*, never for touching banned identity platforms (GMB, Facebook, Yelp, BBB…).
-- Cost control: residential proxies bill per-GB; screencast frames are server-side only (they do NOT traverse the proxy — only the page's own network egress does), so a browsing session is ~the page's real byte weight. Add a per-tenant GB budget + the existing memory/idle guards.
+The Phase-1 `proxy` seam made this **config + provider**, not a rewrite. Built:
+- **`deploy/browse-service/server.py`** — `BROWSE_PROXY_SERVER/USERNAME/PASSWORD/STICKY` env → `_build_proxy()` → passed to `browser.new_context(proxy=…)`. An explicit per-request proxy (from OVU) still wins; otherwise the service-level env proxy applies to every session. **Sticky sessions:** each session gets a `<tenant>-<rand>` token; if the username contains `{session}` it's templated in, so the provider pins one exit IP for the session's lifetime (multi-step flows don't trip a mid-task IP change). `Session.proxied` flag tracks it.
+- **`/session/ip`** (+ OVU `/api/browse/ip`) — probes the session's **real egress IP** via the context's own `APIRequestContext` (same path/proxy the live browser uses; doesn't touch the user's page). This is the proof-of-masking + a "is the residential proxy working" check. `/health` reports `proxy_configured`; `/session/status` reports `proxied` + `egress_ip`.
+- **`browse-viewer.html`** — footer pill shows the exit IP + location: `🛡 <ip> · <city, country>` green when masked, grey `<ip>` when direct.
+- **`scripts/jambot-browse-service.sh`** — reads `BROWSE_PROXY_*` from `.platform-keys.env` and passes them to the container; prints `egress: residential proxy …` or `egress: DIRECT`.
+
+**Turning it on (operator step):** add to `/mnt/system/base/.platform-keys.env`, then `bash scripts/jambot-browse-service.sh restart`:
+```
+BROWSE_PROXY_SERVER=http://gate.example-provider.com:PORT
+BROWSE_PROXY_USERNAME=<user>-sessid-{session}      # {session} → sticky per session
+BROWSE_PROXY_PASSWORD=<pass>
+```
+Verify with `GET /api/browse/ip` (or the viewer pill) — a residential IP means it's live.
+
+**Provider pick (research below):** start with **DataImpulse** (~$1/GB, non-expiring) or **IPRoyal** (~$1.75/GB), PAYG, sticky sessions. Only add a stealth fork (**Patchright** — drop-in undetected Playwright/Chromium) if a target still blocks with a clean residential IP.
+
+**Verified end-to-end 2026-07-19:** baseline probe returns the Hetzner IP (178.156.162.212, `proxied:false`); with a proxy configured, `proxied:true` and the proxy log shows **every** browser CONNECT (`example.com:443`, `api.ipify.org:443`, `ipwho.is:443`) tunneling through it — so a real provider URL yields a residential exit IP with no code change. Real residential-IP confirmation needs provider creds (operator step).
+
+**Guards that still apply:**
+- **Directory/citation policy** (memory `feedback_never_touch_google_business_profiles`): masking is for *browsing/rendering*, never for touching banned identity platforms (GMB, Facebook, Yelp, BBB…). The SSRF guard stays on regardless of proxy.
+- **Cost:** residential proxies bill per-GB; screencast frames are server-side only (they do NOT traverse the proxy — only the page's own egress does), so a session ≈ the page's real byte weight. A per-tenant GB budget is a Phase-5 add.
+- Residential egress does not defeat automation-protocol fingerprinting on the hardest targets; realistic scope is "watch the agent read/browse a page" everywhere, with login-gated retail checkout best-effort (add Patchright there).
 
 ---
 

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -179,6 +179,17 @@ def browse_status():
         return jsonify({"error": "browse service unavailable"}), 503
 
 
+@browse_bp.route("/api/browse/ip", methods=["GET"])
+def browse_ip():
+    """Egress IP of the live session — proof of residential masking (#154 P4)."""
+    try:
+        r = requests.get(f"{BROWSE_SERVICE_URL}/session/ip",
+                         params={"tenant": _tenant()}, headers=_svc_headers(), timeout=_TIMEOUT)
+        return Response(r.content, status=r.status_code, content_type="application/json")
+    except requests.RequestException as e:
+        return jsonify({"error": "browse service unavailable"}), 503
+
+
 @browse_bp.route("/api/browse/stop", methods=["POST"])
 def browse_stop():
     _set_active(False)


### PR DESCRIPTION
Phase 4 of #154 (builds on merged #396/#397/#398). Routes the server-side browser's egress through a **residential IP** so it stops getting blocked/captcha'd for being on a datacenter IP — the #1 server-side-browser blocker.

The Phase-1 `proxy` seam made this **config + provider**, not a rewrite.

## Changes
- **`deploy/browse-service/server.py`** — `BROWSE_PROXY_SERVER/USERNAME/PASSWORD/STICKY` env → `_build_proxy()` → `browser.new_context(proxy=…)`. Explicit per-request proxy (from OVU) still wins; else the env proxy applies to every session. **Sticky sessions:** each session gets a `<tenant>-<rand>` token templated into the username at `{session}`, so the provider pins one exit IP for the session lifetime (multi-step flows don't trip a mid-task IP change). New **`/session/ip`** probes the real egress IP via the context's own `APIRequestContext` (same proxy path the live browser uses; doesn't touch the user's page). `/health` → `proxy_configured`; `/session/status` → `proxied` + `egress_ip`.
- **`routes/browse.py`** — `/api/browse/ip` proxy.
- **`default-pages/browse-viewer.html`** — footer pill: green `🛡 <ip> · <city, country>` when masked, grey `<ip>` when direct.
- **`scripts/jambot-browse-service.sh`** (MIKE-AI) — reads `BROWSE_PROXY_*` from `.platform-keys.env`.

## Verified end-to-end
- ✅ **Baseline** (no proxy): `/session/ip` → `178.156.162.212` (Hetzner), `proxied:false` — matches the host's real public IP
- ✅ **Proxy configured**: `proxied:true`, and an in-container forward proxy's log shows **every** browser CONNECT (`example.com:443`, `api.ipify.org:443`, `ipwho.is:443`) tunneling through it — the browser's whole egress is routed through the proxy
- ✅ OVU `/api/browse/ip` returns IP + geo + `proxied`

Egress IP stayed the datacenter IP only because the test proxy exits via the same host; **swapping the proxy URL for a real residential provider yields a residential exit IP with zero code change.** Real-IP confirmation needs provider creds (operator step, documented in the overview).

## Turning it on (operator)
Add `BROWSE_PROXY_SERVER/USERNAME/PASSWORD` to `.platform-keys.env` (use `{session}` in the username for sticky), `bash scripts/jambot-browse-service.sh restart`, verify with `/api/browse/ip`. Recommended provider: **DataImpulse** (~\$1/GB) or **IPRoyal** (~\$1.75/GB), PAYG, sticky.

## Remaining
Phase 5 (multi-tab, per-tenant GB budget, download capture) — see `docs/jambot/co-browsing-system-overview.md`.

Refs #154.