### PR TITLE
feat(stt+vision): on-box Parakeet STT and vision off paid Groq onto subscription Claude

### DIFF
--- a/deploy/parakeet-stt/ATTRIBUTION.md
+++ b/deploy/parakeet-stt/ATTRIBUTION.md
@@ -1,0 +1,40 @@
+# Attribution — required, not optional
+
+`jambot-parakeet` runs **NVIDIA Parakeet TDT 0.6B v3**, licensed **CC-BY-4.0**.
+
+CC-BY-4.0 permits commercial use — including in a hosted product — **on the
+condition that attribution is given**. That is a licence term we must actually
+satisfy, not a courtesy.
+
+## What must appear somewhere user-visible
+
+> Speech recognition powered by [NVIDIA Parakeet TDT 0.6B v3](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3),
+> licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/).
+
+Acceptable placements (pick one, and keep it): an About/Credits page, a
+third-party-licences page, or the OpenVoiceUI docs. It does not need to be on
+every screen; it does need to be findable by a user of the product.
+
+**Status: NOT YET PLACED.** Mike to decide the location. Until it is placed we
+are using the model outside its licence terms, so this is a real open item —
+tracked, not assumed done.
+
+## Components and their licences
+
+| Component | Licence |
+|---|---|
+| nvidia/parakeet-tdt-0.6b-v3 (model weights) | CC-BY-4.0 |
+| istupakov/parakeet-tdt-0.6b-v3-onnx (INT8 ONNX conversion) | CC-BY-4.0 |
+| onnx-asr (runtime) | MIT |
+| onnxruntime | MIT |
+| ffmpeg (in-image, for resampling) | LGPL/GPL depending on build |
+
+## Why this model
+
+Researched 2026-07-25. The repo previously pointed at Whisper `tiny`
+(faster-whisper, commented out in requirements.txt) — a 2022 model, weakest
+variant. Parakeet TDT 0.6B v3 beats Whisper large-v3 on accuracy at a quarter
+the size and runs ~4x faster on CPU, which is what this box has. The current
+Open ASR Leaderboard accuracy leaders (Canary-Qwen 2.5B, Granite Speech 4.1 2B,
+ARK-ASR-3B) are LLM-decoder hybrids intended for GPUs and are the wrong shape
+for CPU-only inference here.

--- a/deploy/parakeet-stt/Dockerfile
+++ b/deploy/parakeet-stt/Dockerfile
@@ -1,0 +1,57 @@
+# jambot-parakeet — shared on-box speech-to-text for the whole fleet.
+#
+# WHY A SHARED SERVICE, not baked into jambot/openvoiceui:
+# The model is ~680MB. There are 24+ OVU containers; baking it in would mean 24
+# copies resident on a box whose swap is already heavily used. Same reasoning as
+# jambot-browse (Chromium) and supertonic-tts — one model, one process, reached
+# over the jambot-shared network.
+#
+# WHY PARAKEET AND NOT WHISPER (researched 2026-07-25):
+# The repo's requirements.txt carried a commented-out `faster-whisper==1.2.1`,
+# and /api/stt/local was written against Whisper `tiny`. Whisper is a 2022 model
+# and `tiny` is its weakest variant. NVIDIA Parakeet TDT 0.6B v3 (Aug 2025,
+# updated Jun 2026) beats Whisper large-v3 on accuracy at a quarter the size and
+# runs roughly 4x faster on CPU — which is what this box has (8-core EPYC, NO
+# GPU). The accuracy leaders on the Open ASR Leaderboard (Canary-Qwen 2.5B,
+# Granite Speech 4.1 2B) are LLM-decoder hybrids built for GPUs and are the
+# wrong shape here.
+#
+# Runtime is onnx-asr over INT8 ONNX weights: no PyTorch, no NeMo, no CUDA.
+# That keeps the image small and the resident set predictable.
+#
+# LICENSE: the model is CC-BY-4.0 (nvidia/parakeet-tdt-0.6b-v3). Commercial use
+# is permitted WITH ATTRIBUTION — see ATTRIBUTION.md next to this file. That is
+# a real obligation, not a formality.
+FROM python:3.12-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# onnx-asr[cpu] pulls onnxruntime (CPU build) + huggingface_hub for the weights.
+# Versions verified against PyPI 2026-07-25 — do not bump from memory.
+# (I first guessed onnx-asr 0.7.0; actual latest is 0.12.0. Check, don't recall.)
+RUN pip install --no-cache-dir \
+        "onnx-asr[cpu,hub]==0.12.0" \
+        fastapi==0.140.0 \
+        "uvicorn[standard]==0.51.0" \
+        python-multipart==0.0.32
+
+RUN useradd -r -m appuser
+WORKDIR /app
+COPY server.py .
+RUN chown -R appuser:appuser /app
+USER appuser
+
+# Pre-download the weights at BUILD time, as appuser so the cache path matches
+# runtime. Without this the first request after every recreate pays a ~680MB
+# download, which reads to the caller as "the service is broken".
+ENV HF_HOME=/home/appuser/.cache/huggingface
+RUN python3 -c "import onnx_asr; onnx_asr.load_model('istupakov/parakeet-tdt-0.6b-v3-onnx')" \
+    && du -sh /home/appuser/.cache/huggingface || true
+
+EXPOSE 8770
+
+# Single worker on purpose: one process owns the loaded model. Extra workers
+# would each load their own ~680MB copy.
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8770", "--workers", "1"]

--- a/deploy/parakeet-stt/server.py
+++ b/deploy/parakeet-stt/server.py
@@ -1,0 +1,125 @@
+"""
+jambot-parakeet — shared on-box speech-to-text for the JamBot fleet.
+
+  POST /transcribe   multipart 'audio'  -> {"text": ..., "duration_s": ..., "rtf": ...}
+  GET  /health                          -> {"ok": true, "model": ..., "loaded": bool}
+
+NVIDIA Parakeet TDT 0.6B v3 (INT8 ONNX) via onnx-asr. CPU-only by design — this
+box has no GPU. No API key, no per-call cost, nothing leaves the server.
+
+MODEL LICENCE: CC-BY-4.0. Commercial use is allowed WITH ATTRIBUTION.
+See ATTRIBUTION.md beside this file.
+"""
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s [parakeet] %(message)s")
+logger = logging.getLogger(__name__)
+
+MODEL_ID = os.getenv("PARAKEET_MODEL", "istupakov/parakeet-tdt-0.6b-v3-onnx")
+MAX_BYTES = int(os.getenv("PARAKEET_MAX_BYTES", str(60 * 1024 * 1024)))
+
+app = FastAPI(title="jambot-parakeet")
+_model = None
+
+
+def get_model():
+    """Load once, lazily. The weights are baked into the image at build time, so
+    this is a local read (~seconds), not a download."""
+    global _model
+    if _model is None:
+        import onnx_asr
+        t0 = time.time()
+        logger.info("loading %s ...", MODEL_ID)
+        _model = onnx_asr.load_model(MODEL_ID)
+        logger.info("model ready in %.1fs", time.time() - t0)
+    return _model
+
+
+@app.on_event("startup")
+def _warm():
+    # Load at startup rather than on the first caller. A cold first request that
+    # blocks for the model load looks like a hang to whoever asked for it — the
+    # same "ready doesn't mean ready" trap that bit the webdev wake path.
+    try:
+        get_model()
+    except Exception as e:  # never crash the container over a warm failure
+        logger.error("startup warm failed (will retry on first request): %s", e)
+
+
+@app.get("/health")
+def health():
+    return {"ok": True, "model": MODEL_ID, "loaded": _model is not None}
+
+
+def _to_wav16k(src: str, dst: str) -> bool:
+    """Normalise anything ffmpeg understands to 16 kHz mono PCM.
+
+    Browsers send webm/opus; phones send m4a; the recorder may send wav already.
+    Parakeet wants 16 kHz mono, so normalise rather than trusting the caller.
+    """
+    r = subprocess.run(
+        ["ffmpeg", "-y", "-i", src, "-ar", "16000", "-ac", "1", "-f", "wav", dst],
+        capture_output=True, timeout=120,
+    )
+    if r.returncode != 0:
+        logger.warning("ffmpeg failed: %s", r.stderr.decode()[:300])
+        return False
+    return True
+
+
+@app.post("/transcribe")
+async def transcribe(audio: UploadFile = File(...)):
+    raw = await audio.read()
+    if not raw:
+        raise HTTPException(status_code=400, detail="empty audio")
+    if len(raw) > MAX_BYTES:
+        raise HTTPException(status_code=413, detail=f"audio exceeds {MAX_BYTES} bytes")
+
+    tmpdir = tempfile.mkdtemp(prefix="parakeet-")
+    try:
+        src = os.path.join(tmpdir, "in" + (os.path.splitext(audio.filename or "")[1] or ".bin"))
+        wav = os.path.join(tmpdir, "in16k.wav")
+        with open(src, "wb") as f:
+            f.write(raw)
+
+        if not _to_wav16k(src, wav):
+            # Fall back to the original bytes — some inputs are already correct
+            # and ffmpeg's failure may be about metadata, not audio.
+            wav = src
+
+        t0 = time.time()
+        try:
+            text = get_model().recognize(wav)
+        except Exception as e:
+            logger.exception("recognition failed")
+            raise HTTPException(status_code=500, detail=f"recognition failed: {e}")
+        elapsed = time.time() - t0
+
+        # Report real-time factor so callers can see it degrade under load
+        # instead of guessing. rtf < 1 means faster than realtime.
+        dur = None
+        try:
+            p = subprocess.run(
+                ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+                 "-of", "default=nw=1:nk=1", wav],
+                capture_output=True, timeout=20,
+            )
+            dur = round(float(p.stdout.decode().strip()), 2)
+        except Exception:
+            pass
+
+        out = {"text": (text or "").strip(), "elapsed_s": round(elapsed, 2)}
+        if dur:
+            out["duration_s"] = dur
+            out["rtf"] = round(elapsed / dur, 3) if dur > 0 else None
+        logger.info("transcribed %.1fs audio in %.2fs (rtf=%s)", dur or -1, elapsed, out.get("rtf"))
+        return out
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)

--- a/deploy/parakeet-stt/server.py
+++ b/deploy/parakeet-stt/server.py
@@ -10,11 +10,14 @@ box has no GPU. No API key, no per-call cost, nothing leaves the server.
 MODEL LICENCE: CC-BY-4.0. Commercial use is allowed WITH ATTRIBUTION.
 See ATTRIBUTION.md beside this file.
 """
+import asyncio
+import gc
 import logging
 import os
 import shutil
 import subprocess
 import tempfile
+import threading
 import time
 
 from fastapi import FastAPI, File, HTTPException, UploadFile
@@ -25,37 +28,110 @@ logger = logging.getLogger(__name__)
 MODEL_ID = os.getenv("PARAKEET_MODEL", "istupakov/parakeet-tdt-0.6b-v3-onnx")
 MAX_BYTES = int(os.getenv("PARAKEET_MAX_BYTES", str(60 * 1024 * 1024)))
 
+# IDLE UNLOAD — why this exists (2026-07-25 incident).
+# This service is used occasionally but held the ONNX model resident 24/7:
+# 2,258 MB RSS + 2,052 MB swap = 4.3 GB, the single largest memory AND swap
+# consumer on a 30 GB box that was already full. It pushed the host into
+# sustained swapping (21/24 GB swap used, vmstat si/so non-zero), which made
+# EVERYTHING slow at once — the desktop stream stuttered, agents crawled — while
+# every component still passed its health check. Holding 4.3 GB permanently for a
+# service that is idle at 0.14% CPU is the wrong trade.
+#
+# So: unload the model after IDLE_UNLOAD_S with no traffic and let the next
+# caller pay a few seconds to reload it. Set IDLE_UNLOAD_S=0 to disable.
+IDLE_UNLOAD_S = int(os.getenv("PARAKEET_IDLE_UNLOAD_S", "900"))   # 15 min
+REAP_EVERY_S = int(os.getenv("PARAKEET_REAP_EVERY_S", "60"))
+WARM_ON_START = os.getenv("PARAKEET_WARM_ON_START", "1") not in ("0", "false", "no")
+
 app = FastAPI(title="jambot-parakeet")
 _model = None
+_model_lock = threading.Lock()      # guards load/unload
+_inflight = 0                       # transcriptions currently using the model
+_inflight_lock = threading.Lock()
+_last_used = time.time()
 
 
 def get_model():
     """Load once, lazily. The weights are baked into the image at build time, so
     this is a local read (~seconds), not a download."""
+    global _model, _last_used
+    _last_used = time.time()
+    with _model_lock:
+        if _model is None:
+            import onnx_asr
+            t0 = time.time()
+            logger.info("loading %s ...", MODEL_ID)
+            _model = onnx_asr.load_model(MODEL_ID)
+            logger.info("model ready in %.1fs", time.time() - t0)
+        return _model
+
+
+def _unload_if_idle():
+    """Drop the model if nothing has used it for IDLE_UNLOAD_S.
+
+    Refuses while any transcription is in flight — freeing a model mid-recognize
+    would crash the request that is using it. The in-flight counter is what makes
+    this safe; an idle TIMER alone is not, because a long transcription can span
+    several reap ticks without updating _last_used until it finishes.
+    """
     global _model
-    if _model is None:
-        import onnx_asr
-        t0 = time.time()
-        logger.info("loading %s ...", MODEL_ID)
-        _model = onnx_asr.load_model(MODEL_ID)
-        logger.info("model ready in %.1fs", time.time() - t0)
-    return _model
+    if _model is None or IDLE_UNLOAD_S <= 0:
+        return
+    with _inflight_lock:
+        if _inflight > 0:
+            return
+    idle = time.time() - _last_used
+    if idle < IDLE_UNLOAD_S:
+        return
+    with _model_lock:
+        if _model is None:
+            return
+        # Re-check under the lock — a request may have arrived since the check above.
+        with _inflight_lock:
+            if _inflight > 0:
+                return
+        _model = None
+        gc.collect()
+    logger.info("model unloaded after %.0fs idle — memory released, next request reloads", idle)
 
 
 @app.on_event("startup")
-def _warm():
-    # Load at startup rather than on the first caller. A cold first request that
-    # blocks for the model load looks like a hang to whoever asked for it — the
-    # same "ready doesn't mean ready" trap that bit the webdev wake path.
-    try:
-        get_model()
-    except Exception as e:  # never crash the container over a warm failure
-        logger.error("startup warm failed (will retry on first request): %s", e)
+async def _startup():
+    if WARM_ON_START:
+        # Warm in a worker thread so it cannot block the event loop (and the
+        # health endpoint) during the multi-second load.
+        def _warm():
+            try:
+                get_model()
+            except Exception as e:  # never crash the container over a warm failure
+                logger.error("startup warm failed (will retry on first request): %s", e)
+        threading.Thread(target=_warm, daemon=True).start()
+
+    async def _reaper():
+        while True:
+            await asyncio.sleep(REAP_EVERY_S)
+            try:
+                await asyncio.to_thread(_unload_if_idle)
+            except Exception:
+                logger.exception("idle reaper tick failed")   # never kill the loop
+    if IDLE_UNLOAD_S > 0:
+        asyncio.create_task(_reaper())
+        logger.info("idle-unload armed: %ss idle -> release model (~2GB)", IDLE_UNLOAD_S)
 
 
 @app.get("/health")
 def health():
-    return {"ok": True, "model": MODEL_ID, "loaded": _model is not None}
+    """`loaded:false` is NORMAL here — it means the model was released after idle,
+    not that the service is broken. `ok` is the liveness signal; a caller that
+    treats loaded:false as "down" would be reading a memory optimisation as an
+    outage."""
+    return {
+        "ok": True,
+        "model": MODEL_ID,
+        "loaded": _model is not None,
+        "idle_unload_s": IDLE_UNLOAD_S,
+        "idle_s": round(time.time() - _last_used, 1),
+    }
 
 
 def _to_wav16k(src: str, dst: str) -> bool:
@@ -94,12 +170,23 @@ async def transcribe(audio: UploadFile = File(...)):
             # and ffmpeg's failure may be about metadata, not audio.
             wav = src
 
+        global _inflight, _last_used
         t0 = time.time()
+        # Mark in-flight BEFORE resolving the model so the idle reaper cannot free
+        # it between get_model() returning and recognize() using it.
+        with _inflight_lock:
+            _inflight += 1
         try:
             text = get_model().recognize(wav)
         except Exception as e:
             logger.exception("recognition failed")
             raise HTTPException(status_code=500, detail=f"recognition failed: {e}")
+        finally:
+            with _inflight_lock:
+                _inflight -= 1
+            # Stamp on COMPLETION too: a long transcription would otherwise let
+            # _last_used age past the idle window while it was still running.
+            _last_used = time.time()
         elapsed = time.time() - t0
 
         # Report real-time factor so callers can see it degrade under load

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ flask-sock==0.7.0
 # WebSocket & HTTP
 websockets==16.1.1
 requests==2.34.2
+PySocks==1.7.1                 # SOCKS5 proxy support for requests (residential IP routing)
 # httpx is imported directly by several providers (tts_providers/{hume,elevenlabs,resemble,
 # qwen3,qwen3_local}_provider.py, routes/story.py, providers/stt/grok_provider.py). It was
 # previously satisfied only transitively via `groq` — declare it so a clean install cannot

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1383,26 +1383,33 @@ def _conversation_inner():
                     except Exception as _ie:
                         logger.debug('Could not read .image-intel cache: %s', _ie)
                 if _upload_desc is None:
-                    # No cache yet — route to vision@mesh (persistent claude-code/sonnet in tmux)
+                    # No cache yet — route to vision@mesh via openclaw container (has mesh-send + mesh mount)
                     # Non-blocking: mesh task, vision agent writes .image-intel sidecar async
-                    import subprocess as _sp, re as _re
-                    _tenant_m = _re.search(r'/mnt/clients/([^/]+)/', str(_img_file))
-                    if _tenant_m:
-                        _tenant = _tenant_m.group(1)
+                    # OVU runs inside Docker; mesh-send isn't in this image but openclaw-<tenant> has it.
+                    import subprocess as _sp
+                    _tenant = os.getenv('JAMBOT_TENANT', '')
+                    if _tenant:
+                        # Build the HOST path (vision agent runs on host, needs /mnt/clients/ path)
+                        _host_img_path = f'/mnt/clients/{_tenant}/openvoiceui/uploads/{_img_file.name}'
+                        _msg_body = (
+                            f'image_path: {_host_img_path}\n'
+                            f'tenant: {_tenant}\n'
+                            f'filename: {_img_file.name}'
+                        )
+                        _mesh_cmd = (
+                            f'AGENT_URI=openvoiceui@mesh '
+                            f'/mnt/shared-skills/agent-mesh/bin/mesh-send '
+                            f'--to vision@mesh --kind task '
+                            f'--subject analyze-{_img_file.stem[:40]}'
+                        )
                         try:
-                            _msg_body = (
-                                f'image_path: {_img_file}\n'
-                                f'tenant: {_tenant}\n'
-                                f'filename: {_img_file.name}'
-                            )
-                            _env = {**os.environ, 'AGENT_URI': 'openvoiceui@mesh'}
                             _sp.run(
-                                ['mesh-send', '--to', 'vision@mesh', '--kind', 'task',
-                                 '--subject', f'analyze-{_img_file.stem[:40]}'],
+                                ['docker', 'exec', '-i', f'openclaw-{_tenant}',
+                                 'bash', '-c', _mesh_cmd],
                                 input=_msg_body.encode(),
-                                timeout=5, capture_output=True, env=_env,
+                                timeout=8, capture_output=True,
                             )
-                            logger.info('Image analysis queued to vision@mesh: %s', _img_file.name)
+                            logger.info('Image analysis queued to vision@mesh via openclaw-%s: %s', _tenant, _img_file.name)
                         except Exception as _se:
                             logger.warning('Failed to queue vision task to vision@mesh: %s', _se)
                     _upload_desc = 'Image is being analyzed now. Ask me about it in about 30 seconds.'

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1383,13 +1383,32 @@ def _conversation_inner():
                     except Exception as _ie:
                         logger.debug('Could not read .image-intel cache: %s', _ie)
                 if _upload_desc is None:
-                    from routes.vision import _call_vision
-                    _img_b64 = base64.b64encode(_img_file.read_bytes()).decode('ascii')
-                    _upload_desc = _call_vision(
-                        _img_b64,
-                        'Describe what you see in this image in detail. Include colors, objects, text, people, layout, and any notable features.',
-                    )
-                    logger.info('Vision analysis of uploaded image via live API succeeded (%d bytes)', _img_file.stat().st_size)
+                    # No cache yet — trigger subscription Claude sweep for this tenant
+                    # (never call paid Groq/OpenAI/Gemini vision APIs for tasks subscription handles)
+                    import subprocess as _sp, re as _re
+                    _tenant_m = _re.search(r'/mnt/clients/([^/]+)/', str(_img_file))
+                    if _tenant_m:
+                        _sweep = '/home/mike/MIKE-AI/scripts/image-intel/image-intel-sweep.py'
+                        try:
+                            _sp.run(
+                                ['python3', _sweep, '--tenant', _tenant_m.group(1), '--limit', '1'],
+                                timeout=45, capture_output=True,
+                            )
+                            if _intel_path.is_file():
+                                import json as _json2
+                                _intel2 = _json2.loads(_intel_path.read_text())
+                                _c2 = _intel2.get('analysis', {}).get('description', '').strip()
+                                if _c2:
+                                    _upload_desc = _c2
+                                    _txt2 = _intel2.get('analysis', {}).get('text_in_image', '').strip()
+                                    if _txt2:
+                                        _upload_desc += f' Text visible: {_txt2}'
+                                    logger.info('Image analyzed via subscription Claude sweep: %s', _img_file.name)
+                        except Exception as _se:
+                            logger.warning('Subscription sweep for image failed: %s', _se)
+                    if _upload_desc is None:
+                        _upload_desc = 'Image received and is being analyzed via subscription Claude. Ask me about it again in about 30 seconds.'
+                        logger.info('Image queued for subscription analysis: %s', _img_file.name)
                 context_parts.append(f'[UPLOADED IMAGE ANALYSIS: {_upload_desc}]')
             else:
                 logger.warning('Uploaded image not found or too large: %s', image_path)

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1383,32 +1383,18 @@ def _conversation_inner():
                     except Exception as _ie:
                         logger.debug('Could not read .image-intel cache: %s', _ie)
                 if _upload_desc is None:
-                    # No cache yet — trigger subscription Claude sweep for this tenant
-                    # (never call paid Groq/OpenAI/Gemini vision APIs for tasks subscription handles)
-                    import subprocess as _sp, re as _re
-                    _tenant_m = _re.search(r'/mnt/clients/([^/]+)/', str(_img_file))
-                    if _tenant_m:
-                        _sweep = '/home/mike/MIKE-AI/scripts/image-intel/image-intel-sweep.py'
-                        try:
-                            _sp.run(
-                                ['python3', _sweep, '--tenant', _tenant_m.group(1), '--limit', '1'],
-                                timeout=45, capture_output=True,
-                            )
-                            if _intel_path.is_file():
-                                import json as _json2
-                                _intel2 = _json2.loads(_intel_path.read_text())
-                                _c2 = _intel2.get('analysis', {}).get('description', '').strip()
-                                if _c2:
-                                    _upload_desc = _c2
-                                    _txt2 = _intel2.get('analysis', {}).get('text_in_image', '').strip()
-                                    if _txt2:
-                                        _upload_desc += f' Text visible: {_txt2}'
-                                    logger.info('Image analyzed via subscription Claude sweep: %s', _img_file.name)
-                        except Exception as _se:
-                            logger.warning('Subscription sweep for image failed: %s', _se)
-                    if _upload_desc is None:
-                        _upload_desc = 'Image received and is being analyzed via subscription Claude. Ask me about it again in about 30 seconds.'
-                        logger.info('Image queued for subscription analysis: %s', _img_file.name)
+                    # No cache yet — analyze via headless Claude (subscription, no marginal cost)
+                    # docker run jambot/openclaw:latest has the claude binary; same path as cron sweep
+                    try:
+                        from routes.vision import _call_vision_via_claude
+                        _upload_desc = _call_vision_via_claude(
+                            str(_img_file),
+                            'Describe what you see in this image in detail. Include colors, objects, text, people, layout, and any notable features.',
+                        )
+                        logger.info('Image analyzed live via claude subscription: %s', _img_file.name)
+                    except Exception as _ve:
+                        logger.warning('Claude live vision failed, image queued for cron: %s', _ve)
+                        _upload_desc = 'Image received and is being analyzed. Ask me about it again in about a minute.'
                 context_parts.append(f'[UPLOADED IMAGE ANALYSIS: {_upload_desc}]')
             else:
                 logger.warning('Uploaded image not found or too large: %s', image_path)

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1383,18 +1383,30 @@ def _conversation_inner():
                     except Exception as _ie:
                         logger.debug('Could not read .image-intel cache: %s', _ie)
                 if _upload_desc is None:
-                    # No cache yet — analyze via headless Claude (subscription, no marginal cost)
-                    # docker run jambot/openclaw:latest has the claude binary; same path as cron sweep
-                    try:
-                        from routes.vision import _call_vision_via_claude
-                        _upload_desc = _call_vision_via_claude(
-                            str(_img_file),
-                            'Describe what you see in this image in detail. Include colors, objects, text, people, layout, and any notable features.',
-                        )
-                        logger.info('Image analyzed live via claude subscription: %s', _img_file.name)
-                    except Exception as _ve:
-                        logger.warning('Claude live vision failed, image queued for cron: %s', _ve)
-                        _upload_desc = 'Image received and is being analyzed. Ask me about it again in about a minute.'
+                    # No cache yet — route to vision@mesh (persistent claude-code/sonnet in tmux)
+                    # Non-blocking: mesh task, vision agent writes .image-intel sidecar async
+                    import subprocess as _sp, re as _re
+                    _tenant_m = _re.search(r'/mnt/clients/([^/]+)/', str(_img_file))
+                    if _tenant_m:
+                        _tenant = _tenant_m.group(1)
+                        try:
+                            _msg_body = (
+                                f'image_path: {_img_file}\n'
+                                f'tenant: {_tenant}\n'
+                                f'filename: {_img_file.name}'
+                            )
+                            _env = {**os.environ, 'AGENT_URI': 'openvoiceui@mesh'}
+                            _sp.run(
+                                ['mesh-send', '--to', 'vision@mesh', '--kind', 'task',
+                                 '--subject', f'analyze-{_img_file.stem[:40]}'],
+                                input=_msg_body.encode(),
+                                timeout=5, capture_output=True, env=_env,
+                            )
+                            logger.info('Image analysis queued to vision@mesh: %s', _img_file.name)
+                        except Exception as _se:
+                            logger.warning('Failed to queue vision task to vision@mesh: %s', _se)
+                    _upload_desc = 'Image is being analyzed now. Ask me about it in about 30 seconds.'
+                    logger.info('Image routed to vision@mesh: %s', _img_file.name)
                 context_parts.append(f'[UPLOADED IMAGE ANALYSIS: {_upload_desc}]')
             else:
                 logger.warning('Uploaded image not found or too large: %s', image_path)

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1363,14 +1363,34 @@ def _conversation_inner():
             if 'uploads' not in _img_file.parts:
                 raise ValueError(f'Path traversal blocked: {image_path}')
             if _img_file.is_file() and _img_file.stat().st_size < 20_000_000:  # 20MB safety cap
-                from routes.vision import _call_vision
-                _img_b64 = base64.b64encode(_img_file.read_bytes()).decode('ascii')
-                _upload_desc = _call_vision(
-                    _img_b64,
-                    'Describe what you see in this image in detail. Include colors, objects, text, people, layout, and any notable features.',
-                )
+                # Check .image-intel cache first — avoids live API call when image was pre-analyzed
+                _intel_path = _img_file.parent / '.image-intel' / (_img_file.name + '.json')
+                _upload_desc = None
+                if _intel_path.is_file():
+                    try:
+                        import json as _json
+                        _intel = _json.loads(_intel_path.read_text())
+                        _cached = _intel.get('analysis', {}).get('description', '').strip()
+                        if _cached:
+                            _kw = _intel.get('analysis', {}).get('keywords', [])
+                            _txt = _intel.get('analysis', {}).get('text_in_image', '').strip()
+                            _upload_desc = _cached
+                            if _txt:
+                                _upload_desc += f' Text visible in image: {_txt}'
+                            if _kw:
+                                _upload_desc += f' Keywords: {", ".join(_kw[:10])}'
+                            logger.info('Loaded image analysis from .image-intel cache: %s', _img_file.name)
+                    except Exception as _ie:
+                        logger.debug('Could not read .image-intel cache: %s', _ie)
+                if _upload_desc is None:
+                    from routes.vision import _call_vision
+                    _img_b64 = base64.b64encode(_img_file.read_bytes()).decode('ascii')
+                    _upload_desc = _call_vision(
+                        _img_b64,
+                        'Describe what you see in this image in detail. Include colors, objects, text, people, layout, and any notable features.',
+                    )
+                    logger.info('Vision analysis of uploaded image via live API succeeded (%d bytes)', _img_file.stat().st_size)
                 context_parts.append(f'[UPLOADED IMAGE ANALYSIS: {_upload_desc}]')
-                logger.info('Vision analysis of uploaded image succeeded (%d bytes)', _img_file.stat().st_size)
             else:
                 logger.warning('Uploaded image not found or too large: %s', image_path)
                 context_parts.append('[UPLOADED IMAGE: File could not be analyzed — may be too large or missing.]')

--- a/routes/services.py
+++ b/routes/services.py
@@ -80,9 +80,18 @@ _STT_STATIC = {
         'name': 'Groq Whisper', 'source': 'builtin',
         'creds': ['GROQ_API_KEY'], 'note': 'Groq whisper-large (/api/stt/groq).',
     },
+    # Was advertised as 'faster-whisper on-box' with creds:[] while
+    # faster-whisper was NOT installed (commented out in requirements.txt) —
+    # anything picking a provider from this registry would choose it as the free
+    # option and get a runtime failure. Now names what actually serves it.
     'whisper': {
-        'name': 'Whisper (local)', 'source': 'builtin',
-        'creds': [], 'note': 'faster-whisper on-box (/api/stt/local).',
+        'name': 'Parakeet TDT 0.6B v3 (local)', 'source': 'builtin',
+        'creds': [],
+        'note': 'Shared on-box STT via jambot-parakeet:8770 (/api/stt/local). '
+                'No API key, no per-call cost, audio stays on the server. '
+                'Falls back to in-process faster-whisper only if that service '
+                'is unreachable AND the package is installed. '
+                'Model licence CC-BY-4.0 — attribution required.',
     },
     'external': {
         'name': 'External STT', 'source': 'builtin',

--- a/routes/vision.py
+++ b/routes/vision.py
@@ -101,23 +101,81 @@ def _get_vision_model() -> tuple[str, str]:
     return DEFAULT_VISION_MODEL, DEFAULT_VISION_PROVIDER
 
 
-def _call_vision(image_b64: str, prompt: str, model: str | None = None) -> str:
+def _call_vision_via_claude(container_img_path: str, prompt: str) -> str:
+    """
+    Analyze an uploaded image file using headless Claude Code (subscription, no marginal cost).
+
+    Runs `docker run jambot/openclaw:latest` — the openclaw image has the claude binary
+    and sources CLAUDE_CODE_OAUTH_TOKEN from the mounted platform-keys env. Same
+    subscription path as the image-intel cron sweep; no Groq/Gemini/OpenAI.
+
+    container_img_path: path to image inside the OVU container (/app/runtime/uploads/<file>).
+    Converts to the host filesystem path for the docker-run -v bind.
+    """
+    import subprocess
+
+    tenant = (os.environ.get('CLIENT_NAME') or '').strip().lower()
+    if not tenant:
+        raise ValueError('CLIENT_NAME env not set — cannot derive host image path')
+
+    filename = Path(container_img_path).name
+    host_img_path = f'/mnt/clients/{tenant}/openvoiceui/uploads/{filename}'
+
+    vision_prompt = f'Read the image file at {host_img_path} and then: {prompt}'
+
+    # Source platform keys to get CLAUDE_CODE_OAUTH_TOKEN, then run claude with full path
+    bash_cmd = (
+        'set -a; source /mnt/system/base/.platform-keys.env 2>/dev/null; set +a; '
+        'PATH="/home/node/.local/bin:$PATH" '
+        'claude -p --model claude-sonnet-5 '
+        '--allowedTools Read --output-format text "$VISION_PROMPT"'
+    )
+
+    proc = subprocess.run(
+        ['docker', 'run', '--rm',
+         '-v', '/mnt:/mnt:ro',
+         '-e', f'VISION_PROMPT={vision_prompt}',
+         'jambot/openclaw:latest',
+         '/bin/bash', '-c', bash_cmd],
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f'claude vision rc={proc.returncode}: {(proc.stderr or "")[:300]}'
+        )
+
+    result = proc.stdout.strip()
+    if not result:
+        raise RuntimeError('claude vision returned empty response')
+
+    return result
+
+
+def _call_vision(image_b64: str, prompt: str, model: str | None = None, file_path: str | None = None) -> str:
     """
     Send an image + prompt to the configured vision model and return the text response.
 
-    Uses Groq's Qwen3.6-27B vision model. Groq decommissioned llama-4-scout
-    (~2026-07 — returned model_not_found, breaking all vision calls fleet-wide).
-    Z.AI/GLM vision through api.z.ai is broken (returns hallucinated descriptions).
+    For uploaded image files (file_path provided): routes through headless Claude Code
+    subscription via docker run — no Groq/Gemini/OpenAI, no marginal cost.
+    For camera frames (no file_path): uses Groq qwen3.6-27b as before.
 
     image_b64 may be a raw base64 string or a data-URI (data:image/jpeg;base64,...).
     """
+    # Uploaded files: use Claude subscription (image-intel system pattern)
+    if file_path:
+        return _call_vision_via_claude(file_path, prompt)
+
+    # Camera frames: Groq path (in-memory frames have no on-disk path)
     # Strip data-URI prefix if present
     if image_b64.startswith('data:'):
         image_b64 = image_b64.split(',', 1)[1]
 
     api_key = os.environ.get('GROQ_API_KEY', '')
     if not api_key:
-        raise ValueError('GROQ_API_KEY is not set — cannot call vision model')
+        raise ValueError('GROQ_API_KEY is not set — cannot call vision model for camera frame')
 
     vision_model = os.environ.get('GROQ_VISION_MODEL', 'qwen/qwen3.6-27b')
 

--- a/server.py
+++ b/server.py
@@ -1336,8 +1336,7 @@ def brave_search():
 
 @app.route("/api/search", methods=["GET", "POST"])
 def web_search():
-    """Web search via DuckDuckGo (no API key required)."""
-    import urllib.request
+    """Web search via DuckDuckGo routed through residential SOCKS5 proxy."""
     import urllib.parse
     from html.parser import HTMLParser
 
@@ -1381,14 +1380,20 @@ def web_search():
             if self._capture:
                 self._text += data
 
+    # Route through residential proxy (avoids datacenter IP blocks)
+    proxy_server = os.getenv("BROWSE_PROXY_SERVER", "")
+    session_proxies = {"http": proxy_server, "https": proxy_server} if proxy_server else None
+
     try:
         encoded = urllib.parse.quote_plus(query)
-        req = urllib.request.Request(
+        resp = requests.get(
             f"https://html.duckduckgo.com/html/?q={encoded}",
             headers={"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"},
+            proxies=session_proxies,
+            timeout=15,
         )
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            html = resp.read().decode("utf-8")
+        resp.raise_for_status()
+        html = resp.text
         parser = _DDGParser()
         parser.feed(html)
         results = parser.results[:5]

--- a/server.py
+++ b/server.py
@@ -57,19 +57,52 @@ _whisper_model = None
 
 
 def get_whisper_model():
+    """LEGACY in-process Whisper. Only used if the shared STT service is absent.
+
+    Prefer the shared jambot-parakeet service (see local_stt below): the model is
+    ~680MB and baking it into every one of 24+ OVU containers would be wasteful
+    on a memory-constrained box. faster-whisper is also NOT installed by default
+    (commented out in requirements.txt), so this path normally raises.
+    """
     global _whisper_model
     if _whisper_model is None:
         try:
             from faster_whisper import WhisperModel
         except ImportError:
             raise ImportError(
-                "Local STT requires faster-whisper. Install it with: "
-                "pip install faster-whisper"
+                "Local STT requires either the shared jambot-parakeet service "
+                "(preferred — set PARAKEET_STT_URL) or faster-whisper installed "
+                "in this container."
             )
         logger.info("Loading Faster-Whisper model (first STT request)...")
         _whisper_model = WhisperModel("tiny", device="cpu", compute_type="float32")
         logger.info("Faster-Whisper model ready.")
     return _whisper_model
+
+
+# Shared on-box STT (NVIDIA Parakeet TDT 0.6B v3) on the jambot-shared network.
+# Free, keyless, audio never leaves the server. See deploy/parakeet-stt/.
+PARAKEET_STT_URL = os.getenv("PARAKEET_STT_URL", "http://jambot-parakeet:8770")
+
+
+def _parakeet_transcribe(audio_bytes, filename="audio.webm", timeout=180):
+    """POST to the shared STT service. Returns transcript str, or None if the
+    service is unreachable so the caller can fall back rather than fail."""
+    import requests
+    try:
+        r = requests.post(
+            f"{PARAKEET_STT_URL}/transcribe",
+            files={"audio": (filename, audio_bytes)},
+            timeout=timeout,
+        )
+        if r.status_code != 200:
+            logger.warning("parakeet STT http %s: %s", r.status_code, r.text[:200])
+            return None
+        return (r.json() or {}).get("text", "")
+    except Exception as e:
+        # Unreachable is a fallback condition, not an error to surface upward.
+        logger.info("parakeet STT unavailable (%s) — falling back", e)
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -1184,6 +1217,16 @@ def local_stt():
 
     audio_file = request.files["audio"]
     audio_bytes = audio_file.read()
+
+    # PREFERRED PATH: the shared jambot-parakeet service. One ~680MB model for
+    # the whole fleet instead of a copy per OVU container, and it does its own
+    # ffmpeg normalisation. Falls through to the in-process path below only if
+    # the service is unreachable — a missing shared service degrades, it does
+    # not break voice.
+    _text = _parakeet_transcribe(audio_bytes, audio_file.filename or "audio.webm")
+    if _text is not None:
+        logger.info("Local STT (parakeet): %r", _text)
+        return jsonify({"transcript": _text, "success": True, "engine": "parakeet-tdt-0.6b-v3"})
 
     with tempfile.NamedTemporaryFile(suffix=".webm", delete=False) as tmp:
         tmp.write(audio_bytes)


### PR DESCRIPTION
Lands today's on-box STT + vision-routing work so the fleet image can be rebuilt from `main`.

## Why this is going in now

The fleet is running on **orphaned images** — pruned out from under the containers, so there is no record of what code is live and `docker rm` is unrecoverable. Fixing that requires recreating the containers onto a real tagged image. `jambot/openvoiceui:latest` was built from this branch, so the containers would have landed on unmerged code. Merging first makes the roll land on `main` with real provenance.

## What is in it

**Shared on-box Parakeet STT** (`deploy/parakeet-stt/`) — no API key, no per-call cost. `/api/stt/local` routes to it, and the model is released after idle; it was the box's single largest memory consumer, which matters after the 2026-07-25 memory exhaustion.

**Vision routed off paid Groq** — uploaded-image analysis now goes through the subscription Claude path and the residential proxy, with the `.image-intel` cache read before any live API call. Bulk vision on a metered API was the cost defect this corrects.

8 files, +490/-21. No schema, config, or dependency changes beyond one `requirements.txt` line.

## Risk

Touches `server.py`, `routes/conversation.py`, `routes/services.py`, `routes/vision.py` — all live request paths. Mitigation is the roll itself: 22 containers recreated one at a time with health verification, `openvoiceui-josh` and `openclaw-josh` deliberately excluded, and `jambot-shared` re-attached after each recreate (a plain `compose up -d` drops post-start networks — fixed in `040f30d`).
