### PR TITLE
fix(image-splitter): image-only accept (video/camera moved off — separate tool)

### DIFF
--- a/default-pages/image-splitter.html
+++ b/default-pages/image-splitter.html
@@ -209,7 +209,7 @@ body { background: #0a0a0a; color: #e2e8f0; font-family: 'Inter', sans-serif; pa
 <div class="dropzone" id="dropzone">
   <div class="dz-title">Drop an image or click to upload</div>
   <div class="dz-sub">PNG/JPG · Any grid layout · Works best on AI-generated post grids</div>
-  <input type="file" accept="image/*,video/*,.heic,.heif,.HEIC,.HEIF,.avif,.tiff,.tif,.bmp,.mov,.MOV,.mp4,.m4v,.3gp,.3gpp,.avi,.mkv,.webm,.mts,.dng" id="fileInput">
+  <input type="file" accept="image/*,.heic,.heif,.HEIC,.HEIF,.avif,.webp,.gif,.bmp,.tiff,.tif" id="fileInput">
 </div>
 
 <!-- Main UI (hidden until image loaded) -->


### PR DESCRIPTION
Correcting #425: it over-widened the splitter's upload to include video + camera-capture formats. The splitter cuts a **still image** into a grid — video doesn't belong here. Reverts to image formats only, but complete (adds regular types `image/*` can filter: heic/heif/avif/webp/gif/bmp/tiff). Camera/video is a separate tool (camera canvas), untouched.