### PR TITLE
fix(browse): bump Chromium 130 (Oct 2024) to 149, derive UA from live browser

### DIFF
--- a/deploy/browse-service/Dockerfile
+++ b/deploy/browse-service/Dockerfile
@@ -7,7 +7,18 @@
 #
 # The Playwright base image ships a matching Chromium + all the system libs
 # (fonts, nss, gtk, etc.) so we don't hand-maintain the apt list.
-FROM mcr.microsoft.com/playwright/python:v1.48.0-noble
+# ⚠️ KEEP THIS TAG IN LOCKSTEP WITH playwright== IN requirements.txt.
+# The base image ships the Chromium build that its own Playwright expects; if
+# the two drift, `playwright install chromium` below downloads a SECOND browser
+# at build time and you silently ship two.
+#
+# This tag is also the ONLY thing that patches Chromium. It sat on v1.48.0
+# (Chromium 130, Oct 2024) until 2026-07-24 — ~21 months of renderer/sandbox
+# CVEs on the one container whose JOB is rendering untrusted attacker-controlled
+# web content, and which egresses through a residential IP. Nothing flagged it
+# because the image kept getting rebuilt, so it always LOOKED fresh; only the
+# base layer was old. `mon:supply-chain` now tracks running-image age.
+FROM mcr.microsoft.com/playwright/python:v1.61.0-noble
 
 WORKDIR /app
 

--- a/deploy/browse-service/requirements.txt
+++ b/deploy/browse-service/requirements.txt
@@ -1,3 +1,3 @@
-aiohttp==3.10.11
-playwright==1.48.0
-psutil==6.1.0
+aiohttp==3.14.3
+playwright==1.61.0
+psutil==7.2.2

--- a/deploy/browse-service/server.py
+++ b/deploy/browse-service/server.py
@@ -69,11 +69,25 @@ DEFAULT_W = int(os.getenv("BROWSE_WIDTH", "1280"))
 DEFAULT_H = int(os.getenv("BROWSE_HEIGHT", "800"))
 NAV_TIMEOUT_MS = int(os.getenv("BROWSE_NAV_TIMEOUT_MS", "30000"))
 SCREENCAST_QUALITY = int(os.getenv("BROWSE_SCREENCAST_QUALITY", "60"))
-USER_AGENT = os.getenv(
-    "BROWSE_USER_AGENT",
+# We present as desktop Chrome on Windows rather than headless Chromium on
+# Linux — that part is deliberate. What is NOT deliberate is the version drifting
+# away from the browser actually doing the rendering: a UA claiming Chrome/131
+# while Chromium 130 renders the page is a fingerprint MISMATCH, which is worse
+# for bot detection than a truthful UA (it's exactly what detectors look for).
+# That had already happened by 2026-07-24 (UA 131 vs real 130).
+#
+# So the major version is filled in from the LIVE browser at startup (see
+# BrowserPool.startup) and this is only the template + fallback. An explicit
+# BROWSE_USER_AGENT env override still wins and is left untouched.
+_UA_TEMPLATE = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+    "(KHTML, like Gecko) Chrome/{major}.0.0.0 Safari/537.36"
 )
+_UA_FALLBACK_MAJOR = "131"
+USER_AGENT = os.getenv("BROWSE_USER_AGENT") or _UA_TEMPLATE.format(
+    major=_UA_FALLBACK_MAJOR
+)
+_UA_PINNED = bool(os.getenv("BROWSE_USER_AGENT"))  # operator override — never rewrite
 
 # ── IP masking / residential egress (#154 Phase 4) ───────────────────────────
 # When BROWSE_PROXY_SERVER is set, every session egresses through it — the fix
@@ -248,8 +262,19 @@ class BrowseService:
                 "--disable-blink-features=AutomationControlled",
             ],
         )
-        logger.info("chromium launched; max_sessions=%d idle_timeout=%ds",
-                    MAX_SESSIONS, IDLE_TIMEOUT_S)
+        # Align the advertised UA major with the browser that actually renders,
+        # so a future Chromium bump can't silently re-open the mismatch above.
+        global USER_AGENT
+        if not _UA_PINNED:
+            try:
+                major = (self.browser.version or "").split(".")[0]
+                if major.isdigit():
+                    USER_AGENT = _UA_TEMPLATE.format(major=major)
+            except Exception as e:      # never block startup over a UA string
+                logger.warning("could not derive UA from browser version: %s", e)
+
+        logger.info("chromium launched v%s; ua=%s max_sessions=%d idle_timeout=%ds",
+                    self.browser.version, USER_AGENT, MAX_SESSIONS, IDLE_TIMEOUT_S)
 
     async def shutdown(self):
         for tenant in list(self.sessions):


### PR DESCRIPTION
`jambot-browse` was rebuilt as recently as today and therefore **looked fresh** in every image listing, while actually shipping **Chromium 130.0.6723.31 from Oct 2024** — roughly 21 months of accumulated renderer/sandbox CVEs. Only the `FROM` layer was stale, and nothing inspected it.

This is the container whose *job* is rendering untrusted, attacker-controllable web content, and it egresses through a residential IP — the worst place on the box for a stale browser.

## Changes
- base `v1.48.0-noble` → `v1.61.0-noble` (Chromium **130 → 149.0.7827.55**)
- `playwright` 1.48.0 → 1.61.0, `aiohttp` 3.10.11 → 3.14.3, `psutil` 6.1.0 → 7.2.2
- Comment at `FROM`: the base tag and the playwright pin must move **together**, or the `playwright install chromium` step downloads a second browser at build time. Verified only one build is present (`/ms-playwright/chromium-1228`).

## Fingerprint mismatch also fixed
The UA hardcoded `Chrome/131` while Chromium **130** did the rendering. A UA that disagrees with the renderer is *worse* for bot detection than a truthful one — mismatches are exactly what detectors look for. The major version is now derived from `browser.version` at startup, so it self-heals on every future bump. `BROWSE_USER_AGENT` still overrides and is never rewritten.

Startup log now shows: `chromium launched v149.0.7827.55; ua=...Chrome/149.0.0.0...`

## Verification
- Smoke passes end-to-end through the residential proxy: `example.com` title + 16409-byte PNG screenshot, clean session stop
- `openvoiceui-test-dev` reaches the service over `jambot-shared`
- API surface reviewed for 1.48→1.61 breaking changes: only stable APIs in use (`async_playwright`, `chromium.launch`, `new_context`, `new_cdp_session`, `Page.screencastFrame`, `page.on("download")`, `download.save_as`)
