### PR TITLE
fix(image-splitter): back button uses action:close (fixes black screen)

### DIFF
--- a/default-pages/image-splitter.html
+++ b/default-pages/image-splitter.html
@@ -145,7 +145,7 @@ body { background: #0a0a0a; color: #e2e8f0; font-family: 'Inter', sans-serif; pa
 </head>
 <body>
 
-<button class="back-btn" onclick="window.parent.postMessage({type:'canvas-action',action:'navigate',page:'desktop'},'*')">← Back</button>
+<button class="back-btn" onclick="window.parent.postMessage({type:'canvas-action',action:'close'},'*')">← Back</button>
 
 <div class="header">
   <h1>Image Splitter</h1>


### PR DESCRIPTION
`page:'desktop'` navigated the canvas iframe to a non-existent `desktop` page → black screen. Desktop isn't a canvas page; Back should dismiss the canvas. Switched to `action:'close'` (→ `CanvasControl.hide()`), the handler that returns to the desktop.