### PR TITLE
fix(grid-creator): version stamp for auto-reseed

### DIFF
--- a/default-pages/grid-creator.html
+++ b/default-pages/grid-creator.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- openvoiceui-version: 2026-07-30-refs -->
 <html lang="en">
 <head>
 <meta charset="UTF-8">


### PR DESCRIPTION
Adds the openvoiceui-version comment so grid-creator page updates auto-propagate from default-pages to per-tenant canvas-pages on roll/wake (the seed logic only re-seeds versioned pages). Fixes the stale-served-page class that required a manual container copy this cycle.