### PR TITLE
fix(csp): allow Google Maps hosts so map canvas pages actually render

### DIFF
--- a/app.py
+++ b/app.py
@@ -357,10 +357,17 @@ def create_app(config_override: dict = None):
             # CDN, which compiles CSS at runtime via eval()/new Function — without unsafe-eval the script
             # loads but generates NO styles → pages still render as raw text. (canvas.py CSP already had
             # these; the global one didn't — that was the real cause of the unstyled SEO dashboard.)
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://*.clerk.accounts.dev https://*.jam-bot.com; "
+            # maps.googleapis.com + maps.gstatic.com are REQUIRED for the `maps` skill's
+            # canvas pages (Google Maps JS API). Without them the JS is blocked and every
+            # map page renders an empty box — silently, since the only signal is a console
+            # CSP violation. Found 2026-07-24: the maps skill documented these as allowed
+            # but they were never actually in either CSP. Do NOT re-strip.
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://*.clerk.accounts.dev https://*.jam-bot.com https://maps.googleapis.com https://maps.gstatic.com; "
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
             "font-src 'self' data: https://fonts.gstatic.com; "
-            "img-src 'self' data: blob: https://img.clerk.com https://images.clerk.dev https://*.clerk.accounts.dev https://lh3.googleusercontent.com https://avatars.githubusercontent.com https://bhaleyart.github.io; "
+            # Map tiles/markers come from maps.gstatic.com, *.googleapis.com (khms tile
+            # shards) and *.ggpht.com (Street View); googleusercontent serves place photos.
+            "img-src 'self' data: blob: https://img.clerk.com https://images.clerk.dev https://*.clerk.accounts.dev https://lh3.googleusercontent.com https://avatars.githubusercontent.com https://bhaleyart.github.io https://maps.googleapis.com https://maps.gstatic.com https://*.googleapis.com https://*.ggpht.com https://*.googleusercontent.com; "
             "media-src 'self' blob:; "
             "connect-src 'self' wss: https:; "
             "frame-src 'self' https://*.clerk.accounts.dev https://*.jam-bot.com https:; "

--- a/routes/canvas.py
+++ b/routes/canvas.py
@@ -971,7 +971,10 @@ def canvas_pages_proxy(path):
                 # directly from the browser with user's own API keys.
                 resp.headers['Content-Security-Policy'] = (
                     "default-src 'none'; "
-                    "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://games.jam-bot.com blob:; "
+                    # maps.googleapis.com + maps.gstatic.com: required by the `maps` skill's
+                    # Google Maps JS canvas pages. Omitting them silently blanks every map
+                    # (console-only CSP violation). Found 2026-07-24. Do NOT re-strip.
+                    "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://games.jam-bot.com https://maps.googleapis.com https://maps.gstatic.com blob:; "
                     "style-src 'unsafe-inline' https://games.jam-bot.com https://fonts.googleapis.com; "
                     "img-src 'self' data: blob: https:; "
                     "media-src 'self' blob: https:; "
@@ -982,7 +985,8 @@ def canvas_pages_proxy(path):
                         "https://api.x.ai https://api.groq.com "
                         "https://api.together.xyz https://openrouter.ai "
                         "https://api.anthropic.com https://api.cohere.ai "
-                        "https://api.dataforseo.com https://sandbox.dataforseo.com; "
+                        "https://api.dataforseo.com https://sandbox.dataforseo.com "
+                        "https://maps.googleapis.com; "
                     "worker-src blob:; "
                     "frame-src 'self' https://*.jam-bot.com https://*.netlify.app https://midiviz.com "
                         "https://w.soundcloud.com https://bandcamp.com https://*.bandcamp.com"


### PR DESCRIPTION
`maps.googleapis.com` / `maps.gstatic.com` were in **neither** CSP block, despite the `maps` skill documenting them as an allowed script source. Every Google Maps canvas page rendered an empty box.

The failure is silent — the only signal is a console CSP violation, so it reads as a bug in the page rather than in the header. mac-claude burned a full build cycle on it before root-causing the header, and `directions-printguys.html` on test-dev has been dead the same way.

## Changes
- `app.py` (global CSP): + maps hosts in `script-src`; + tile / StreetView / place-photo hosts in `img-src`
- `routes/canvas.py` (canvas-serve CSP): same for `script-src`, + `maps.googleapis.com` in `connect-src` (its `img-src` was already `https:`, so tiles were fine there)

Additive allowlisting only — no behaviour change for non-map pages.

## Verification
Hot-patched onto test-dev and confirmed live:
```
script-src ... https://maps.googleapis.com https://maps.gstatic.com
img-src   ... https://maps.gstatic.com https://*.googleapis.com https://*.ggpht.com
```