### PR TITLE
fix(image-splitter): back opens desktop (action:menu)

### DIFF
--- a/default-pages/image-splitter.html
+++ b/default-pages/image-splitter.html
@@ -145,7 +145,7 @@ body { background: #0a0a0a; color: #e2e8f0; font-family: 'Inter', sans-serif; pa
 </head>
 <body>
 
-<button class="back-btn" onclick="window.parent.postMessage({type:'canvas-action',action:'close'},'*')">← Back</button>
+<button class="back-btn" onclick="window.parent.postMessage({type:'canvas-action',action:'menu'},'*')">← Back</button>
 
 <div class="header">
   <h1>Image Splitter</h1>


### PR DESCRIPTION
Back should go to the desktop. `close` only hid the canvas; a raw navigate to 'desktop' black-screened. `action:'menu'` → host `showMenu()` → `openPage('desktop.html')`, the app's own desktop-launch path.