### PR TITLE
fix(maps): allowlist GET /api/maps/config for canvas iframes

### DIFF
--- a/app.py
+++ b/app.py
@@ -203,6 +203,12 @@ def create_app(config_override: dict = None):
             '/api/icons/',    # GET icon library — generate/upload gated (SEC-9)
             '/api/suno',      # GET status/song-list — generation POSTs gated (SEC-9)
             '/api/profiles',  # GET profile config — activate/save writes gated (SEC-10)
+            '/api/maps/config',  # GET Google-Maps JS API key — canvas iframe pages can't
+                                 # authenticate (window.authFetch not injected there) and the
+                                 # JS key is browser-exposed BY DESIGN (Google Maps JS loads it
+                                 # client-side). Security boundary = HTTP-referrer restriction on
+                                 # the key in Google Cloud (must be *.jam-bot.com). /api/maps/
+                                 # directions (POST, billable server-side calls) stays gated.
         )
         # NOTE: /api/stt/ is intentionally NOT public — the Deepgram token
         # endpoint returns a live secret (SEC-1). All /api/stt/* now requires a


### PR DESCRIPTION
Canvas iframe pages can't authenticate (window.authFetch not injected there), so loadMaps() fetch('/api/maps/config') hit the global require_auth gate -> 401 -> Google Maps JS never loaded. Adds ONLY the GET config endpoint to _PUBLIC_READ_PREFIXES (GET-only, same pattern as /api/tts). /api/maps/directions (POST, billable) stays gated. Cherry-picked clean off main — does NOT include co-browsing Phase 5.

Fixes allstate-voice canvas map-page bug. Security boundary = HTTP-referrer restriction on the maps key in Google Cloud.