### PR TITLE
fix(uploads): CSP by type — media plays inline, html/svg stays sandboxed

### DIFF
--- a/routes/static_files.py
+++ b/routes/static_files.py
@@ -530,7 +530,20 @@ def serve_upload(filename):
         resp.headers['Content-Disposition'] = (
             'attachment; filename="%s"' % Path(filename).name.replace('"', ''))
     resp.headers['X-Content-Type-Options'] = 'nosniff'
-    resp.headers['Content-Security-Policy'] = "default-src 'none'; sandbox; frame-ancestors 'none'"
+    # CSP by type (2026-08-02): the strict `sandbox; default-src 'none'` neutralizes stored
+    # XSS in html/svg/js, but `sandbox` with no allowlist ALSO stops the browser's built-in
+    # media/pdf viewer from loading — so direct links to an uploaded .mp4/.mp3/.pdf served 200
+    # but played nothing (koolfoam video, mac-claude directive). Inert media served inline with
+    # its real mime + nosniff has no script surface, so it gets a CSP that permits only
+    # self-origin media/images/pdf to render while still blocking all script + framing, and
+    # crucially drops `sandbox`. Non-safe types (already downgraded to a text/plain attachment
+    # above) keep the maximally-locked CSP.
+    if _ext in _SAFE_INLINE:
+        resp.headers['Content-Security-Policy'] = (
+            "default-src 'none'; img-src 'self' data: blob:; media-src 'self' blob:; "
+            "object-src 'self'; style-src 'unsafe-inline'; frame-ancestors 'none'")
+    else:
+        resp.headers['Content-Security-Policy'] = "default-src 'none'; sandbox; frame-ancestors 'none'"
     resp.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
     resp.headers['Pragma'] = 'no-cache'
     resp.headers['Expires'] = '0'


### PR DESCRIPTION
## Problem
Direct links to uploaded media (e.g. `/uploads/*.mp4`, `.mp3`, `.pdf`) served **200 but played nothing** in the browser. The `/uploads` handler set `Content-Security-Policy: default-src 'none'; sandbox; frame-ancestors 'none'` on **every** response — and `sandbox` with no allowlist blocks the browser's built-in media/pdf viewer from loading.

## Fix
That strict CSP exists to neutralize stored XSS in user/agent-uploaded html/svg/js — which is still necessary. But inert media is already served inline with its real mime + `nosniff` (no script surface), so it doesn't need `sandbox`. The CSP is now branched by type:
- **Safe inline media** (`_SAFE_INLINE`: images, mp4/webm/ogg/mov, mp3/wav/m4a, pdf) → `default-src 'none'; img-src 'self' data: blob:; media-src 'self' blob:; object-src 'self'; style-src 'unsafe-inline'; frame-ancestors 'none'` — media renders, scripts/framing still blocked, no `sandbox`.
- **Everything else** (html/svg/js/xml — already downgraded to a `text/plain` attachment) → unchanged strict `default-src 'none'; sandbox; frame-ancestors 'none'`.

## Verification (live, fleet hot-patched before this PR)
- `.mp4` upload: new media CSP, plays in browser ✓
- `.svg` upload: still `text/plain` attachment + strict sandbox CSP (no XSS regression) ✓
- Rolled to all 26 live OVU containers; image rebuild bakes it for future recreates.