### PR TITLE
fix(csp): style-src blocked CDN stylesheets, img-src blocked map tiles

### DIFF
--- a/app.py
+++ b/app.py
@@ -363,11 +363,16 @@ def create_app(config_override: dict = None):
             # CSP violation. Found 2026-07-24: the maps skill documented these as allowed
             # but they were never actually in either CSP. Do NOT re-strip.
             "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://*.clerk.accounts.dev https://*.jam-bot.com https://maps.googleapis.com https://maps.gstatic.com; "
-            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+            # jsdelivr serves stylesheets as well as scripts (Leaflet, etc). It was in
+            # script-src but NOT style-src, so a canvas page could load a library's JS
+            # and have its CSS silently blocked — which renders as "the widget is
+            # missing and everything overlaps", not as an obvious error. Found 2026-07-27
+            # on allstate's Leaflet map page.
+            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; "
             "font-src 'self' data: https://fonts.gstatic.com; "
             # Map tiles/markers come from maps.gstatic.com, *.googleapis.com (khms tile
             # shards) and *.ggpht.com (Street View); googleusercontent serves place photos.
-            "img-src 'self' data: blob: https://img.clerk.com https://images.clerk.dev https://*.clerk.accounts.dev https://lh3.googleusercontent.com https://avatars.githubusercontent.com https://bhaleyart.github.io https://maps.googleapis.com https://maps.gstatic.com https://*.googleapis.com https://*.ggpht.com https://*.googleusercontent.com; "
+            "img-src 'self' data: blob: https://img.clerk.com https://images.clerk.dev https://*.clerk.accounts.dev https://lh3.googleusercontent.com https://avatars.githubusercontent.com https://bhaleyart.github.io https://maps.googleapis.com https://maps.gstatic.com https://*.googleapis.com https://*.ggpht.com https://*.googleusercontent.com;  https://*.tile.openstreetmap.org https://tile.openstreetmap.org https://*.basemaps.cartocdn.com"
             "media-src 'self' blob:; "
             "connect-src 'self' wss: https:; "
             "frame-src 'self' https://*.clerk.accounts.dev https://*.jam-bot.com https:; "


### PR DESCRIPTION
allstate's Leaflet page rendered no map and its elements overlapped. Two CSP gaps — same class as the `maps.googleapis.com` omission fixed in #412, but in different directives.

**1. `style-src` blocked `cdn.jsdelivr.net`** even though `script-src` already allowed it. A canvas page could load a library's JavaScript and have its stylesheet silently blocked. That does not surface as an error — it surfaces as *"the widget is missing and everything overlaps"*, because a CSS-less Leaflet has no pane positioning and its absolutely-positioned children collapse onto each other. Exactly the two reported symptoms.

**2. `img-src` carried the Google Maps tile origins but not OpenStreetMap's.** Any page using the standard Leaflet + OSM `tileLayer` gets no tiles. Added the OSM origins plus carto basemaps, which the same pages commonly fall back to.

**Verified this was NOT the #412 bug before patching** — allstate's served CSP already contains `maps.googleapis.com`, and its image is `d8e1779`, identical to test-dev. The first hypothesis was wrong and checking it cost one curl.

**Scope note:** the allstate page *also* never linked `leaflet.css` at all. That half is a page defect being fixed separately in the tenant's canvas-pages. This PR only removes the platform-side blocker, so CDN stylesheets and OSM tiles work for every tenant rather than one page.

⚠️ **Not live on merge.** `app.py` is not bind-mounted into tenant containers, so this needs an image rebuild + fleet roll to take effect — the same gap that left #412 patched on test-dev only.