### PR TITLE
feat(albums): job photo albums — CompanyCam-style camera capture

### DIFF
--- a/default-pages/camera-capture.html
+++ b/default-pages/camera-capture.html
@@ -1,0 +1,601 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<title>Job Photos</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; -webkit-tap-highlight-color: transparent; }
+
+  :root {
+    --bg: #0a0a0a;
+    --surface: #141414;
+    --surface2: #1e1e1e;
+    --border: #2a2a2a;
+    --accent: #f59e0b;
+    --accent-dim: rgba(245,158,11,0.15);
+    --text: #f1f1f1;
+    --muted: #888;
+    --green: #22c55e;
+    --red: #ef4444;
+    --radius: 12px;
+  }
+
+  html, body {
+    height: 100%;
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 15px;
+    overflow: hidden;
+  }
+
+  /* ---- App shell ---- */
+  #app {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ---- Header ---- */
+  header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+    min-height: 56px;
+  }
+
+  header h1 {
+    font-size: 16px;
+    font-weight: 600;
+    flex: 1;
+  }
+
+  .btn-icon {
+    background: none;
+    border: none;
+    color: var(--accent);
+    font-size: 22px;
+    cursor: pointer;
+    padding: 4px;
+    line-height: 1;
+  }
+
+  /* ---- Viewfinder ---- */
+  #viewfinder-wrap {
+    flex: 1;
+    position: relative;
+    overflow: hidden;
+    background: #000;
+  }
+
+  #video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  #canvas-snap { display: none; }
+
+  /* flash overlay */
+  #flash {
+    position: absolute;
+    inset: 0;
+    background: #fff;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.05s;
+  }
+
+  /* GPS badge */
+  #gps-badge {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    background: rgba(0,0,0,0.55);
+    backdrop-filter: blur(6px);
+    border-radius: 20px;
+    padding: 4px 10px;
+    font-size: 11px;
+    color: var(--muted);
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
+  #gps-badge.ok { color: var(--green); }
+  #gps-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+
+  /* Session counter */
+  #session-counter {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    background: rgba(0,0,0,0.55);
+    backdrop-filter: blur(6px);
+    border-radius: 20px;
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  /* ---- Bottom controls ---- */
+  #controls {
+    background: var(--surface);
+    border-top: 1px solid var(--border);
+    flex-shrink: 0;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  /* album row */
+  #album-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  #album-select {
+    flex: 1;
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-radius: var(--radius);
+    padding: 10px 12px;
+    font-size: 14px;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
+  #btn-new-album {
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    color: var(--accent);
+    border-radius: var(--radius);
+    padding: 10px 14px;
+    font-size: 13px;
+    cursor: pointer;
+    white-space: nowrap;
+    font-weight: 600;
+  }
+
+  /* note row */
+  #note-wrap {
+    position: relative;
+  }
+  #note-input {
+    width: 100%;
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-radius: var(--radius);
+    padding: 10px 12px;
+    font-size: 14px;
+    resize: none;
+    font-family: inherit;
+  }
+  #note-input::placeholder { color: var(--muted); }
+
+  /* shutter row */
+  #shutter-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 24px;
+  }
+
+  #btn-flip {
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 50%;
+    width: 44px; height: 44px;
+    font-size: 20px;
+    cursor: pointer;
+    color: var(--text);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  #btn-shutter {
+    width: 70px; height: 70px;
+    border-radius: 50%;
+    background: #fff;
+    border: 4px solid rgba(255,255,255,0.3);
+    cursor: pointer;
+    transition: transform 0.1s, opacity 0.1s;
+    outline: none;
+    position: relative;
+  }
+  #btn-shutter:active { transform: scale(0.92); }
+  #btn-shutter.uploading { background: var(--accent); }
+
+  #btn-view {
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 50%;
+    width: 44px; height: 44px;
+    font-size: 20px;
+    cursor: pointer;
+    color: var(--text);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    position: relative;
+  }
+  #view-count {
+    position: absolute;
+    top: -4px; right: -4px;
+    background: var(--accent);
+    color: #000;
+    border-radius: 10px;
+    font-size: 10px;
+    font-weight: 700;
+    padding: 1px 5px;
+    display: none;
+  }
+
+  /* ---- Toast ---- */
+  #toast {
+    position: fixed;
+    bottom: 0;
+    left: 0; right: 0;
+    padding: 14px 20px;
+    background: var(--surface);
+    border-top: 1px solid var(--border);
+    font-size: 14px;
+    text-align: center;
+    transform: translateY(100%);
+    transition: transform 0.25s ease;
+    z-index: 999;
+  }
+  #toast.show { transform: translateY(0); }
+  #toast.success { border-color: var(--green); color: var(--green); }
+  #toast.error { border-color: var(--red); color: var(--red); }
+
+  /* ---- Modals ---- */
+  .modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.75);
+    display: flex;
+    align-items: flex-end;
+    z-index: 200;
+    display: none;
+  }
+  .modal-overlay.open { display: flex; }
+  .modal-sheet {
+    width: 100%;
+    background: var(--surface);
+    border-radius: 20px 20px 0 0;
+    padding: 20px 20px 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .modal-sheet h2 {
+    font-size: 16px;
+    font-weight: 600;
+    text-align: center;
+  }
+  .modal-sheet input[type=text] {
+    width: 100%;
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-radius: var(--radius);
+    padding: 12px;
+    font-size: 15px;
+    font-family: inherit;
+  }
+  .modal-sheet input::placeholder { color: var(--muted); }
+  .modal-actions { display: flex; gap: 10px; }
+  .btn-cancel {
+    flex: 1;
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    color: var(--muted);
+    border-radius: var(--radius);
+    padding: 13px;
+    font-size: 15px;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .btn-primary {
+    flex: 2;
+    background: var(--accent);
+    border: none;
+    color: #000;
+    border-radius: var(--radius);
+    padding: 13px;
+    font-size: 15px;
+    font-weight: 700;
+    cursor: pointer;
+    font-family: inherit;
+  }
+
+  /* ---- No camera ---- */
+  #no-camera {
+    display: none;
+    position: absolute;
+    inset: 0;
+    background: var(--bg);
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 12px;
+    text-align: center;
+    padding: 24px;
+    color: var(--muted);
+    font-size: 14px;
+  }
+  #no-camera .icon { font-size: 48px; }
+  #no-camera.visible { display: flex; }
+</style>
+</head>
+<body>
+<div id="app">
+  <header>
+    <span style="font-size:22px">📸</span>
+    <h1>Job Photos</h1>
+    <button class="btn-icon" onclick="openAlbumsPage()" title="Browse albums">🗂</button>
+  </header>
+
+  <div id="viewfinder-wrap">
+    <video id="video" autoplay playsinline muted></video>
+    <canvas id="canvas-snap"></canvas>
+    <div id="flash"></div>
+    <div id="gps-badge"><span id="gps-dot"></span><span id="gps-text">No GPS</span></div>
+    <div id="session-counter" style="display:none">0 photos</div>
+    <div id="no-camera">
+      <div class="icon">📷</div>
+      <p>Camera access denied or unavailable.<br>Please allow camera access and reload.</p>
+    </div>
+  </div>
+
+  <div id="controls">
+    <div id="album-row">
+      <select id="album-select">
+        <option value="">— Select album / job —</option>
+      </select>
+      <button id="btn-new-album" onclick="openNewAlbum()">+ New</button>
+    </div>
+
+    <textarea id="note-input" placeholder="Add a note (optional)..." rows="2"></textarea>
+
+    <div id="shutter-row">
+      <button id="btn-flip" onclick="flipCamera()" title="Flip camera">🔄</button>
+      <button id="btn-shutter" onclick="capturePhoto()" aria-label="Capture photo"></button>
+      <a id="btn-view" href="#" onclick="openAlbumsPage(); return false;" title="View albums">
+        🖼
+        <span id="view-count"></span>
+      </a>
+    </div>
+  </div>
+</div>
+
+<!-- Toast -->
+<div id="toast"></div>
+
+<!-- New album modal -->
+<div class="modal-overlay" id="modal-new-album">
+  <div class="modal-sheet">
+    <h2>New Album</h2>
+    <input type="text" id="new-album-name" placeholder="e.g. Smith Roof Install" maxlength="80">
+    <input type="text" id="new-album-desc" placeholder="Description (optional)" maxlength="160">
+    <div class="modal-actions">
+      <button class="btn-cancel" onclick="closeNewAlbum()">Cancel</button>
+      <button class="btn-primary" onclick="createAlbum()">Create</button>
+    </div>
+  </div>
+</div>
+
+<script>
+// ---- State ----
+let stream = null;
+let facingMode = 'environment';  // back camera by default
+let lat = null, lng = null;
+let sessionCount = 0;
+let albums = [];
+let uploading = false;
+
+// ---- GPS ----
+function startGPS() {
+  if (!navigator.geolocation) return;
+  const opts = { enableHighAccuracy: true, maximumAge: 10000, timeout: 15000 };
+  navigator.geolocation.watchPosition(pos => {
+    lat = pos.coords.latitude;
+    lng = pos.coords.longitude;
+    const el = document.getElementById('gps-badge');
+    el.classList.add('ok');
+    document.getElementById('gps-text').textContent =
+      lat.toFixed(5) + ', ' + lng.toFixed(5);
+  }, () => {
+    document.getElementById('gps-text').textContent = 'No GPS';
+    document.getElementById('gps-badge').classList.remove('ok');
+  }, opts);
+}
+
+// ---- Camera ----
+async function startCamera() {
+  const video = document.getElementById('video');
+  const noCam = document.getElementById('no-camera');
+  try {
+    if (stream) { stream.getTracks().forEach(t => t.stop()); }
+    stream = await navigator.mediaDevices.getUserMedia({
+      video: { facingMode, width: { ideal: 1920 }, height: { ideal: 1080 } },
+      audio: false
+    });
+    video.srcObject = stream;
+    noCam.classList.remove('visible');
+  } catch (err) {
+    console.error('Camera error:', err);
+    noCam.classList.add('visible');
+  }
+}
+
+function flipCamera() {
+  facingMode = facingMode === 'environment' ? 'user' : 'environment';
+  startCamera();
+}
+
+// ---- Capture ----
+async function capturePhoto() {
+  const albumId = document.getElementById('album-select').value;
+  if (!albumId) {
+    showToast('Select or create an album first', 'error');
+    return;
+  }
+  if (uploading) return;
+
+  const video = document.getElementById('video');
+  const canvas = document.getElementById('canvas-snap');
+  canvas.width = video.videoWidth || 1280;
+  canvas.height = video.videoHeight || 720;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(video, 0, 0);
+
+  // Flash effect
+  const flash = document.getElementById('flash');
+  flash.style.opacity = '1';
+  setTimeout(() => { flash.style.opacity = '0'; }, 80);
+
+  // Convert to blob
+  canvas.toBlob(async (blob) => {
+    if (!blob) { showToast('Capture failed', 'error'); return; }
+    await uploadPhoto(albumId, blob);
+  }, 'image/jpeg', 0.92);
+}
+
+async function uploadPhoto(albumId, blob) {
+  uploading = true;
+  const shutter = document.getElementById('btn-shutter');
+  shutter.classList.add('uploading');
+
+  const note = document.getElementById('note-input').value.trim();
+  const fd = new FormData();
+  fd.append('file', blob, `photo-${Date.now()}.jpg`);
+  if (lat !== null) fd.append('lat', lat.toString());
+  if (lng !== null) fd.append('lng', lng.toString());
+  if (note) fd.append('note', note);
+
+  try {
+    const resp = await fetch(`/api/albums/${albumId}/photos`, { method: 'POST', body: fd });
+    if (!resp.ok) throw new Error(await resp.text());
+    sessionCount++;
+    updateSessionCounter();
+    document.getElementById('note-input').value = '';
+    showToast('Photo saved ✓', 'success');
+    // Refresh albums list in background to update photo count
+    loadAlbums(false);
+  } catch (err) {
+    console.error(err);
+    showToast('Upload failed — ' + err.message, 'error');
+  } finally {
+    uploading = false;
+    shutter.classList.remove('uploading');
+  }
+}
+
+function updateSessionCounter() {
+  const el = document.getElementById('session-counter');
+  el.style.display = 'block';
+  el.textContent = sessionCount + (sessionCount === 1 ? ' photo' : ' photos');
+
+  const viewCount = document.getElementById('view-count');
+  viewCount.style.display = 'block';
+  viewCount.textContent = sessionCount;
+}
+
+// ---- Albums ----
+async function loadAlbums(selectFirst = true) {
+  try {
+    const resp = await fetch('/api/albums');
+    const data = await resp.json();
+    albums = data.albums || [];
+    const sel = document.getElementById('album-select');
+    const current = sel.value;
+    sel.innerHTML = '<option value="">— Select album / job —</option>';
+    albums.forEach(a => {
+      const opt = document.createElement('option');
+      opt.value = a.id;
+      opt.textContent = `${a.name} (${a.photo_count} photos)`;
+      if (a.id === current) opt.selected = true;
+      sel.appendChild(opt);
+    });
+    if (selectFirst && albums.length && !current) {
+      sel.value = albums[0].id;
+    }
+  } catch (e) {
+    console.warn('Could not load albums:', e);
+  }
+}
+
+function openNewAlbum() {
+  document.getElementById('modal-new-album').classList.add('open');
+  document.getElementById('new-album-name').focus();
+}
+function closeNewAlbum() {
+  document.getElementById('modal-new-album').classList.remove('open');
+  document.getElementById('new-album-name').value = '';
+  document.getElementById('new-album-desc').value = '';
+}
+
+async function createAlbum() {
+  const name = document.getElementById('new-album-name').value.trim();
+  if (!name) { document.getElementById('new-album-name').focus(); return; }
+  const desc = document.getElementById('new-album-desc').value.trim();
+  try {
+    const resp = await fetch('/api/albums', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, description: desc })
+    });
+    const album = await resp.json();
+    closeNewAlbum();
+    await loadAlbums(false);
+    document.getElementById('album-select').value = album.id;
+    showToast(`Album "${name}" created`, 'success');
+  } catch (e) {
+    showToast('Failed to create album', 'error');
+  }
+}
+
+// ---- Navigation ----
+function openAlbumsPage() {
+  // Navigate to job albums page (opens in same tab)
+  window.location.href = '/pages/job-albums.html';
+}
+
+// ---- Toast ----
+let toastTimer = null;
+function showToast(msg, type = '') {
+  const el = document.getElementById('toast');
+  el.textContent = msg;
+  el.className = 'show' + (type ? ' ' + type : '');
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => { el.className = ''; }, 2200);
+}
+
+// ---- Enter key on new album modal ----
+document.getElementById('new-album-name').addEventListener('keydown', e => {
+  if (e.key === 'Enter') createAlbum();
+});
+
+// ---- Init ----
+(async function init() {
+  startGPS();
+  await startCamera();
+  await loadAlbums(true);
+})();
+</script>
+</body>
+</html>

--- a/default-pages/job-albums.html
+++ b/default-pages/job-albums.html
@@ -1,0 +1,893 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<title>Job Albums</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; -webkit-tap-highlight-color: transparent; }
+
+  :root {
+    --bg: #0a0a0a;
+    --surface: #141414;
+    --surface2: #1e1e1e;
+    --border: #2a2a2a;
+    --accent: #f59e0b;
+    --text: #f1f1f1;
+    --muted: #777;
+    --green: #22c55e;
+    --red: #ef4444;
+    --radius: 12px;
+  }
+
+  html, body {
+    height: 100%;
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 15px;
+    overflow: hidden;
+  }
+
+  #app {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ---- Header ---- */
+  header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+    min-height: 56px;
+  }
+  header h1 { font-size: 16px; font-weight: 600; flex: 1; }
+  .btn-header {
+    background: none;
+    border: none;
+    color: var(--accent);
+    font-size: 22px;
+    cursor: pointer;
+    padding: 4px;
+    line-height: 1;
+  }
+  .btn-header.text-btn {
+    font-size: 14px;
+    font-weight: 600;
+    padding: 6px 10px;
+    background: var(--accent);
+    color: #000;
+    border-radius: 8px;
+  }
+
+  /* ---- Views ---- */
+  .view {
+    flex: 1;
+    overflow-y: auto;
+    display: none;
+    -webkit-overflow-scrolling: touch;
+  }
+  .view.active { display: block; }
+
+  /* ---- Albums list ---- */
+  #albums-view {
+    padding: 16px;
+  }
+
+  .empty-state {
+    text-align: center;
+    padding: 60px 24px;
+    color: var(--muted);
+  }
+  .empty-state .icon { font-size: 52px; margin-bottom: 12px; }
+  .empty-state p { font-size: 14px; line-height: 1.5; }
+  .empty-state .cta {
+    display: inline-block;
+    margin-top: 20px;
+    background: var(--accent);
+    color: #000;
+    border-radius: var(--radius);
+    padding: 12px 24px;
+    font-weight: 700;
+    font-size: 15px;
+    text-decoration: none;
+    cursor: pointer;
+    border: none;
+    font-family: inherit;
+  }
+
+  .albums-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+
+  .album-card {
+    background: var(--surface);
+    border-radius: var(--radius);
+    border: 1px solid var(--border);
+    overflow: hidden;
+    cursor: pointer;
+    transition: border-color 0.15s;
+    -webkit-user-select: none;
+  }
+  .album-card:active { border-color: var(--accent); }
+  .album-cover {
+    width: 100%;
+    aspect-ratio: 4/3;
+    object-fit: cover;
+    background: var(--surface2);
+    display: block;
+  }
+  .album-cover-placeholder {
+    width: 100%;
+    aspect-ratio: 4/3;
+    background: var(--surface2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 32px;
+    color: var(--border);
+  }
+  .album-info { padding: 10px 10px 12px; }
+  .album-name {
+    font-size: 13px;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: 3px;
+  }
+  .album-meta { font-size: 11px; color: var(--muted); }
+
+  /* ---- Album detail ---- */
+  #album-view {
+    display: none;
+    flex-direction: column;
+  }
+  #album-view.active {
+    display: flex;
+  }
+
+  #album-view .album-header {
+    padding: 14px 16px 10px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+  #album-view .album-header h2 { font-size: 16px; font-weight: 700; }
+  #album-view .album-header p { font-size: 12px; color: var(--muted); margin-top: 2px; }
+
+  .detail-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+    flex-shrink: 0;
+  }
+  .detail-tab {
+    flex: 1;
+    padding: 10px;
+    text-align: center;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--muted);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    background: none;
+    border-left: none;
+    border-right: none;
+    border-top: none;
+    color: var(--muted);
+    font-family: inherit;
+    transition: color 0.15s;
+  }
+  .detail-tab.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+  }
+
+  .tab-content { display: none; flex: 1; overflow-y: auto; -webkit-overflow-scrolling: touch; }
+  .tab-content.active { display: block; }
+
+  /* Photo grid */
+  .photos-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2px;
+    padding: 2px;
+  }
+  .photo-thumb {
+    aspect-ratio: 1;
+    object-fit: cover;
+    cursor: pointer;
+    width: 100%;
+    display: block;
+    background: var(--surface2);
+    transition: opacity 0.1s;
+  }
+  .photo-thumb:active { opacity: 0.75; }
+
+  /* Before/After slider tab */
+  #ba-tab {
+    padding: 16px;
+    display: none;
+    flex-direction: column;
+    gap: 12px;
+  }
+  #ba-tab.active { display: flex; }
+
+  .ba-selector {
+    display: flex;
+    gap: 8px;
+  }
+  .ba-slot {
+    flex: 1;
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    cursor: pointer;
+    overflow: hidden;
+    position: relative;
+    min-height: 100px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 6px;
+    color: var(--muted);
+    font-size: 12px;
+  }
+  .ba-slot img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+  .ba-slot-label {
+    position: absolute;
+    top: 6px;
+    left: 6px;
+    background: rgba(0,0,0,0.65);
+    border-radius: 6px;
+    padding: 2px 6px;
+    font-size: 11px;
+    font-weight: 700;
+    color: #fff;
+  }
+
+  .ba-slider-wrap {
+    position: relative;
+    overflow: hidden;
+    border-radius: var(--radius);
+    background: var(--surface2);
+    min-height: 200px;
+  }
+  .ba-slider-wrap img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  #ba-after { position: absolute; inset: 0; overflow: hidden; }
+  #ba-after img { position: absolute; right: 0; top: 0; height: 100%; width: 100%; object-fit: cover; object-position: right; }
+  #ba-divider {
+    position: absolute;
+    top: 0; bottom: 0;
+    width: 3px;
+    background: #fff;
+    box-shadow: 0 0 8px rgba(0,0,0,0.5);
+    cursor: col-resize;
+    z-index: 10;
+    transform: translateX(-50%);
+  }
+  #ba-handle {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 32px; height: 32px;
+    background: #fff;
+    border-radius: 50%;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    color: #333;
+  }
+  .ba-hint { font-size: 12px; color: var(--muted); text-align: center; }
+
+  /* ---- Lightbox ---- */
+  #lightbox {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.97);
+    display: none;
+    flex-direction: column;
+    z-index: 500;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox-header {
+    display: flex;
+    align-items: center;
+    padding: 12px 16px;
+    gap: 10px;
+    flex-shrink: 0;
+  }
+  #lightbox-header h3 { flex: 1; font-size: 14px; color: var(--muted); }
+  #lightbox-btn-close {
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 24px;
+    cursor: pointer;
+    padding: 4px;
+    line-height: 1;
+  }
+  #lightbox-img-wrap {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+  }
+  #lightbox-img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+  }
+  #lightbox-footer {
+    padding: 12px 16px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  #lightbox-note { font-size: 14px; color: var(--text); }
+  #lightbox-meta { font-size: 12px; color: var(--muted); }
+  .lightbox-actions { display: flex; gap: 8px; }
+  .lb-btn {
+    flex: 1;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-radius: 8px;
+    padding: 10px;
+    font-size: 13px;
+    cursor: pointer;
+    font-family: inherit;
+    text-align: center;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+  }
+  .lb-btn.accent { background: var(--accent); color: #000; border-color: transparent; font-weight: 700; }
+
+  /* ---- Photo picker sheet (for B/A selection) ---- */
+  #photo-picker-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.8);
+    z-index: 300;
+    display: none;
+    align-items: flex-end;
+  }
+  #photo-picker-overlay.open { display: flex; }
+  #photo-picker-sheet {
+    width: 100%;
+    background: var(--surface);
+    border-radius: 20px 20px 0 0;
+    max-height: 70vh;
+    display: flex;
+    flex-direction: column;
+  }
+  .picker-header {
+    padding: 14px 16px 10px;
+    border-bottom: 1px solid var(--border);
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--muted);
+    flex-shrink: 0;
+  }
+  #picker-grid {
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 2px;
+    padding: 2px;
+  }
+  .picker-thumb {
+    aspect-ratio: 1;
+    object-fit: cover;
+    width: 100%;
+    cursor: pointer;
+    transition: opacity 0.1s;
+  }
+  .picker-thumb:active { opacity: 0.7; }
+
+  /* ---- Modal (new album) ---- */
+  .modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.75);
+    display: none;
+    align-items: flex-end;
+    z-index: 200;
+  }
+  .modal-overlay.open { display: flex; }
+  .modal-sheet {
+    width: 100%;
+    background: var(--surface);
+    border-radius: 20px 20px 0 0;
+    padding: 20px 20px 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .modal-sheet h2 { font-size: 16px; font-weight: 600; text-align: center; }
+  .modal-sheet input[type=text] {
+    width: 100%;
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-radius: var(--radius);
+    padding: 12px;
+    font-size: 15px;
+    font-family: inherit;
+  }
+  .modal-sheet input::placeholder { color: var(--muted); }
+  .modal-actions { display: flex; gap: 10px; }
+  .btn-cancel {
+    flex: 1; background: var(--surface2); border: 1px solid var(--border);
+    color: var(--muted); border-radius: var(--radius); padding: 13px;
+    font-size: 15px; cursor: pointer; font-family: inherit;
+  }
+  .btn-primary {
+    flex: 2; background: var(--accent); border: none; color: #000;
+    border-radius: var(--radius); padding: 13px; font-size: 15px;
+    font-weight: 700; cursor: pointer; font-family: inherit;
+  }
+
+  /* ---- Toast ---- */
+  #toast {
+    position: fixed; bottom: 0; left: 0; right: 0;
+    padding: 14px 20px; background: var(--surface);
+    border-top: 1px solid var(--border); font-size: 14px;
+    text-align: center; transform: translateY(100%);
+    transition: transform 0.25s ease; z-index: 999;
+  }
+  #toast.show { transform: translateY(0); }
+  #toast.success { border-color: var(--green); color: var(--green); }
+  #toast.error { border-color: var(--red); color: var(--red); }
+
+  /* scrollbars */
+  ::-webkit-scrollbar { width: 4px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
+</style>
+</head>
+<body>
+<div id="app">
+  <!-- ---- Header ---- -->
+  <header>
+    <button class="btn-header" id="btn-back" onclick="goBack()" style="display:none">←</button>
+    <span style="font-size:20px" id="header-icon">🗂</span>
+    <h1 id="header-title">Job Albums</h1>
+    <button class="btn-header text-btn" onclick="goCaptureMode()">📸 Capture</button>
+    <button class="btn-header" onclick="openNewAlbumModal()" title="New album">＋</button>
+  </header>
+
+  <!-- ---- Albums list view ---- -->
+  <div class="view active" id="albums-view">
+    <div style="padding:16px">
+      <div id="albums-empty" class="empty-state" style="display:none">
+        <div class="icon">📂</div>
+        <p>No albums yet.<br>Create an album to start organizing job photos.</p>
+        <button class="cta" onclick="openNewAlbumModal()">Create First Album</button>
+      </div>
+      <div class="albums-grid" id="albums-grid"></div>
+    </div>
+  </div>
+
+  <!-- ---- Album detail view ---- -->
+  <div class="view" id="album-view">
+    <div class="album-header">
+      <h2 id="detail-album-name">Album</h2>
+      <p id="detail-album-meta"></p>
+    </div>
+    <div class="detail-tabs">
+      <button class="detail-tab active" onclick="switchTab('photos')">Photos</button>
+      <button class="detail-tab" onclick="switchTab('before-after')">Before / After</button>
+    </div>
+
+    <!-- Photos tab -->
+    <div class="tab-content active" id="tab-photos">
+      <div class="photos-grid" id="photos-grid"></div>
+    </div>
+
+    <!-- Before/After tab -->
+    <div class="tab-content" id="tab-before-after">
+      <div id="ba-tab">
+        <div class="ba-selector">
+          <div class="ba-slot" id="ba-slot-before" onclick="openPhotoPicker('before')">
+            <span style="font-size:28px">📷</span>
+            <span>Before</span>
+          </div>
+          <div class="ba-slot" id="ba-slot-after" onclick="openPhotoPicker('after')">
+            <span style="font-size:28px">📷</span>
+            <span>After</span>
+          </div>
+        </div>
+        <div class="ba-slider-wrap" id="ba-slider-wrap" style="display:none">
+          <img id="ba-before-img" src="" alt="Before">
+          <div id="ba-after" style="width:50%">
+            <img id="ba-after-img" src="" alt="After">
+          </div>
+          <div id="ba-divider" style="left:50%">
+            <div id="ba-handle">⇔</div>
+          </div>
+        </div>
+        <p class="ba-hint" id="ba-hint">Select a before and after photo to compare them.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Lightbox -->
+<div id="lightbox">
+  <div id="lightbox-header">
+    <h3 id="lightbox-title"></h3>
+    <button id="lightbox-btn-close" onclick="closeLightbox()">✕</button>
+  </div>
+  <div id="lightbox-img-wrap">
+    <img id="lightbox-img" src="" alt="">
+  </div>
+  <div id="lightbox-footer">
+    <div id="lightbox-note"></div>
+    <div id="lightbox-meta"></div>
+    <div class="lightbox-actions">
+      <a class="lb-btn" id="lightbox-download" href="#" download>⬇ Download</a>
+      <button class="lb-btn accent" id="lightbox-ba-btn" onclick="useForBA()">Compare ⇔</button>
+    </div>
+  </div>
+</div>
+
+<!-- Photo picker (for B/A) -->
+<div id="photo-picker-overlay" onclick="closePhotoPicker()">
+  <div id="photo-picker-sheet" onclick="event.stopPropagation()">
+    <div class="picker-header" id="picker-header">Choose photo</div>
+    <div id="picker-grid"></div>
+  </div>
+</div>
+
+<!-- New album modal -->
+<div class="modal-overlay" id="modal-new-album">
+  <div class="modal-sheet">
+    <h2>New Album</h2>
+    <input type="text" id="new-album-name" placeholder="e.g. Smith Roof Install" maxlength="80">
+    <input type="text" id="new-album-desc" placeholder="Description (optional)" maxlength="160">
+    <div class="modal-actions">
+      <button class="btn-cancel" onclick="closeNewAlbumModal()">Cancel</button>
+      <button class="btn-primary" onclick="createAlbum()">Create</button>
+    </div>
+  </div>
+</div>
+
+<!-- Toast -->
+<div id="toast"></div>
+
+<script>
+// ---- State ----
+let currentAlbum = null;
+let currentAlbumPhotos = [];
+let baSlotTarget = null; // 'before' | 'after'
+let baBeforeUrl = null;
+let baAfterUrl = null;
+let lightboxPhoto = null;
+let baSliderActive = false;
+let activeTab = 'photos';
+
+// ---- Navigation ----
+function goBack() {
+  showView('albums');
+  document.getElementById('btn-back').style.display = 'none';
+  document.getElementById('header-icon').textContent = '🗂';
+  document.getElementById('header-title').textContent = 'Job Albums';
+  loadAlbums();
+}
+
+function goCaptureMode() {
+  window.location.href = '/pages/camera-capture.html';
+}
+
+function showView(name) {
+  document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
+  if (name === 'albums') {
+    document.getElementById('albums-view').classList.add('active');
+    document.getElementById('album-view').classList.remove('active');
+  } else if (name === 'album') {
+    document.getElementById('albums-view').classList.remove('active');
+    document.getElementById('album-view').classList.add('active');
+  }
+}
+
+// ---- Albums list ----
+async function loadAlbums() {
+  try {
+    const resp = await fetch('/api/albums');
+    const data = await resp.json();
+    const albums = data.albums || [];
+    renderAlbums(albums);
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+function renderAlbums(albums) {
+  const grid = document.getElementById('albums-grid');
+  const empty = document.getElementById('albums-empty');
+  grid.innerHTML = '';
+  if (!albums.length) {
+    empty.style.display = 'block';
+    return;
+  }
+  empty.style.display = 'none';
+  albums.forEach(album => {
+    const card = document.createElement('div');
+    card.className = 'album-card';
+    card.onclick = () => openAlbum(album.id);
+    const coverHTML = album.cover_url
+      ? `<img class="album-cover" src="${esc(album.cover_url)}" alt="" loading="lazy">`
+      : `<div class="album-cover-placeholder">📂</div>`;
+    card.innerHTML = `
+      ${coverHTML}
+      <div class="album-info">
+        <div class="album-name">${esc(album.name)}</div>
+        <div class="album-meta">${album.photo_count} photo${album.photo_count !== 1 ? 's' : ''} · ${fmtDate(album.created_at)}</div>
+      </div>`;
+    grid.appendChild(card);
+  });
+}
+
+// ---- Album detail ----
+async function openAlbum(albumId) {
+  try {
+    const resp = await fetch(`/api/albums/${albumId}`);
+    currentAlbum = await resp.json();
+    currentAlbumPhotos = currentAlbum.photos || [];
+    renderAlbumDetail();
+    showView('album');
+    document.getElementById('btn-back').style.display = 'inline';
+    document.getElementById('header-icon').textContent = '📁';
+    document.getElementById('header-title').textContent = currentAlbum.name;
+  } catch (e) {
+    showToast('Could not load album', 'error');
+  }
+}
+
+function renderAlbumDetail() {
+  document.getElementById('detail-album-name').textContent = currentAlbum.name;
+  document.getElementById('detail-album-meta').textContent =
+    `${currentAlbumPhotos.length} photo${currentAlbumPhotos.length !== 1 ? 's' : ''} · Created ${fmtDate(currentAlbum.created_at)}`;
+
+  const grid = document.getElementById('photos-grid');
+  grid.innerHTML = '';
+  if (!currentAlbumPhotos.length) {
+    grid.innerHTML = `<div style="grid-column:1/-1;padding:40px 16px;text-align:center;color:var(--muted);font-size:14px">
+      No photos yet.<br><button onclick="goCaptureMode()" style="margin-top:12px;background:var(--accent);color:#000;border:none;border-radius:8px;padding:10px 20px;font-weight:700;font-size:14px;cursor:pointer;font-family:inherit">Capture Photos</button>
+    </div>`;
+    return;
+  }
+  currentAlbumPhotos.forEach((photo, i) => {
+    const img = document.createElement('img');
+    img.className = 'photo-thumb';
+    img.src = photo.url;
+    img.alt = photo.note || `Photo ${i + 1}`;
+    img.loading = 'lazy';
+    img.onclick = () => openLightbox(photo, i);
+    grid.appendChild(img);
+  });
+
+  // Also build picker grid
+  renderPickerGrid();
+}
+
+function switchTab(name) {
+  activeTab = name;
+  document.querySelectorAll('.detail-tab').forEach((t, i) => {
+    t.classList.toggle('active', (i === 0 && name === 'photos') || (i === 1 && name === 'before-after'));
+  });
+  document.querySelectorAll('.tab-content').forEach(tc => tc.classList.remove('active'));
+  if (name === 'photos') {
+    document.getElementById('tab-photos').classList.add('active');
+  } else {
+    document.getElementById('tab-before-after').classList.add('active');
+    document.getElementById('ba-tab').style.display = 'flex';
+  }
+}
+
+// ---- Lightbox ----
+function openLightbox(photo, index) {
+  lightboxPhoto = photo;
+  document.getElementById('lightbox-img').src = photo.url;
+  document.getElementById('lightbox-title').textContent =
+    `Photo ${index + 1} of ${currentAlbumPhotos.length}`;
+  document.getElementById('lightbox-note').textContent = photo.note || '';
+  let meta = fmtDate(photo.taken_at);
+  if (photo.lat && photo.lng) meta += ` · GPS: ${parseFloat(photo.lat).toFixed(5)}, ${parseFloat(photo.lng).toFixed(5)}`;
+  document.getElementById('lightbox-meta').textContent = meta;
+  const dl = document.getElementById('lightbox-download');
+  dl.href = photo.url;
+  dl.download = photo.filename;
+  document.getElementById('lightbox').classList.add('open');
+}
+
+function closeLightbox() {
+  document.getElementById('lightbox').classList.remove('open');
+  lightboxPhoto = null;
+}
+
+function useForBA() {
+  if (!lightboxPhoto) return;
+  closeLightbox();
+  switchTab('before-after');
+  openPhotoPicker(baBeforeUrl ? 'after' : 'before');
+  setBASlot(baBeforeUrl ? 'after' : 'before', lightboxPhoto.url);
+}
+
+// ---- Before / After ----
+function renderPickerGrid() {
+  const grid = document.getElementById('picker-grid');
+  grid.innerHTML = '';
+  currentAlbumPhotos.forEach(photo => {
+    const img = document.createElement('img');
+    img.className = 'picker-thumb';
+    img.src = photo.url;
+    img.alt = photo.note || '';
+    img.loading = 'lazy';
+    img.onclick = () => pickPhoto(photo.url);
+    grid.appendChild(img);
+  });
+}
+
+function openPhotoPicker(slot) {
+  baSlotTarget = slot;
+  document.getElementById('picker-header').textContent =
+    slot === 'before' ? 'Choose BEFORE photo' : 'Choose AFTER photo';
+  document.getElementById('photo-picker-overlay').classList.add('open');
+}
+function closePhotoPicker() {
+  document.getElementById('photo-picker-overlay').classList.remove('open');
+}
+
+function pickPhoto(url) {
+  setBASlot(baSlotTarget, url);
+  closePhotoPicker();
+}
+
+function setBASlot(slot, url) {
+  const slotEl = document.getElementById(`ba-slot-${slot}`);
+  slotEl.innerHTML = `
+    <img src="${esc(url)}" alt="">
+    <div class="ba-slot-label">${slot === 'before' ? 'BEFORE' : 'AFTER'}</div>`;
+  if (slot === 'before') {
+    baBeforeUrl = url;
+    document.getElementById('ba-before-img').src = url;
+  } else {
+    baAfterUrl = url;
+    document.getElementById('ba-after-img').src = url;
+  }
+  if (baBeforeUrl && baAfterUrl) {
+    showBASlider();
+  }
+}
+
+function showBASlider() {
+  const wrap = document.getElementById('ba-slider-wrap');
+  wrap.style.display = 'block';
+  document.getElementById('ba-hint').textContent = 'Drag the divider to compare.';
+  initBADrag();
+}
+
+function initBADrag() {
+  const wrap = document.getElementById('ba-slider-wrap');
+  const divider = document.getElementById('ba-divider');
+  const afterEl = document.getElementById('ba-after');
+  let dragging = false;
+
+  function setPos(clientX) {
+    const rect = wrap.getBoundingClientRect();
+    let pct = (clientX - rect.left) / rect.width;
+    pct = Math.max(0.05, Math.min(0.95, pct));
+    const pctPx = pct * 100;
+    divider.style.left = pctPx + '%';
+    afterEl.style.width = (100 - pctPx) + '%';
+    // Keep after image filling from the right
+    const afterImg = document.getElementById('ba-after-img');
+    afterImg.style.width = wrap.offsetWidth + 'px';
+    afterImg.style.objectPosition = `${pctPx}% center`;
+  }
+
+  divider.onmousedown = e => { dragging = true; e.preventDefault(); };
+  document.onmousemove = e => { if (dragging) setPos(e.clientX); };
+  document.onmouseup = () => { dragging = false; };
+
+  divider.ontouchstart = e => { dragging = true; };
+  document.ontouchmove = e => {
+    if (dragging && e.touches[0]) {
+      setPos(e.touches[0].clientX);
+      e.preventDefault();
+    }
+  };
+  document.ontouchend = () => { dragging = false; };
+}
+
+// ---- New album modal ----
+function openNewAlbumModal() {
+  document.getElementById('modal-new-album').classList.add('open');
+  document.getElementById('new-album-name').focus();
+}
+function closeNewAlbumModal() {
+  document.getElementById('modal-new-album').classList.remove('open');
+  document.getElementById('new-album-name').value = '';
+  document.getElementById('new-album-desc').value = '';
+}
+async function createAlbum() {
+  const name = document.getElementById('new-album-name').value.trim();
+  if (!name) { document.getElementById('new-album-name').focus(); return; }
+  const desc = document.getElementById('new-album-desc').value.trim();
+  try {
+    const resp = await fetch('/api/albums', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, description: desc })
+    });
+    const album = await resp.json();
+    closeNewAlbumModal();
+    showToast(`Album "${name}" created`, 'success');
+    await loadAlbums();
+    openAlbum(album.id);
+  } catch (e) {
+    showToast('Failed to create album', 'error');
+  }
+}
+document.getElementById('new-album-name').addEventListener('keydown', e => {
+  if (e.key === 'Enter') createAlbum();
+});
+
+// ---- Helpers ----
+function esc(str) {
+  return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+function fmtDate(iso) {
+  if (!iso) return '';
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  } catch { return iso; }
+}
+
+let toastTimer = null;
+function showToast(msg, type = '') {
+  const el = document.getElementById('toast');
+  el.textContent = msg;
+  el.className = 'show' + (type ? ' ' + type : '');
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => { el.className = ''; }, 2200);
+}
+
+// ---- Init ----
+loadAlbums();
+</script>
+</body>
+</html>

--- a/routes/albums.py
+++ b/routes/albums.py
@@ -1,0 +1,270 @@
+"""
+routes/albums.py — Job Photo Albums API
+
+Provides CompanyCam-style photo album management:
+  GET  /api/albums              — list all albums
+  POST /api/albums              — create new album
+  GET  /api/albums/<id>         — album detail + photos
+  PUT  /api/albums/<id>         — update album name/description
+  POST /api/albums/<id>/photos  — upload photo to album (multipart + GPS)
+  GET  /api/albums/<id>/photos/<photo_id> — get single photo metadata
+"""
+
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from flask import Blueprint, jsonify, request, send_file
+
+from services.paths import UPLOADS_DIR
+
+logger = logging.getLogger(__name__)
+
+albums_bp = Blueprint('albums', __name__)
+
+ALBUMS_DIR = UPLOADS_DIR / 'albums'
+ALBUMS_INDEX = ALBUMS_DIR / 'index.json'
+
+ALLOWED_IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.heic', '.heif', '.webp', '.gif'}
+
+
+def _ensure_albums_dir():
+    ALBUMS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _load_index() -> list:
+    _ensure_albums_dir()
+    if not ALBUMS_INDEX.exists():
+        return []
+    try:
+        return json.loads(ALBUMS_INDEX.read_text(encoding='utf-8'))
+    except Exception:
+        return []
+
+
+def _save_index(index: list) -> None:
+    _ensure_albums_dir()
+    ALBUMS_INDEX.write_text(json.dumps(index, indent=2, ensure_ascii=False), encoding='utf-8')
+    try:
+        ALBUMS_INDEX.chmod(0o666)
+    except OSError:
+        pass
+
+
+def _load_album(album_id: str) -> dict | None:
+    album_file = ALBUMS_DIR / album_id / 'album.json'
+    if not album_file.exists():
+        return None
+    try:
+        return json.loads(album_file.read_text(encoding='utf-8'))
+    except Exception:
+        return None
+
+
+def _save_album(album_id: str, data: dict) -> None:
+    album_dir = ALBUMS_DIR / album_id
+    album_dir.mkdir(parents=True, exist_ok=True)
+    album_file = album_dir / 'album.json'
+    album_file.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding='utf-8')
+    try:
+        album_file.chmod(0o666)
+    except OSError:
+        pass
+
+
+def _update_index_entry(album_id: str, data: dict) -> None:
+    """Sync album summary fields into the flat index."""
+    index = _load_index()
+    entry = {
+        'id': album_id,
+        'name': data.get('name', ''),
+        'description': data.get('description', ''),
+        'created_at': data.get('created_at', ''),
+        'updated_at': data.get('updated_at', ''),
+        'photo_count': len(data.get('photos', [])),
+        'cover_url': data['photos'][0]['url'] if data.get('photos') else None,
+    }
+    for i, item in enumerate(index):
+        if item.get('id') == album_id:
+            index[i] = entry
+            _save_index(index)
+            return
+    index.append(entry)
+    _save_index(index)
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@albums_bp.route('/api/albums', methods=['GET'])
+def list_albums():
+    """Return all albums, newest first."""
+    index = _load_index()
+    index_sorted = sorted(index, key=lambda x: x.get('created_at', ''), reverse=True)
+    return jsonify({'albums': index_sorted})
+
+
+@albums_bp.route('/api/albums', methods=['POST'])
+def create_album():
+    """Create a new album. Body: {name, description?}"""
+    body = request.get_json(silent=True) or {}
+    name = (body.get('name') or '').strip()
+    if not name:
+        return jsonify({'error': 'name is required'}), 400
+
+    album_id = uuid.uuid4().hex[:12]
+    now = datetime.now(timezone.utc).isoformat(timespec='seconds')
+    data = {
+        'id': album_id,
+        'name': name,
+        'description': body.get('description', '').strip(),
+        'created_at': now,
+        'updated_at': now,
+        'photos': [],
+    }
+    _save_album(album_id, data)
+    _update_index_entry(album_id, data)
+    logger.info('album created: %s "%s"', album_id, name)
+    return jsonify(data), 201
+
+
+@albums_bp.route('/api/albums/<album_id>', methods=['GET'])
+def get_album(album_id: str):
+    """Return album detail including all photos."""
+    data = _load_album(album_id)
+    if not data:
+        return jsonify({'error': 'album not found'}), 404
+    return jsonify(data)
+
+
+@albums_bp.route('/api/albums/<album_id>', methods=['PUT'])
+def update_album(album_id: str):
+    """Update album name/description."""
+    data = _load_album(album_id)
+    if not data:
+        return jsonify({'error': 'album not found'}), 404
+    body = request.get_json(silent=True) or {}
+    if 'name' in body:
+        data['name'] = (body['name'] or '').strip() or data['name']
+    if 'description' in body:
+        data['description'] = body.get('description', '').strip()
+    data['updated_at'] = datetime.now(timezone.utc).isoformat(timespec='seconds')
+    _save_album(album_id, data)
+    _update_index_entry(album_id, data)
+    return jsonify(data)
+
+
+@albums_bp.route('/api/albums/<album_id>/photos', methods=['POST'])
+def upload_photo(album_id: str):
+    """Upload a photo to an album.
+
+    Multipart form fields:
+      file     — image file (required)
+      lat      — GPS latitude (optional)
+      lng      — GPS longitude (optional)
+      note     — caption/note (optional)
+    """
+    import mimetypes
+    import re as _re
+
+    data = _load_album(album_id)
+    if not data:
+        return jsonify({'error': 'album not found'}), 404
+
+    if 'file' not in request.files:
+        return jsonify({'error': 'no file provided'}), 400
+
+    f = request.files['file']
+    if not f.filename:
+        return jsonify({'error': 'empty filename'}), 400
+
+    ext = Path(f.filename).suffix.lower()
+    if ext not in ALLOWED_IMAGE_EXTS:
+        return jsonify({'error': f'unsupported file type: {ext}'}), 415
+
+    # Size check
+    f.stream.seek(0, 2)
+    file_size = f.stream.tell()
+    f.stream.seek(0)
+    if file_size > 100 * 1024 * 1024:
+        return jsonify({'error': 'file too large (100 MB max)'}), 413
+
+    photo_id = uuid.uuid4().hex[:12]
+    now = datetime.now(timezone.utc).isoformat(timespec='seconds')
+    safe_name = f'photo-{photo_id}{ext}'
+    album_dir = ALBUMS_DIR / album_id
+    album_dir.mkdir(parents=True, exist_ok=True)
+    dest = album_dir / safe_name
+    f.save(str(dest))
+    try:
+        dest.chmod(0o666)
+    except OSError:
+        pass
+
+    # HEIC → JPG conversion
+    if ext in ('.heic', '.heif'):
+        jpg_name = f'photo-{photo_id}.jpg'
+        jpg_dest = album_dir / jpg_name
+        try:
+            import pillow_heif
+            from PIL import Image as _Image
+            pillow_heif.register_heif_opener()
+            with _Image.open(str(dest)) as _img:
+                _img.convert('RGB').save(str(jpg_dest), 'JPEG', quality=90)
+            dest = jpg_dest
+            safe_name = jpg_name
+            ext = '.jpg'
+        except Exception as exc:
+            logger.warning('HEIC→JPG failed for album photo: %s', exc)
+
+    lat = request.form.get('lat', '').strip()
+    lng = request.form.get('lng', '').strip()
+    note = request.form.get('note', '').strip()
+
+    photo_url = f'/uploads/albums/{album_id}/{safe_name}'
+    photo_entry = {
+        'id': photo_id,
+        'filename': safe_name,
+        'url': photo_url,
+        'url_full': f'https://{request.host}/uploads/albums/{album_id}/{safe_name}',
+        'lat': lat or None,
+        'lng': lng or None,
+        'note': note,
+        'size': file_size,
+        'taken_at': now,
+    }
+
+    data['photos'].append(photo_entry)
+    data['updated_at'] = now
+    _save_album(album_id, data)
+    _update_index_entry(album_id, data)
+
+    logger.info('photo added to album %s: %s (gps=%s,%s)', album_id, safe_name, lat or '-', lng or '-')
+    return jsonify({'photo': photo_entry, 'album_id': album_id}), 201
+
+
+@albums_bp.route('/api/albums/<album_id>/photos/<photo_id>', methods=['GET'])
+def get_photo(album_id: str, photo_id: str):
+    """Get single photo metadata."""
+    data = _load_album(album_id)
+    if not data:
+        return jsonify({'error': 'album not found'}), 404
+    for p in data.get('photos', []):
+        if p.get('id') == photo_id:
+            return jsonify(p)
+    return jsonify({'error': 'photo not found'}), 404
+
+
+# Serve album photos directly (albums are subdirs of uploads)
+@albums_bp.route('/uploads/albums/<album_id>/<filename>')
+def serve_album_photo(album_id: str, filename: str):
+    """Serve photo files from album directories."""
+    safe_id = ''.join(c for c in album_id if c.isalnum())
+    safe_file = Path(filename).name
+    dest = ALBUMS_DIR / safe_id / safe_file
+    if not dest.exists() or not dest.is_file():
+        return 'Not found', 404
+    return send_file(str(dest))

--- a/server.py
+++ b/server.py
@@ -182,6 +182,9 @@ if DEFAULT_PAGES_DIR.is_dir():
 from routes.static_files import static_files_bp, DJ_SOUNDS, SOUNDS_DIR
 app.register_blueprint(static_files_bp)
 
+from routes.albums import albums_bp
+app.register_blueprint(albums_bp)
+
 from routes.admin import admin_bp
 app.register_blueprint(admin_bp)
 


### PR DESCRIPTION
## Summary

- **`routes/albums.py`** — New Flask blueprint: `GET/POST /api/albums`, `POST /api/albums/<id>/photos` (multipart + GPS lat/lng), `GET /api/albums/<id>`, album index stored at `UPLOADS_DIR/albums/index.json`, per-album metadata at `UPLOADS_DIR/albums/<id>/album.json`, HEIC→JPG auto-conversion, photo files at `UPLOADS_DIR/albums/<id>/photo-<uuid>.jpg`
- **`default-pages/camera-capture.html`** — Mobile-first PWA camera page: back-camera default, album selector + create-new sheet, GPS auto-capture, tap-to-capture with flash feedback, immediate server upload, session photo counter, zero localStorage
- **`default-pages/job-albums.html`** — Album browser: 2-col album grid with cover photos, 3-col photo grid inside each album, before/after slider tab with drag handle, lightbox with GPS metadata, photo picker sheet for B/A slot selection
- **`server.py`** — Register `albums_bp`

All state server-side per CLAUDE.md VPS rules. No localStorage.