### PR TITLE
feat(spend): metered-API spend tally — receipt per paid generation call

### DIFF
--- a/routes/icons.py
+++ b/routes/icons.py
@@ -374,6 +374,8 @@ def generate_icon_image(prompt, name=None, style=None, allow_reuse=True):
 
     # Call Gemini API
     try:
+        from services.metered_spend import log_spend
+        log_spend('icons/generate', GEMINI_MODEL)
         resp = requests.post(
             f'{GEMINI_URL}?key={GEMINI_API_KEY}',
             json={

--- a/routes/image_gen.py
+++ b/routes/image_gen.py
@@ -21,6 +21,7 @@ import time
 import requests as http
 from flask import Blueprint, jsonify, request
 from services.paths import UPLOADS_DIR
+from services.metered_spend import log_spend
 
 logger = logging.getLogger(__name__)
 image_gen_bp = Blueprint('image_gen', __name__)
@@ -301,6 +302,9 @@ def generate_image():
                 return jsonify({'error': 'GEMINI_API_KEY not configured on server'}), 503
             imgs_out, text_out = _generate_gemini(model, prompt, images)
 
+        # Spend tally — the call was made (and billed) whether or not an image came back.
+        log_spend('image-gen', model, cost_key='hf-inference' if is_hf else None)
+
         if not imgs_out:
             return jsonify({'error': 'Model returned no image', 'text': text_out}), 502
 
@@ -340,6 +344,7 @@ def enhance_prompt_route():
 
     try:
         enhanced = _enhance_prompt(idea, quality, style)
+        log_spend('image-gen/enhance', 'enhance-prompt')
         if not enhanced:
             return jsonify({'error': 'LLM returned empty response'}), 502
         logger.info('enhance_prompt: idea_len=%d → prompt_len=%d quality=%s', len(idea), len(enhanced), quality)

--- a/services/metered_spend.py
+++ b/services/metered_spend.py
@@ -1,0 +1,64 @@
+"""Metered-API spend tally — one JSONL row per paid generation call.
+
+WHY (Mike, 2026-07-28): last month closed with ~$100 of Gemini and $50 of OpenAI
+spend that nobody on the box could see until the bill arrived. Nothing here
+watches metered keys — the usage-costs layer tracks subscription tokens, not
+per-call metered APIs. This module is the missing receipt trail: every call
+that costs real money appends one line, into the tenant's UPLOADS_DIR so the
+HOST sees it via the existing /mnt/clients/<t>/openvoiceui/uploads mount with
+no new plumbing. Host-side aggregator: scripts/metered-spend-report.py →
+boot-gate line.
+
+Costs are ESTIMATES (list-price ballpark per image/call, not billing truth) —
+they exist to make relative burn visible daily, not to reconcile invoices.
+Update EST_COST_USD when providers reprice; an unknown model logs cost=None,
+which the aggregator surfaces as UNPRICED rather than silently $0 (a spend row
+that cannot be priced must not look free).
+
+Never raises: a broken tally must not break generation itself.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+
+from services.paths import UPLOADS_DIR
+
+logger = logging.getLogger(__name__)
+
+SPEND_LOG = UPLOADS_DIR / ".metered-spend.jsonl"
+
+# List-price ballparks per CALL (image models: per image). Estimates on purpose.
+EST_COST_USD = {
+    # Gemini image generation
+    "nano-banana-pro-preview": 0.15,
+    "gemini-3.1-flash-image-preview": 0.04,
+    "gemini-2.5-flash-image": 0.04,
+    "gemini-2.0-flash-exp-image-generation": 0.04,
+    "imagen-4.0-generate-001": 0.04,
+    "imagen-4.0-fast-generate-001": 0.02,
+    "imagen-3.0-generate-002": 0.03,
+    # Gemini text calls made by generation features (prompt enhance)
+    "enhance-prompt": 0.001,
+    # HF inference (FLUX/SD) — credit-metered, negligible per call at our tier;
+    # priced non-zero so volume still shows up in the tally.
+    "hf-inference": 0.005,
+}
+
+
+def log_spend(route: str, model: str, n_calls: int = 1, cost_key: str | None = None) -> None:
+    """Append one spend row. cost_key overrides model for pricing (e.g. 'hf-inference')."""
+    try:
+        est = EST_COST_USD.get(cost_key or model)
+        row = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "route": route,
+            "model": model,
+            "n": n_calls,
+            "est_usd": round(est * n_calls, 4) if est is not None else None,
+        }
+        with SPEND_LOG.open("a") as f:
+            f.write(json.dumps(row) + "\n")
+    except Exception:  # noqa: BLE001 — tally must never break the feature
+        logger.warning("metered_spend: failed to log row", exc_info=True)


### PR DESCRIPTION
Container half of the spend-visibility fix (host aggregator + boot-gate section already live, MIKE-AI `4dee837`).

Every metered generation call — image-gen (Gemini/Imagen/HF), prompt enhance, icons — appends one JSONL row (`ts, route, model, n, est_usd`) to `UPLOADS_DIR/.metered-spend.jsonl`, host-visible via the existing uploads mount. Hourly host cron aggregates; boot-gate shows month-to-date/today with a red flag at $25/mo.

- Unknown model → `est_usd: null` → surfaces as **UNPRICED**, never $0
- Logged at call time, not save time — the call is billed even if no image returns
- `log_spend()` never raises — tally failure can't break generation

Context: last month closed with ~$100 Gemini + $50 OpenAI seen only at billing time. Companion to #421 (cheap-by-default).