### PR TITLE
feat(canvas-styles): build a canvas style from the tenant's own website

### DIFF
--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -1,0 +1,303 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# Voice Agent Tool Catalog — THE single source of truth for the tool surface
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Spec: docs/jambot/voice-agent-tool-bus.md
+# Framework: future-dev-plans/17-MULTI-AGENT-FRAMEWORK.md
+#
+# Three projections are GENERATED from this file by services/tool_catalog.py:
+#
+#   1. realtime_tools()  → OpenAI-Realtime-shaped tools[] for session.update
+#                          (Grok Voice, OpenAI Realtime; Hume derives from it)
+#   2. marker_specs()    → the [MARKER] regex set for text-streaming agents
+#                          (clawdbot / OpenClaw / Hermes) — kept working
+#   3. prompt_docs()     → the "here are your tools" system-prompt block
+#
+# ── RULES ──────────────────────────────────────────────────────────────────
+#
+#  * NEVER hand-write a marker regex in VoiceSession.js or app.js again.
+#    Add the tool here. A marker that exists in code but not in this catalog
+#    is INVISIBLE to every realtime agent.
+#
+#  * `capability` gates the tool. A tool whose capability is not in the
+#    profile's allowlist is NOT SENT to the model at all — it never learns the
+#    tool exists. Refusal-by-omission beats refusal-by-rejection.
+#
+#  * `dangerous: true` requires an EXPLICIT per-profile opt-in on top of the
+#    capability. Used for anything that executes code or spends money.
+#
+#  * `execution` decides the routing:
+#      client       → browser, via EventBridge. Inline result.
+#      server_sync  → POST /api/tools/invoke, returns fast. Inline result.
+#      server_async → POST /api/tools/invoke, returns {job_id} immediately;
+#                     the real answer arrives later over /ws/agent-events.
+#
+#  * Parity note: the `marker:` block must stay behaviour-identical to the
+#    hand-written parser in src/core/VoiceSession.js (_checkCmdsInStream /
+#    _stripCmdTags) until Phase 2 migrates that file to generated output.
+#    Those regexes are load-bearing for every OpenClaw tenant.
+# ═══════════════════════════════════════════════════════════════════════════
+
+version: 1
+
+# ── Capability tags ────────────────────────────────────────────────────────
+# Profiles allowlist these. Descriptions are surfaced in the admin UI.
+capabilities:
+  canvas:   "Show, close and drive canvas pages on the display"
+  music:    "Control music playback"
+  audio_fx: "Play sound effects and DJ stingers"
+  face:     "Face recognition enrolment"
+  session:  "Session lifecycle — sleep, reset"
+  media_gen: "Generate new media (costs money)"
+  code:     "Dispatch coding work to a server-side CLI agent"
+
+
+tools:
+
+  # ═════════════════════════════════════════════════════════════════════════
+  # CANVAS — client-side, via EventBridge
+  # ═════════════════════════════════════════════════════════════════════════
+
+  - name: open_canvas_page
+    description: >-
+      Display a canvas page on the user's screen. Use when the user asks to see,
+      open, show or pull up a page. Pass the page name without the .html suffix.
+    execution: client
+    capability: canvas
+    event: cmd:canvas_page
+    marker:
+      form: "[CANVAS:<page>]"
+      pattern: '\[CANVAS:([^\]]+)\]'
+      groups: [page]
+      dedupe_key: CANVAS_PAGE
+    params:
+      type: object
+      properties:
+        page:
+          type: string
+          description: "Page name without extension, e.g. 'dashboard' or 'weather'."
+      required: [page]
+
+  - name: open_canvas_menu
+    description: >-
+      Open the canvas page picker so the user can choose a page themselves. Use
+      when the user asks what pages exist or wants to browse them.
+    execution: client
+    capability: canvas
+    event: cmd:canvas_menu
+    marker:
+      form: "[CANVAS_MENU]"
+      pattern: '\[CANVAS_MENU\]'
+      groups: []
+      dedupe_key: CANVAS_MENU
+    params:
+      type: object
+      properties: {}
+
+  - name: screenshot_canvas
+    description: >-
+      Capture what is currently displayed on the canvas so you can look at it.
+      Use when the user asks about something on screen that you cannot otherwise see.
+    execution: client
+    capability: canvas
+    event: cmd:canvas_screenshot
+    marker:
+      form: "[CANVAS_SCREENSHOT]"
+      pattern: '\[CANVAS_SCREENSHOT\]'
+      groups: []
+      dedupe_key: CANVAS_SCREENSHOT
+    params:
+      type: object
+      properties: {}
+
+  # ═════════════════════════════════════════════════════════════════════════
+  # MUSIC — client-side
+  # ═════════════════════════════════════════════════════════════════════════
+
+  - name: play_music
+    description: >-
+      Start music playback. Omit `track` to resume or play whatever is queued;
+      pass a track name to play something specific.
+    execution: client
+    capability: music
+    event: cmd:music_play
+    marker:
+      form: "[MUSIC_PLAY]  or  [MUSIC_PLAY:<track>]"
+      pattern: '\[MUSIC_PLAY(?::([^\]]+))?\]'
+      groups: [track]
+      dedupe_key: MUSIC_PLAY
+    params:
+      type: object
+      properties:
+        track:
+          type: string
+          description: "Optional track name. Omit to resume/play the current queue."
+
+  - name: stop_music
+    description: "Stop music playback."
+    execution: client
+    capability: music
+    event: cmd:music_stop
+    marker:
+      form: "[MUSIC_STOP]"
+      pattern: '\[MUSIC_STOP\]'
+      groups: []
+      dedupe_key: MUSIC_STOP
+    params:
+      type: object
+      properties: {}
+
+  - name: next_track
+    description: "Skip to the next track."
+    execution: client
+    capability: music
+    event: cmd:music_next
+    marker:
+      form: "[MUSIC_NEXT]"
+      pattern: '\[MUSIC_NEXT\]'
+      groups: []
+      dedupe_key: MUSIC_NEXT
+    params:
+      type: object
+      properties: {}
+
+  - name: play_spotify
+    description: "Play a specific track on Spotify."
+    execution: client
+    capability: music
+    event: cmd:spotify
+    marker:
+      form: "[SPOTIFY:<track>|<artist>]"
+      pattern: '\[SPOTIFY:([^|\]]+)(?:\|([^\]]+))?\]'
+      groups: [track, artist]
+      dedupe_key: SPOTIFY
+    params:
+      type: object
+      properties:
+        track:  { type: string, description: "Track title." }
+        artist: { type: string, description: "Artist name (optional but improves the match)." }
+      required: [track]
+
+  # ═════════════════════════════════════════════════════════════════════════
+  # AUDIO FX — client-side
+  # ═════════════════════════════════════════════════════════════════════════
+
+  - name: play_sound
+    description: >-
+      Play a short sound effect or DJ stinger. Use sparingly, for emphasis.
+    execution: client
+    capability: audio_fx
+    event: cmd:sound
+    marker:
+      form: "[SOUND:<name>]"
+      pattern: '\[SOUND:([^\]]+)\]'
+      groups: [sound]
+      dedupe_key: SOUND
+    params:
+      type: object
+      properties:
+        sound:
+          type: string
+          description: "Sound effect id, e.g. 'air_horn'."
+      required: [sound]
+
+  # ═════════════════════════════════════════════════════════════════════════
+  # FACE / SESSION — client-side
+  # ═════════════════════════════════════════════════════════════════════════
+
+  - name: register_face
+    description: >-
+      Enrol the face currently visible on camera under a given name, so you can
+      recognise that person later.
+    execution: client
+    capability: face
+    event: cmd:register_face
+    marker:
+      form: "[REGISTER_FACE:<name>]"
+      pattern: '\[REGISTER_FACE:([^\]]+)\]'
+      groups: [name]
+      dedupe_key: REGISTER_FACE
+    params:
+      type: object
+      properties:
+        name:
+          type: string
+          description: "Name to associate with the visible face."
+      required: [name]
+
+  - name: sleep
+    description: >-
+      Go dormant and wait for the wake word. Use when the user says goodbye,
+      says they're done, or asks you to go to sleep.
+    execution: client
+    capability: session
+    event: cmd:sleep
+    marker:
+      form: "[SLEEP]"
+      pattern: '\[SLEEP\]'
+      groups: []
+      dedupe_key: SLEEP
+    params:
+      type: object
+      properties: {}
+
+  # ═════════════════════════════════════════════════════════════════════════
+  # MEDIA GENERATION — server-side, async, COSTS MONEY
+  # ═════════════════════════════════════════════════════════════════════════
+  # Every generated asset is written to the server the moment it is produced,
+  # before any UI decision. Root CLAUDE.md is authoritative on this.
+
+  - name: generate_song
+    description: >-
+      Generate an original song from a text description. Takes a few minutes —
+      you will be told when it is ready, so acknowledge and carry on talking.
+    execution: server_async
+    capability: media_gen
+    dangerous: true          # spends real credits
+    handler: suno_generate
+    marker:
+      form: "[SUNO_GENERATE:<prompt>]"
+      pattern: '\[SUNO_GENERATE:([^\]]+)\]'
+      groups: [prompt]
+      dedupe_key: SUNO_GENERATE
+    params:
+      type: object
+      properties:
+        prompt:
+          type: string
+          description: "Description of the song — style, mood, subject, vocals."
+      required: [prompt]
+
+  # ═════════════════════════════════════════════════════════════════════════
+  # CODE — server-side, async, dispatches a CLI agent
+  # ═════════════════════════════════════════════════════════════════════════
+  # THE reason this bus exists. The voice agent does no coding itself; it hands
+  # a brief to a CLI agent on the server and reports the conclusion when it
+  # lands. See docs/jambot/voice-agent-tool-bus.md §3 and §4.
+
+  - name: code_task
+    description: >-
+      Hand a coding or build task to the server's CLI coding agent. Use for
+      anything that means writing, editing, fixing or building code or pages.
+      Returns immediately with a job id — say you're on it and keep talking.
+      You will be told the outcome when the agent finishes.
+    execution: server_async
+    capability: code
+    dangerous: true          # executes a CLI agent on the host
+    handler: code_task
+    # No marker: text-streaming agents (OpenClaw) already ARE coding agents.
+    # Exposing this to them would be a self-dispatch loop.
+    marker: null
+    params:
+      type: object
+      properties:
+        brief:
+          type: string
+          description: >-
+            Full self-contained description of the work. The CLI agent cannot
+            hear the conversation — restate everything it needs to know.
+        target:
+          type: string
+          description: >-
+            Optional file or page the work applies to, e.g. 'dashboard.html'.
+      required: [brief]

--- a/default-pages/canvas-styles.html
+++ b/default-pages/canvas-styles.html
@@ -1,4 +1,4 @@
-<!-- openvoiceui-version: 1 -->
+<!-- openvoiceui-version: 2 -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -62,6 +62,59 @@ svg{display:block}
 }
 .hero .active-line .dot{width:9px;height:9px;border-radius:50%;background:var(--green);flex:none}
 .hero .active-line strong{color:var(--text);font-weight:600}
+
+/* ---------- Match my website ---------- */
+.sr-only{
+  position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+  clip:rect(0 0 0 0);white-space:nowrap;border:0;
+}
+.brandbox{
+  background:var(--card);border:1px solid var(--border);border-radius:var(--radius);
+  box-shadow:var(--shadow);padding:22px;margin-bottom:26px;
+  display:grid;grid-template-columns:1fr auto;gap:8px 24px;align-items:end;
+}
+.brandbox-copy{grid-column:1/-1;max-width:64ch}
+.brandbox h2{
+  display:flex;align-items:center;gap:9px;
+  font-size:1.05rem;font-weight:700;letter-spacing:-.01em;color:var(--text);
+}
+.brandbox h2 svg{width:19px;height:19px;color:var(--blue);flex:none}
+.brandbox p{color:var(--muted);margin-top:6px;font-size:.93rem;line-height:1.55}
+.brandbox-form{display:flex;gap:10px;min-width:0}
+.brandbox-form input{
+  flex:1;min-width:0;font:inherit;font-size:.95rem;color:var(--text);
+  background:var(--bg);border:1px solid var(--border-strong);border-radius:10px;
+  padding:10px 13px;transition:border-color .15s,box-shadow .15s;
+}
+.brandbox-form input::placeholder{color:var(--faint)}
+.brandbox-form input:focus{
+  outline:none;border-color:var(--blue);box-shadow:0 0 0 3px var(--blue-soft);
+}
+.brandbox-form input[aria-invalid="true"]{border-color:var(--red)}
+.brandbox-form .btn{white-space:nowrap}
+.brandbox-hint{color:var(--faint);font-size:.82rem;grid-column:1/-1;margin-top:-2px}
+.brandbox-hint.is-error{color:var(--red)}
+.brandbox-status{
+  grid-column:1/-1;display:flex;align-items:center;gap:12px;margin-top:4px;
+  background:var(--blue-soft);border:1px solid #dbeafe;border-radius:10px;padding:12px 14px;
+}
+.brandbox-status.is-done{background:var(--green-soft);border-color:#dcfce7}
+.brandbox-status.is-error{background:var(--red-soft);border-color:#fee2e2}
+.brandbox-status .bs-text{display:flex;flex-direction:column;gap:2px;min-width:0;flex:1}
+.brandbox-status strong{font-size:.9rem;font-weight:600;color:var(--text)}
+.brandbox-status span{font-size:.84rem;color:var(--muted)}
+.spinner{
+  width:16px;height:16px;flex:none;border-radius:50%;
+  border:2px solid #bfdbfe;border-top-color:var(--blue);
+  animation:spin .8s linear infinite;
+}
+@keyframes spin{to{transform:rotate(360deg)}}
+@media (prefers-reduced-motion:reduce){.spinner{animation-duration:2.4s}}
+@media (max-width:640px){
+  .brandbox{grid-template-columns:1fr;padding:18px}
+  .brandbox-form{flex-direction:column}
+  .brandbox-form .btn{width:100%;justify-content:center}
+}
 
 /* ---------- Grid + cards ---------- */
 .grid{
@@ -294,6 +347,35 @@ details.advanced .adv-body{padding:0 18px 16px}
       <span>Current style: <strong id="activeName">&mdash;</strong></span>
     </div>
   </header>
+
+  <!-- Match my website -->
+  <section class="brandbox" id="brandBox" aria-labelledby="brandTitle">
+    <div class="brandbox-copy">
+      <h2 id="brandTitle">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a15 15 0 0 1 0 18a15 15 0 0 1 0-18z"/></svg>
+        Match my website
+      </h2>
+      <p>Enter your website and we&rsquo;ll study its colours, type and layout, then build a style
+         that matches your brand &mdash; so quotes and pages your assistant creates look like they
+         came from the same company your customers already know.</p>
+    </div>
+    <form class="brandbox-form" id="brandForm" autocomplete="off">
+      <label class="sr-only" for="brandUrl">Your website address</label>
+      <input type="text" id="brandUrl" name="url" inputmode="url" spellcheck="false"
+             placeholder="yourcompany.com" aria-describedby="brandHint">
+      <button class="btn btn-primary" id="brandBtn" type="submit">Build my style</button>
+    </form>
+    <p class="brandbox-hint" id="brandHint">Takes a few minutes. You can leave this page &mdash; it keeps working.</p>
+
+    <div class="brandbox-status hidden" id="brandStatus" role="status" aria-live="polite">
+      <span class="spinner" id="brandSpinner" aria-hidden="true"></span>
+      <div class="bs-text">
+        <strong id="brandStatusTitle">Reviewing your site&hellip;</strong>
+        <span id="brandStatusDetail"></span>
+      </div>
+      <button class="btn btn-secondary hidden" id="brandSeeBtn" type="button">See it</button>
+    </div>
+  </section>
 
   <!-- Loading skeletons -->
   <div class="grid" id="skeletons" aria-hidden="true">
@@ -1009,10 +1091,158 @@ details.advanced .adv-body{padding:0 18px 16px}
   });
 
   // -------------------------------------------------------------------
+  // Match my website
+  //
+  // No client-side state at all: the server owns the job, and the page asks it
+  // what is happening. A refresh mid-review picks the same job back up, and two
+  // tabs agree — which localStorage could never give us (and which the root
+  // CLAUDE.md forbids anyway: the VPS is the database).
+  // -------------------------------------------------------------------
+  var BRAND_API = API + '/from-website';
+  var brandPoll = null;
+
+  function setBrandStatus(kind, title, detail, styleId) {
+    var box = $('brandStatus');
+    box.classList.remove('hidden', 'is-done', 'is-error');
+    if (kind !== 'running') box.classList.add(kind === 'done' ? 'is-done' : 'is-error');
+    $('brandSpinner').classList.toggle('hidden', kind !== 'running');
+    $('brandStatusTitle').textContent = title;
+    $('brandStatusDetail').textContent = detail || '';
+
+    var see = $('brandSeeBtn');
+    see.classList.toggle('hidden', !styleId);
+    see.onclick = styleId ? function () {
+      var found = null;
+      for (var i = 0; i < state.styles.length; i++) {
+        if (state.styles[i].id === styleId) found = state.styles[i];
+      }
+      if (found) openPreview(found);
+    } : null;
+  }
+
+  function setBrandBusy(busy) {
+    $('brandBtn').disabled = busy;
+    $('brandUrl').disabled = busy;
+    $('brandBtn').textContent = busy ? 'Working…' : 'Build my style';
+  }
+
+  function stopBrandPoll() {
+    if (brandPoll) { clearInterval(brandPoll); brandPoll = null; }
+  }
+
+  function applyBrandJob(job, opts) {
+    opts = opts || {};
+    if (!job) { setBrandBusy(false); return; }
+
+    if (job.status === 'queued' || job.status === 'running') {
+      setBrandBusy(true);
+      setBrandStatus('running',
+        'Reviewing ' + (job.url || 'your site') + '…',
+        job.progress || 'Queued — starting shortly.');
+      return;
+    }
+
+    stopBrandPoll();
+    setBrandBusy(false);
+
+    if (job.status === 'done' && job.style_id) {
+      setBrandStatus('done', 'Your brand style is ready',
+        job.summary || 'It is in the gallery below.', job.style_id);
+      // Reload so the new style appears with a live preview, then offer it.
+      loadStyles(true).then(function () {
+        if (opts.announce) {
+          toast('Built a style from ' + (job.url || 'your website'), {kind: 'ok'});
+        }
+      });
+      return;
+    }
+
+    if (job.status === 'done' && job.style_missing) {
+      // Job says success, store disagrees. Say so plainly rather than showing a
+      // ready state for something the gallery cannot render.
+      setBrandStatus('error', 'The review finished but the style did not save',
+        'Nothing was added to your gallery. Try again, or ask your assistant.');
+      return;
+    }
+
+    if (job.status === 'failed') {
+      setBrandStatus('error', 'We could not build a style from that site',
+        job.error || 'Something went wrong during the review.');
+      return;
+    }
+
+    setBrandStatus('error', 'That review stopped unexpectedly',
+      'Status: ' + (job.status || 'unknown'));
+  }
+
+  function pollBrandJob(jobId) {
+    stopBrandPoll();
+    brandPoll = setInterval(function () {
+      fetchJson(BRAND_API + '/' + encodeURIComponent(jobId))
+        .then(function (job) { applyBrandJob(job, {announce: true}); })
+        .catch(function () { /* transient — keep polling */ });
+    }, 5000);
+  }
+
+  $('brandForm').addEventListener('submit', function (e) {
+    e.preventDefault();
+    var input = $('brandUrl');
+    var url = (input.value || '').trim();
+    var hint = $('brandHint');
+    hint.classList.remove('is-error');
+    input.removeAttribute('aria-invalid');
+
+    if (!url) {
+      hint.textContent = 'Enter your website address first.';
+      hint.classList.add('is-error');
+      input.setAttribute('aria-invalid', 'true');
+      input.focus();
+      return;
+    }
+
+    setBrandBusy(true);
+    hint.textContent = 'Takes a few minutes. You can leave this page — it keeps working.';
+    fetch(BRAND_API, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({url: url}),
+    }).then(function (r) {
+      return r.json().then(function (d) { return {ok: r.ok, data: d}; });
+    }).then(function (res) {
+      if (!res.ok) {
+        setBrandBusy(false);
+        hint.textContent = res.data.error || 'That request was rejected.';
+        hint.classList.add('is-error');
+        input.setAttribute('aria-invalid', 'true');
+        return;
+      }
+      setBrandStatus('running', 'Reviewing ' + url + '…',
+        'Opening it in a browser and measuring the design.');
+      pollBrandJob(res.data.job_id);
+    }).catch(function () {
+      setBrandBusy(false);
+      hint.textContent = 'Could not reach the server. Check your connection and try again.';
+      hint.classList.add('is-error');
+    });
+  });
+
+  function resumeBrandJob() {
+    return fetchJson(BRAND_API).then(function (data) {
+      var job = data && data.job;
+      if (!job) return;
+      applyBrandJob(job);
+      if (job.status === 'queued' || job.status === 'running') {
+        $('brandUrl').value = job.url || '';
+        pollBrandJob(job.job_id);
+      }
+    }).catch(function () { /* the picker still works without this */ });
+  }
+
+  // -------------------------------------------------------------------
   // Boot
   // -------------------------------------------------------------------
   $('retryBtn').addEventListener('click', function () { loadStyles(); });
-  loadStyles();
+  loadStyles().then(resumeBrandJob);
 })();
 </script>
 </body>

--- a/docs/jambot/voice-agent-tool-bus.md
+++ b/docs/jambot/voice-agent-tool-bus.md
@@ -1,0 +1,219 @@
+# Voice Agent Tool Bus — system overview
+
+> **Status: SPEC + PHASE 1 BUILD.**
+> The layer that lets a voice agent *do things* — regardless of which brain is behind it.
+> Companion: `future-dev-plans/17-MULTI-AGENT-FRAMEWORK.md` (the adapter framework).
+>
+> Read this BEFORE touching `config/tools.yaml`, `services/tool_catalog.py`,
+> `services/tool_jobs.py`, `routes/tools.py`, `src/shell/tool-bridge.js`, or the
+> marker-parsing blocks in `src/core/VoiceSession.js` / `src/app.js`.
+
+---
+
+## 1. Why this exists
+
+Two agent classes need the same tool surface but speak different protocols:
+
+| | Brain | How it asks for a tool | Gets a result back? |
+|---|---|---|---|
+| **Text-streaming** | OpenClaw (`clawdbot`), Hermes | `[MARKER]` scraped from prose | ❌ no |
+| **Realtime speech-to-speech** | Grok Voice, OpenAI Realtime, Hume EVI | native `function_call` | ✅ yes |
+
+Before this bus, only the first existed — and it was defined implicitly by regexes
+duplicated across `src/core/VoiceSession.js` and `src/app.js`. There was no catalog, no
+schema, no return value, and no way to hand a realtime model a tool list.
+
+The bus fixes that with **one catalog and three generated projections**, so both classes
+drive the same tools off the same definitions.
+
+---
+
+## 2. Architecture
+
+```
+  ┌──────────────┐        ┌──────────────┐        ┌──────────────┐
+  │ realtime     │        │ text-stream  │        │  admin /     │
+  │ agent (Grok) │        │ agent        │        │  scripts     │
+  └──────┬───────┘        └──────┬───────┘        └──────┬───────┘
+     function_call            [MARKER]                 HTTP
+         │                       │                       │
+         ▼                       ▼                       ▼
+  ┌──────────────────────────────────────────────────────────────┐
+  │                    src/shell/tool-bridge.js                  │
+  │   normalize → capability gate → route by execution class     │
+  └───────────────┬──────────────────────────┬───────────────────┘
+                  │ client-side              │ server-side
+                  ▼                          ▼
+        EventBridge AgentEvents      POST /api/tools/invoke
+        (canvas, music, mood,                │
+         sound, face)                 ┌──────┴───────┐
+                                      │ sync         │ async
+                                      ▼              ▼
+                              inline result    job store
+                                              (runtime/tool-jobs/)
+                                                     │
+                                              CLI-agent worker
+                                              claude -p --model …
+                                                     │
+                                                     ▼
+                                          /ws/agent-events  (push)
+                                                     │
+                                                     ▼
+                                    bridge.emit(FORCE_MESSAGE)
+                                                     │
+                                                     ▼
+                                     adapter injects → agent SPEAKS
+                                            the conclusion
+```
+
+### The single source of truth
+
+`config/tools.yaml`. Every tool declares: name, description, JSON-schema params,
+execution class, capability tag, and (for legacy compat) its marker form.
+
+`services/tool_catalog.py` generates from it:
+
+1. **`tools[]`** — OpenAI-Realtime-shaped function definitions for `session.update`
+   (Grok, OpenAI Realtime; Hume's tool format derives from the same objects).
+2. **Marker regexes** — the `[CANVAS:x]` family, so text-streaming agents keep working
+   **unchanged**. Generated, not hand-duplicated.
+3. **Prompt docs** — the "here are your tools" block injected into a system prompt for
+   brains without native function calling.
+
+> **Invariant:** never hand-write a marker regex again. Add the tool to the catalog and
+> regenerate. A marker that exists in code but not in the catalog is invisible to every
+> realtime agent — the same class of bug as `feedback_tools_md_routing`.
+
+### Execution classes
+
+| Class | Meaning | Result |
+|---|---|---|
+| `client` | Runs in the browser via EventBridge — canvas, music, sound, mood | Inline, immediate |
+| `server_sync` | Server call that returns fast (< ~2 s) — list pages, read state | Inline |
+| `server_async` | Long-running — image gen, song gen, **`code_task`** | `{job_id, status: "dispatched"}` then a push |
+
+`server_async` is the whole reason the bus exists. A voice agent must **not** block for four
+minutes while a CLI agent builds something. It dispatches, says "on it," keeps the
+conversation alive, and gets told the outcome when it lands.
+
+---
+
+## 3. The async round trip (the new part)
+
+```
+1. User (voice): "add a dark mode toggle to the dashboard page"
+2. Grok emits function_call: code_task{ brief: "...", target: "dashboard.html" }
+3. tool-bridge → POST /api/tools/invoke → job store writes runtime/tool-jobs/<id>.json
+4. Server returns { job_id, status: "dispatched", eta_hint: "a few minutes" }
+5. tool-bridge returns THAT to Grok as the function result
+   → Grok says "On it — I'll tell you when it's done." Conversation continues.
+6. Worker runs:  scripts/with-claude-env.sh claude -p --model sonnet …
+7. Worker writes result to the job file, appends to the event log
+8. /ws/agent-events pushes { type: "job.done", job_id, summary } to the browser
+9. tool-bridge → bridge.emit(AgentActions.FORCE_MESSAGE, { text: "[TOOL RESULT] ..." })
+10. Adapter injects it (already implemented in EVERY adapter — see table below)
+11. Grok speaks the conclusion and may chain a tool call to show the result
+```
+
+**Step 10 is already built.** Every adapter implements both push actions:
+
+| Adapter | CONTEXT_UPDATE (silent) | FORCE_MESSAGE (must act) |
+|---|---|---|
+| `xai-realtime` | `:194` `_sendContextUpdate` → `session.update` | `:195` `_sendForceMessage` → `conversation.item.create` + `response.create` |
+| `hume-evi` | `:118` | `:119` |
+| `elevenlabs-classic` | `:168` | `:169` |
+| `elevenlabs-hybrid` | `:194` | `:195` |
+| `clawdbot` | `:94` `[CONTEXT: …]` | `:87` `sendMessage` |
+
+Working precedent for a non-agent subsystem pushing into a live conversation:
+`src/shell/music-bridge.js:44-53` and `src/shell/commercial-bridge.js:37`.
+
+The **only** genuinely new plumbing is the server→browser half: `/ws/agent-events`.
+
+### Why not just poll?
+
+Polling is what `routes/suno.py` does today and it is fine for a modal that a user is
+staring at. It is wrong here: the browser tab may be mid-conversation, the agent needs to
+be *interrupted* with news, and per root `CLAUDE.md` no job state may live in the browser.
+Push keeps the job state entirely server-side, which is also what makes the result survive
+a page reload.
+
+---
+
+## 4. Capability gating — required, not optional
+
+A voice agent that can dispatch arbitrary coding work to a CLI agent on this box is a
+**real privilege surface**. Two live burns say so:
+
+- Memory `mac-listener-task-kind-auto-executes` — `KIND=task` to a Mac listener auto-ran in
+  permissionless headless Claude (paid-API + arbitrary-execution risk).
+- SEC item filed 2026-08-01 by `bun-desktop@mesh` — `ovui_mcp.py` binds `0.0.0.0:8091`
+  with **no inbound auth** and serves `terminal_execute` to anything that can reach it.
+
+So gating is in the schema from the first commit, not bolted on:
+
+- Every tool carries a `capability` tag.
+- Every profile carries an allowlist. A tool not in the profile's allowlist is **not sent**
+  to the model at all — it never learns the tool exists. Refusal-by-omission beats
+  refusal-by-rejection.
+- `server_async` tools that shell out (`code_task`) additionally require an explicit
+  `dangerous: true` in the catalog and an explicit profile opt-in.
+- The worker runs with a **pinned model** and a scoped working directory. Never
+  account-default (root `CLAUDE.md` model discipline: that silently selects opus for bulk
+  work), never the whole filesystem.
+- Every invocation is logged with `{profile, tool, params, user_id}` — the surface must be
+  auditable after the fact, not just gated before it.
+
+---
+
+## 5. Files
+
+| Path | Role |
+|---|---|
+| `config/tools.yaml` | **Canonical catalog.** The only place a tool is defined. |
+| `services/tool_catalog.py` | Loads catalog; generates realtime `tools[]`, marker regexes, prompt docs. |
+| `services/tool_jobs.py` | Durable job store — create / read / update / list. Filesystem-backed. |
+| `routes/tools.py` | `/api/tools/catalog`, `/api/tools/invoke`, `/api/tools/jobs/<id>`. |
+| `server.py` `/ws/agent-events` | Per-session push channel for job completion. |
+| `src/shell/tool-bridge.js` | Client router: normalize → gate → EventBridge or HTTP. |
+| `src/adapters/xai-realtime.js` | `tools[]` in `session.update`; handles `function_call`. |
+| `runtime/tool-jobs/` | Job state on disk (gitignored, bind-mounted, survives recreate). |
+
+Job state deliberately lives under `runtime/` alongside `OVUI_DB_PATH` — see
+`services/paths.py`, which documents why the container's writable layer is **not** safe
+(wiped on recreate).
+
+---
+
+## 6. Adding a tool
+
+1. Add it to `config/tools.yaml` — name, description, params schema, `execution`,
+   `capability`, and `marker` if text-streaming agents should reach it too.
+2. If `client`: handle it in `src/shell/tool-bridge.js` by emitting the right `AgentEvents`.
+3. If `server_sync` / `server_async`: add the handler in `routes/tools.py`.
+4. Add the capability to whichever `profiles/*.json` should have it.
+
+Do **not** add a marker regex to `VoiceSession.js` or `app.js`. They consume generated
+output.
+
+---
+
+## 7. Relationship to issue #244
+
+#244 (Provider Pluggability) is the **backend** for server-side tools, not a prerequisite
+for this bus. When `generate_image` fires, its handler should resolve a provider through
+`providers/registry.py` rather than a hardcoded vendor. Build the tool first, then swap
+what's behind it. Detail: `future-dev-plans/17-MULTI-AGENT-FRAMEWORK.md` §6.
+
+---
+
+## 8. Known gaps / not yet done
+
+- `XAI_API_KEY` exists only in `test-dev`'s compose `.env` — **not** in
+  `/mnt/system/base/.platform-keys.env`. Grok Voice is one-tenant until that moves.
+- Grok voice (`Celeste`) and model (`grok-voice-think-fast-1.0`, hardcoded in the
+  `server.py` proxy URL) are not profile-configurable.
+- `elevenlabs-classic` / `elevenlabs-hybrid` remain commented out in `adapter-registry.js`.
+- Marker parsing in `VoiceSession.js` / `app.js` is still hand-written; migrating it to
+  generated output is Phase 2 and must be behaviour-identical (it is load-bearing for every
+  OpenClaw tenant).

--- a/future-dev-plans/17-MULTI-AGENT-FRAMEWORK.md
+++ b/future-dev-plans/17-MULTI-AGENT-FRAMEWORK.md
@@ -1,0 +1,228 @@
+# 17 — Multi-Agent Framework
+
+> **Status: BUILT (core) / EXTENDING (tools).**
+> This document was cited by `src/adapters/_template.js`, `src/adapters/xai-realtime.js`,
+> `src/shell/adapter-registry.js` and `src/shell/orchestrator.js` for months but was never
+> committed. This file reconstructs the contract **from the shipped code** so the citations
+> resolve, and states where the framework is going next.
+>
+> Companion doc — the tool layer: `docs/jambot/voice-agent-tool-bus.md`
+
+---
+
+## 1. The problem this solves
+
+OpenVoiceUI started as a front-end for exactly one brain: the OpenClaw gateway, spoken to
+over `/ws/clawdbot`. Everything — mic handling, TTS playback, canvas commands, mood, music —
+was fused to that one transport.
+
+That is wrong for two reasons:
+
+1. **Realtime speech-to-speech APIs exist** (xAI Grok, OpenAI Realtime, Hume EVI,
+   ElevenLabs). They are all-in-one STT+LLM+TTS over a single WebSocket with sub-second
+   latency. They do not want our STT, our TTS, or our turn-taking. They want the mic bytes
+   and nothing else.
+2. **Not every agent should be an OpenClaw agent.** A voice agent that answers questions and
+   opens canvas pages does not need a full coding harness behind it. Coding work should be
+   *dispatched* to a CLI agent, not carried by the conversation.
+
+The framework's job: let the UI shell stay identical while the **brain behind it is swappable
+at profile level**.
+
+---
+
+## 2. Architecture
+
+```
+                     ┌──────────────────────────────────┐
+                     │            UI SHELL              │
+                     │  face · transcript · canvas ·    │
+                     │  music · soundboard · mood       │
+                     └───────────────┬──────────────────┘
+                                     │
+                            ┌────────┴─────────┐
+                            │   EventBridge    │   src/core/EventBridge.js
+                            │  (the ONLY seam) │
+                            └────────┬─────────┘
+                    AgentEvents ↑    │    ↓ AgentActions
+                                     │
+                     ┌───────────────┴──────────────────┐
+                     │        ADAPTER (exactly one)     │
+                     │  init / start / stop / destroy   │
+                     └───────────────┬──────────────────┘
+                                     │  owns its own audio,
+                                     │  WebSocket, SDK, protocol
+        ┌────────────┬───────────────┼───────────────┬──────────────┐
+        │            │               │               │              │
+   clawdbot     hume-evi      xai-realtime    elevenlabs-*    (your next one)
+   OpenClaw     Hume EVI      Grok Realtime   ElevenLabs
+```
+
+**The single rule that makes this work:** an adapter talks to the outside world *only*
+through the bridge. It never imports another adapter, never reaches into the UI, never
+touches the DOM. The UI never knows which adapter is loaded — it only knows the
+capability list.
+
+### Files
+
+| File | Role |
+|---|---|
+| `src/core/EventBridge.js` | The seam. `AgentEvents` (agent→UI) + `AgentActions` (UI→agent). |
+| `src/shell/adapter-registry.js` | `adapterId → module path`, dynamic import with caching, fallback to default. |
+| `src/shell/orchestrator.js` | Loads the profile's adapter, wires bridge, runs lifecycle. |
+| `src/adapters/_template.js` | Copy-me starting point. |
+| `src/adapters/*.js` | The adapters themselves. |
+| `profiles/*.json` | Profile declares `"adapter": "<id>"` + `adapter_config`. |
+
+### Adapter lifecycle
+
+```
+init(bridge, config)   load SDK, subscribe to AgentActions.  NO mic, NO connection.
+start()                user gesture. AudioContext, mic, connect. emit CONNECTED.
+stop()                 tear down audio + socket. Re-startable.
+destroy()              stop() + unsubscribe everything + close AudioContext.
+```
+
+`init` must not start the mic — browsers require a user gesture for `AudioContext`, and
+profile switching calls `init` on adapters that may never be started.
+
+### Capabilities
+
+An adapter declares what it can do; the UI shows/hides features accordingly:
+
+```
+'canvas' · 'dj_soundboard' · 'caller_effects' · 'music_sync' · 'multi_voice'
+'emotion_detection' · 'commercials' · 'vps_control' · 'wake_word' · 'tools'
+```
+
+`'tools'` is new — see §5.
+
+---
+
+## 3. Adding an adapter
+
+1. `cp src/adapters/_template.js src/adapters/my-adapter.js`
+2. Add `'my-adapter': '../adapters/my-adapter.js'` to `ADAPTER_PATHS` in
+   `src/shell/adapter-registry.js`
+3. `profiles/my-profile.json` with `"adapter": "my-adapter"`
+
+Done. Profiles auto-discover via `profiles/manager.py` globbing `profiles/*.json`.
+
+**If the adapter needs a provider API key**, proxy it server-side. Never ship a key to the
+browser. The pattern is `/ws/xai-realtime` in `server.py` — a transparent bidirectional
+relay that injects `Authorization: Bearer` on the upstream leg. The browser gets a
+same-origin WebSocket and never sees the credential. A `/api/<provider>/config` route
+returning `{"available": bool}` lets the adapter surface a useful error instead of failing
+silently on connect.
+
+---
+
+## 4. Shipped adapters
+
+| ID | Backend | Registered | Notes |
+|---|---|---|---|
+| `clawdbot` | OpenClaw gateway `/ws/clawdbot` | ✅ default | Text-streaming. Marker protocol (§5). |
+| `hume-evi` | Hume EVI | ✅ | Emotion scores per utterance. |
+| `xai-realtime` | Grok Voice via `/ws/xai-realtime` | ✅ | PCM16 @ 24 kHz, server VAD. Tools pending (§5). |
+| `elevenlabs-classic` | ElevenLabs Conversational | ⛔ commented out | Built, not enabled. |
+| `elevenlabs-hybrid` | ElevenLabs + own LLM | ⛔ commented out | Built, not enabled. |
+
+---
+
+## 5. Where the framework is incomplete — the tool layer
+
+The adapter seam is solved. **The tool seam is not.**
+
+Today an agent acts on the world by emitting **text markers** that the client regex-scrapes
+out of the prose stream and then strips before display:
+
+```
+[CANVAS:dashboard]  [CANVAS_ACTION:{...}]  [CANVAS_MENU]  [CANVAS_STYLE:...]
+[CANVAS_SCREENSHOT] [CANVAS_URL:...]  [MUSIC_PLAY] [MUSIC_STOP] [MUSIC_NEXT]
+[SOUND:air_horn]  [MOOD:happy]  [IMAGE:...]  [SOUNDCLOUD] [SOUNDCLOUD_PAGE]
+```
+
+Parsed in `src/core/VoiceSession.js` (~L420-510) **and** duplicated in `src/app.js`
+(~L30-90, L4257+). There is no catalog — the tool surface is defined implicitly by
+scattered regexes.
+
+This works for text-streaming brains. It **structurally cannot** work for a realtime
+speech-to-speech brain:
+
+1. The model emits **audio**. The text transcript is a byproduct. Grok will say
+   *"bracket canvas colon dashboard"* out loud.
+2. Markers arrive *after* the audio is already playing → wrong ordering.
+3. Markers are fire-and-forget. There is **no return value**, so the agent cannot reason
+   about a result — which is exactly what "dispatch a coding job and tell me how it went"
+   requires.
+4. Realtime APIs have native `tools` / `function_call` with a result round-trip. That is
+   the correct channel and we are not using it.
+
+### The fix
+
+One canonical catalog, three generated projections:
+
+```
+                    config/tools.yaml            ← single source of truth
+                           │
+       ┌───────────────────┼───────────────────┐
+       ▼                   ▼                   ▼
+  realtime tools[]    [MARKER] regexes   system-prompt docs
+  (Grok/OpenAI/Hume)  (clawdbot — kept   (both)
+   function calling    working, now
+                       GENERATED)
+```
+
+The marker protocol is **not removed** — it is generated from the catalog instead of
+hand-duplicated across two files, so OpenClaw agents keep working unchanged while realtime
+agents get real function calling off the same definitions.
+
+Plus two pieces of new plumbing:
+
+- **Async tool contract.** Sync tools (`open_canvas`, `play_song`) return inline. Async
+  tools (`code_task`) return `{job_id, status: "dispatched"}` immediately so the agent says
+  "on it" and keeps talking — the whole point of sub-second voice.
+- **Server→agent push.** `AgentActions.CONTEXT_UPDATE` / `FORCE_MESSAGE` already exist and
+  are already implemented in *every* adapter. What's missing is the server→browser half.
+
+Full spec: **`docs/jambot/voice-agent-tool-bus.md`**.
+
+---
+
+## 6. Relationship to issue #244 (Provider Pluggability)
+
+Different axis, commonly confused:
+
+- **#244 is service pluggability** — which vendor does STT / vision / image-gen / music.
+- **This doc is agent pluggability** — which brain drives the conversation.
+
+A realtime voice API is all-in-one STT+LLM+TTS and **bypasses the STT/TTS/LLM registries
+entirely**. Making STT pluggable does nothing for a Grok-voice agent; Grok does its own STT
+internally.
+
+Where #244 *does* land is one layer down: when a tool named `generate_image` fires, the
+**server-side handler** should resolve its provider through a registry instead of a
+hardcoded vendor. #244 is therefore the **backend for the tools, not a prerequisite for
+this framework**.
+
+Recommended order: build the tool catalog first, then pull #244 items in as each tool needs
+one. Refactoring seven services with no consumer means guessing the interfaces; with a tool
+bus driving it each item becomes "swap what's behind tool N," verifiable per tool.
+
+Groundwork already exists and should be reused, not reinvented: `providers/registry.py`
+(singleton + `ProviderType` + autodiscover) and `config/providers.yaml`. Note only the
+`stt:` section there is load-bearing today; `llm:` is deprecated
+(`providers/llm/DEPRECATED.md`) and `tts:` is informational — live TTS uses
+`tts_providers/`.
+
+---
+
+## 7. Invariants
+
+- An adapter communicates **only** through the bridge.
+- An adapter **never** imports another adapter.
+- `destroy()` releases every resource — AudioContext, sockets, subscriptions, timers.
+- Provider credentials **never** reach the browser. Proxy server-side.
+- No `localStorage` / `sessionStorage` / IndexedDB for any state. The VPS is the database.
+  (Root `CLAUDE.md` — JamBot is a browser terminal for one user's own VPS, not a website.)
+- New adapters are **additive**. Adding one must not change behaviour for existing profiles.

--- a/routes/canvas_styles.py
+++ b/routes/canvas_styles.py
@@ -8,14 +8,21 @@ POST   /api/canvas/styles/<id>/archive    — archive custom (nothing is ever de
 POST   /api/canvas/styles/<id>/unarchive
 POST   /api/canvas/styles/<id>/activate   — set tenant-active style, render agent files
 GET    /api/canvas/styles/<id>/preview    — the style's template/demo page as HTML
+POST   /api/canvas/styles/from-website    — spool a brand-review job (host worker)
+GET    /api/canvas/styles/from-website/<job_id> — poll that job
 
 Store + renderer: services/canvas_styles.py
+Brand review pipeline: scripts/brand-style/ on the HOST (this container has no
+browser and no coding agent), reached through the durable tool-job spool.
 """
 import logging
+import os
+import re
 
-from flask import Blueprint, Response, jsonify, request
+from flask import Blueprint, Response, g, jsonify, request
 
 from services import canvas_styles as store
+from services import tool_jobs
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +166,112 @@ def lint_page(page_id):
         logger.error('lint failed for %s: %s', page_id, exc)
         return jsonify({'error': 'lint failed'}), 500
     return jsonify({'page_id': safe, 'ok': not issues, 'issues': issues})
+
+
+_URL_SHAPE_RE = re.compile(
+    r'^(?:https?://)?'
+    r'(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}'
+    r'(?::\d{2,5})?(?:[/?#]\S*)?$',
+    re.I,
+)
+
+
+@canvas_styles_bp.post('/api/canvas/styles/from-website')
+def style_from_website():
+    """Ask the host to review a website and build a matching style.
+
+    This container cannot do the work: it has no browser to render the site and
+    no coding agent to judge what it sees. So the request is spooled to the same
+    durable job bus the voice tools use, and the host worker
+    (scripts/tool-job-worker.py -> handle_brand_style) executes it.
+
+    The shape check here is a courtesy so the user gets an instant, readable
+    error for a typo. It is NOT the security boundary — the host worker does the
+    real SSRF check (public_url_or_reason) against every resolved address, since
+    that is the process that will actually open the URL.
+    """
+    data = request.get_json(silent=True) or {}
+    url = (data.get('url') or '').strip()
+    if not url:
+        return jsonify({'error': 'a website URL is required'}), 400
+    if len(url) > 500:
+        return jsonify({'error': 'that URL is too long'}), 400
+    if not _URL_SHAPE_RE.match(url):
+        return jsonify({'error': "that doesn't look like a website address — "
+                                 'try something like example.com'}), 400
+
+    # Provenance only — the worker derives the real tenant from the job file's
+    # own path (/mnt/clients/<tenant>/...), which is authoritative and cannot be
+    # wrong even on tenants that never set these env vars.
+    tenant = (os.getenv('JAMBOT_TENANT') or os.getenv('TENANT_NAME')
+              or os.getenv('CLIENT_NAME') or None)
+    job = tool_jobs.create(
+        'brand_style',
+        {'url': url},
+        tenant=tenant,
+        user_id=getattr(g, 'clerk_user_id', None),
+    )
+    logger.info('brand style requested: job=%s url=%s tenant=%s', job['id'], url, tenant)
+    return jsonify({
+        'ok': True,
+        'job_id': job['id'],
+        'status': job['status'],
+        'message': 'Reviewing the site — this takes a few minutes.',
+    }), 202
+
+
+@canvas_styles_bp.get('/api/canvas/styles/from-website')
+def style_from_website_latest():
+    """The most recent brand-review job, so the picker can resume after a reload.
+
+    The browser stores NOTHING (root CLAUDE.md: the VPS is the database). A user
+    who refreshes mid-review must still see it running, and the only way to know
+    that without client storage is to ask the server.
+    """
+    jobs = [j for j in tool_jobs.list_jobs() if j.get('tool') == 'brand_style']
+    if not jobs:
+        return jsonify({'job': None})
+    return jsonify({'job': _brand_job_view(jobs[0])})
+
+
+def _brand_job_view(job: dict) -> dict:
+    out = {
+        'job_id': job['id'],
+        'status': job.get('status'),
+        'url': (job.get('params') or {}).get('url'),
+        'progress': job.get('progress'),
+        'error': job.get('error'),
+        'created_at': job.get('created_at'),
+    }
+    result = job.get('result') or {}
+    style_id = job.get('style_id')
+    if not style_id:
+        for art in result.get('artifacts') or []:
+            if art.get('type') == 'canvas_style':
+                style_id = art.get('id')
+                break
+    if style_id:
+        # Report the style only if it is REALLY in the store. A finished job
+        # claiming a style that the picker cannot then show is worse than a
+        # failure, because it looks like success.
+        exists = store.get_style(style_id) is not None
+        out['style_id'] = style_id if exists else None
+        out['style_missing'] = not exists
+        if exists:
+            out['preview_url'] = f'/api/canvas/styles/{style_id}/preview'
+    if result.get('summary'):
+        out['summary'] = result['summary']
+    return out
+
+
+@canvas_styles_bp.get('/api/canvas/styles/from-website/<job_id>')
+def style_from_website_status(job_id):
+    job = tool_jobs.get(job_id)
+    if not job:
+        return jsonify({'error': 'job not found'}), 404
+    if job.get('tool') != 'brand_style':
+        return jsonify({'error': 'not a brand-style job'}), 400
+    return jsonify(_brand_job_view(job))
 
 
 @canvas_styles_bp.get('/api/canvas/styles/<style_id>/preview')

--- a/routes/tools.py
+++ b/routes/tools.py
@@ -1,0 +1,380 @@
+"""
+Voice Agent Tool Bus — HTTP surface.
+
+Spec: docs/jambot/voice-agent-tool-bus.md
+
+    GET  /api/tools/catalog          capability-filtered catalog for a profile
+    POST /api/tools/invoke           run a server tool (sync result or job_id)
+    GET  /api/tools/jobs/<job_id>    poll one job
+    GET  /api/tools/events           SSE — job completions pushed to the browser
+
+Auth: every /api/* path is already covered by the app-wide `require_auth`
+before_request gate in app.py. We resolve user_id here only for provenance.
+
+── WHY SSE AND NOT A WEBSOCKET ────────────────────────────────────────────────
+The spec originally named this /ws/agent-events. SSE won because the channel is
+strictly one-way (server → browser), EventSource reconnects natively with
+Last-Event-ID semantics we get for free via ?since=, and it stays inside a
+blueprint instead of requiring surgery on server.py's @sock routes. server.py
+runs app.run(threaded=True), so a held SSE connection costs one thread — fine
+for a single-user tenant. nginx needs X-Accel-Buffering: no, which is set below
+and matches the existing SSE routes in routes/admin.py.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from flask import Blueprint, Response, jsonify, request
+
+from services import tool_jobs
+from services.tool_catalog import catalog
+
+logger = logging.getLogger(__name__)
+
+tools_bp = Blueprint("tools", __name__)
+
+
+def _profiles_dir() -> Path:
+    """Resolve the LIVE profiles dir the same way ProfileManager does.
+
+    Do not hardcode <repo>/profiles: when /app/runtime/profiles is mounted it
+    SHADOWS the bundled dir, and a tenant's real profile set lives only there.
+    Reading the bundled copy would grant tools based on a profile the running
+    app never loads.
+    """
+    try:
+        from profiles.manager import ProfileManager
+        return Path(ProfileManager.get_instance().profiles_dir)
+    except Exception:
+        runtime = Path("/app/runtime/profiles")
+        if runtime.is_dir():
+            return runtime
+        return Path(__file__).parent.parent / "profiles"
+
+
+
+# SSE tuning. The heartbeat is not decoration: without periodic bytes, nginx and
+# intermediate proxies close an idle stream and the browser silently stops
+# receiving job completions — a promise the agent made and can no longer keep.
+SSE_POLL_SECS = 1.0
+SSE_HEARTBEAT_SECS = 20.0
+SSE_MAX_LIFETIME_SECS = 3600.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _tenant() -> Optional[str]:
+    return (
+        os.getenv("JAMBOT_TENANT")
+        or os.getenv("TENANT_NAME")
+        or os.getenv("CLIENT_NAME")
+        or None
+    )
+
+
+def _user_id() -> Optional[str]:
+    try:
+        from services.auth import get_token_from_request, verify_clerk_token
+        token = get_token_from_request()
+        return verify_clerk_token(token) if token else None
+    except Exception:
+        return None
+
+
+def _profile_tool_grants(profile_id: Optional[str]) -> Tuple[Set[str], Set[str]]:
+    """(capabilities, allow_dangerous) for a profile.
+
+    Read from the profile JSON directly rather than through ProfileManager: the
+    Profile dataclass has no `tools` field, so round-tripping through
+    from_dict/to_dict would silently DROP these grants on the next profile save.
+    Losing a grant fails closed (annoying), but a save that quietly rewrites a
+    security-relevant block is the worse failure.
+
+    Profile contract:
+        "tools": {
+          "capabilities":    ["canvas", "music"],
+          "allow_dangerous": ["code_task"]
+        }
+
+    Absent block → fall back to features.tools. `true` grants the safe default
+    set; anything dangerous still needs an explicit opt-in and is never implied.
+    """
+    if not profile_id:
+        return set(), set()
+
+    path = _profiles_dir() / f"{profile_id}.json"
+    if not path.exists():
+        logger.warning("tools: unknown profile %r — no tools granted", profile_id)
+        return set(), set()
+
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception as exc:
+        # Unreadable config is an ALERT, and it must fail CLOSED.
+        logger.error("tools: profile %s unreadable (%s) — no tools granted", profile_id, exc)
+        return set(), set()
+
+    block = data.get("tools")
+    if isinstance(block, dict):
+        return (
+            set(block.get("capabilities") or ()),
+            set(block.get("allow_dangerous") or ()),
+        )
+
+    if (data.get("features") or {}).get("tools"):
+        return {"canvas", "music", "audio_fx", "session", "face"}, set()
+
+    return set(), set()
+
+
+def _log_invocation(tool: str, params: Dict[str, Any], *, profile: Optional[str],
+                    user_id: Optional[str], outcome: str) -> None:
+    """Audit line. The surface must be reviewable after the fact, not only gated
+    before it (voice-agent-tool-bus.md §4)."""
+    logger.info(
+        "tool-invoke tool=%s outcome=%s profile=%s user=%s params=%s",
+        tool, outcome, profile, user_id, json.dumps(params, ensure_ascii=False)[:500],
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /api/tools/catalog
+# ---------------------------------------------------------------------------
+
+@tools_bp.route("/api/tools/catalog", methods=["GET"])
+def get_catalog():
+    """Catalog filtered to what this profile may use.
+
+    The realtime_tools[] in the response is what the adapter hands the model in
+    session.update. A tool absent from it is one the model never learns exists.
+    """
+    profile_id = request.args.get("profile")
+    caps, dangerous = _profile_tool_grants(profile_id)
+    payload = catalog.to_client_json(caps=caps, allow_dangerous=dangerous)
+    payload["profile"] = profile_id
+    payload["granted_capabilities"] = sorted(caps)
+    payload["granted_dangerous"] = sorted(dangerous)
+    return jsonify(payload)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/tools/invoke
+# ---------------------------------------------------------------------------
+
+@tools_bp.route("/api/tools/invoke", methods=["POST"])
+def invoke():
+    """Execute a server-side tool.
+
+    server_sync  → {"status": "ok", "result": {...}}
+    server_async → {"status": "dispatched", "job_id": "...", "message": "..."}
+
+    The dispatched response is what gets handed back to the model as the function
+    result, so `message` is written to be spoken.
+    """
+    body = request.get_json(silent=True) or {}
+    tool_name = body.get("tool")
+    params = body.get("params") or {}
+    profile_id = body.get("profile")
+    session_id = body.get("session_id")
+
+    tool = catalog.get(tool_name) if tool_name else None
+    if not tool:
+        _log_invocation(str(tool_name), params, profile=profile_id,
+                        user_id=None, outcome="unknown_tool")
+        return jsonify({"status": "error", "error": f"Unknown tool: {tool_name}"}), 404
+
+    user_id = _user_id()
+    caps, dangerous = _profile_tool_grants(profile_id)
+
+    # Gate. Re-checked server-side even though the browser was only ever GIVEN
+    # allowed tools — a client-side filter is a UX affordance, not a control.
+    if tool.capability not in caps:
+        _log_invocation(tool.name, params, profile=profile_id,
+                        user_id=user_id, outcome="denied_capability")
+        return jsonify({
+            "status": "error",
+            "error": f"Tool '{tool.name}' requires capability '{tool.capability}', "
+                     f"which this profile does not have.",
+        }), 403
+
+    if tool.dangerous and tool.name not in dangerous:
+        _log_invocation(tool.name, params, profile=profile_id,
+                        user_id=user_id, outcome="denied_dangerous")
+        return jsonify({
+            "status": "error",
+            "error": f"Tool '{tool.name}' is restricted and this profile has not opted in.",
+        }), 403
+
+    if tool.is_client:
+        # Client tools never come here — the browser routes them through the
+        # EventBridge. Reaching this branch means tool-bridge.js mis-routed.
+        _log_invocation(tool.name, params, profile=profile_id,
+                        user_id=user_id, outcome="wrong_route")
+        return jsonify({
+            "status": "error",
+            "error": f"'{tool.name}' is a client-side tool and cannot be invoked over HTTP.",
+        }), 400
+
+    # ── async: spool a job, return immediately ────────────────────────────
+    if tool.is_async:
+        job = tool_jobs.create(
+            tool.name,
+            params,
+            tenant=_tenant(),
+            user_id=user_id,
+            profile=profile_id,
+            session_id=session_id,
+        )
+        _log_invocation(tool.name, params, profile=profile_id,
+                        user_id=user_id, outcome=f"dispatched:{job['id']}")
+        return jsonify({
+            "status": "dispatched",
+            "job_id": job["id"],
+            # Written to be SPOKEN — this is the function result the model sees.
+            "message": "Started. This runs in the background; you'll be told when "
+                       "it finishes. Acknowledge briefly and continue the conversation.",
+        })
+
+    # ── sync ──────────────────────────────────────────────────────────────
+    handler = SYNC_HANDLERS.get(tool.handler or "")
+    if not handler:
+        _log_invocation(tool.name, params, profile=profile_id,
+                        user_id=user_id, outcome="no_handler")
+        return jsonify({
+            "status": "error",
+            "error": f"No handler registered for '{tool.name}'.",
+        }), 501
+
+    try:
+        result = handler(params)
+    except Exception as exc:
+        logger.exception("tool %s handler failed", tool.name)
+        _log_invocation(tool.name, params, profile=profile_id,
+                        user_id=user_id, outcome="handler_error")
+        return jsonify({"status": "error", "error": str(exc)}), 500
+
+    _log_invocation(tool.name, params, profile=profile_id, user_id=user_id, outcome="ok")
+    return jsonify({"status": "ok", "result": result})
+
+
+# Sync server tools register here: handler id (from tools.yaml) -> callable.
+SYNC_HANDLERS: Dict[str, Any] = {}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/tools/jobs/<job_id>
+# ---------------------------------------------------------------------------
+
+@tools_bp.route("/api/tools/jobs/<job_id>", methods=["GET"])
+def get_job(job_id: str):
+    job = tool_jobs.get(job_id)
+    if not job:
+        return jsonify({"error": "not found"}), 404
+    return jsonify(job)
+
+
+@tools_bp.route("/api/tools/jobs", methods=["GET"])
+def list_jobs():
+    return jsonify({
+        "jobs": tool_jobs.list_jobs(
+            status=request.args.get("status"),
+            session_id=request.args.get("session_id"),
+        )
+    })
+
+
+# ---------------------------------------------------------------------------
+# GET /api/tools/events  — SSE push
+# ---------------------------------------------------------------------------
+
+@tools_bp.route("/api/tools/events", methods=["GET"])
+def events():
+    """Stream job completions to the browser.
+
+    The browser turns a `job.done` event into
+    bridge.emit(AgentActions.FORCE_MESSAGE, ...) — which every adapter already
+    implements — so the live voice agent speaks the conclusion.
+
+    ?session_id= scopes the stream to one conversation.
+    ?since=<epoch> replays anything that completed while the tab was reconnecting,
+    which is what stops a result from being lost in the gap.
+    """
+    session_id = request.args.get("session_id")
+    try:
+        since = float(request.args.get("since") or 0.0)
+    except ValueError:
+        since = 0.0
+
+    def generate():
+        seen: Set[str] = set()
+        watermark = since or (time.time() - 300.0)  # 5-min replay window on a cold open
+        started = time.time()
+        last_beat = 0.0
+
+        yield f"data: {json.dumps({'type': 'connected', 'at': time.time()})}\n\n"
+
+        while True:
+            now = time.time()
+            if now - started > SSE_MAX_LIFETIME_SECS:
+                # Bounded lifetime; EventSource reconnects on its own and the
+                # ?since= watermark makes the handover lossless.
+                yield f"data: {json.dumps({'type': 'reconnect'})}\n\n"
+                return
+
+            try:
+                jobs = tool_jobs.list_jobs(session_id=session_id, since=watermark)
+            except Exception as exc:
+                logger.error("tools/events: job scan failed: %s", exc)
+                jobs = []
+
+            for job in sorted(jobs, key=lambda j: j.get("updated_at", 0)):
+                if job.get("status") not in tool_jobs.TERMINAL:
+                    continue
+                if job["id"] in seen:
+                    continue
+                seen.add(job["id"])
+                watermark = max(watermark, job.get("updated_at", now))
+
+                ok = job.get("status") == tool_jobs.DONE
+                summary = (
+                    (job.get("result") or {}).get("summary")
+                    if ok else job.get("error")
+                ) or "Finished with no summary."
+
+                payload = {
+                    "type": "job.done" if ok else "job.failed",
+                    "job_id": job["id"],
+                    "tool": job.get("tool"),
+                    "ok": ok,
+                    "summary": summary,
+                    "artifacts": (job.get("result") or {}).get("artifacts", []),
+                    "at": job.get("updated_at"),
+                }
+                yield f"data: {json.dumps(payload)}\n\n"
+                last_beat = now
+
+            if now - last_beat > SSE_HEARTBEAT_SECS:
+                # Comment frame — keeps proxies from reaping an idle stream.
+                yield ": keepalive\n\n"
+                last_beat = now
+
+            time.sleep(SSE_POLL_SECS)
+
+    return Response(
+        generate(),
+        mimetype="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )

--- a/server.py
+++ b/server.py
@@ -221,6 +221,11 @@ app.register_blueprint(story_bp)
 from routes.airadio_bridge import airadio_bp
 app.register_blueprint(airadio_bp)
 
+# Voice Agent Tool Bus — /api/tools/* (catalog, invoke, jobs, SSE events).
+# Spec: docs/jambot/voice-agent-tool-bus.md
+from routes.tools import tools_bp
+app.register_blueprint(tools_bp)
+
 try:
     from routes.song_tagger import song_tagger_bp
     app.register_blueprint(song_tagger_bp)

--- a/services/canvas_styles.py
+++ b/services/canvas_styles.py
@@ -156,6 +156,18 @@ def get_active_style_id() -> str | None:
     return get_active().get('style_id')
 
 
+_WEBFONT_IMPORT_RE = re.compile(
+    r"@import\s+url\(\s*['\"]?(https?://(?:fonts\.googleapis\.com|fonts\.bunny\.net)"
+    r"[^'\")]+)['\"]?\s*\)\s*;",
+    re.I,
+)
+_WEBFONT_LINK_RE = re.compile(
+    r'(<link\b[^>]*\bhref=["\'])(https?://(?:fonts\.googleapis\.com|fonts\.bunny\.net)'
+    r'[^"\']+)(["\'][^>]*>)',
+    re.I,
+)
+
+
 def apply_tokens_to_template(template_html: str, tokens: dict) -> str:
     """Re-bind token values into the template's CSS custom properties.
 
@@ -163,16 +175,40 @@ def apply_tokens_to_template(template_html: str, tokens: dict) -> str:
     clone edits tokens, the stored template still carries the source style's
     literal values — rewrite every `--<token>:` declaration so token edits
     actually change the rendered page. Safe on originals (no-op rewrite).
+
+    `font-import` is the exception and needs its own handling: it is not a CSS
+    custom property, it is the stylesheet that LOADS the faces. The templates
+    pull fonts with `@import url('https://fonts.googleapis.com/…')` at the top
+    of their <style> block, so rewriting `--font-display` alone set a family
+    the browser had never downloaded — the page silently fell through the stack
+    to Impact while reporting the correct token. Anyone cloning a preset and
+    changing its typography hit this, not just generated brand styles.
     """
     out = template_html
     for key, val in tokens.items():
         if not isinstance(val, str) or not val.strip():
             continue
+        if key == 'font-import':
+            continue  # handled below — it is a resource URL, not a declaration
         out = re.sub(
             r'(--' + re.escape(key) + r'\s*:\s*)[^;}]+',
             lambda m: m.group(1) + val.strip(),
             out,
         )
+
+    font_import = (tokens.get('font-import') or '').strip()
+    if font_import.startswith(('http://', 'https://')):
+        url = font_import.replace('&', '&amp;') if '&amp;' not in font_import else font_import
+        new_out, n = _WEBFONT_IMPORT_RE.subn(
+            lambda m: f"@import url('{font_import}');", out)
+        out = new_out
+        out = _WEBFONT_LINK_RE.sub(lambda m: m.group(1) + url + m.group(3), out)
+        if not n and '@import' not in out[:2000] and '<style' in out:
+            # Template loads no webfont of its own — inject the import at the top
+            # of its first <style> block so a custom family still resolves.
+            out = re.sub(r'(<style[^>]*>)',
+                         lambda m: m.group(1) + f"\n@import url('{font_import}');",
+                         out, count=1)
     return out
 
 

--- a/services/tool_catalog.py
+++ b/services/tool_catalog.py
@@ -1,0 +1,381 @@
+"""
+Voice Agent Tool Catalog — loads config/tools.yaml and generates every
+projection of the tool surface.
+
+Spec: docs/jambot/voice-agent-tool-bus.md
+
+    from services.tool_catalog import catalog
+
+    catalog.realtime_tools(caps={'canvas', 'music'})   # -> tools[] for session.update
+    catalog.marker_specs()                             # -> [MARKER] regex specs
+    catalog.prompt_docs(caps={'canvas'})               # -> system-prompt block
+    catalog.get('open_canvas_page')                    # -> ToolDef
+
+Why one catalog: before this, the tool surface was defined implicitly by regexes
+duplicated across src/core/VoiceSession.js and src/app.js. There was no schema, no
+return value, and no way to hand a realtime model (Grok Voice, OpenAI Realtime) a
+tool list. See future-dev-plans/17-MULTI-AGENT-FRAMEWORK.md §5.
+
+Capability gating: realtime_tools() and prompt_docs() FILTER by capability. A tool
+the profile is not allowed to use is never described to the model at all — it does
+not learn the tool exists. That is deliberate; refusal-by-omission beats
+refusal-by-rejection. `dangerous: true` tools need an explicit extra opt-in on top.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+try:
+    import yaml
+    _YAML_AVAILABLE = True
+except ImportError:  # pragma: no cover - yaml is a hard dep in prod
+    _YAML_AVAILABLE = False
+
+_CATALOG_YAML = Path(__file__).parent.parent / "config" / "tools.yaml"
+
+VALID_EXECUTION = {"client", "server_sync", "server_async"}
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class MarkerSpec:
+    """The legacy [MARKER] form of a tool, for text-streaming agents."""
+    tool_name: str
+    form: str                      # human-readable, e.g. "[CANVAS:<page>]"
+    pattern: str                   # regex with one capture group per entry in `groups`
+    groups: List[str]              # capture-group index -> param name
+    dedupe_key: str                # matches the `seen` keys in VoiceSession.js
+    event: Optional[str]           # eventBus event emitted client-side
+
+    def compiled(self) -> re.Pattern:
+        return re.compile(self.pattern, re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class ToolDef:
+    name: str
+    description: str
+    execution: str                 # client | server_sync | server_async
+    capability: str
+    params: Dict[str, Any]         # JSON Schema object
+    dangerous: bool = False
+    handler: Optional[str] = None  # server_* only: handler id in routes/tools.py
+    event: Optional[str] = None    # client only: EventBridge event
+    marker: Optional[MarkerSpec] = field(default=None)
+
+    @property
+    def is_async(self) -> bool:
+        return self.execution == "server_async"
+
+    @property
+    def is_client(self) -> bool:
+        return self.execution == "client"
+
+    def to_realtime(self) -> Dict[str, Any]:
+        """OpenAI-Realtime-shaped function definition (Grok Voice uses this too)."""
+        return {
+            "type": "function",
+            "name": self.name,
+            "description": " ".join(self.description.split()),
+            "parameters": self.params or {"type": "object", "properties": {}},
+        }
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+class ToolCatalog:
+    """Singleton view over config/tools.yaml."""
+
+    _instance: Optional["ToolCatalog"] = None
+    _lock = threading.Lock()
+
+    def __new__(cls, *a, **kw):
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+                    cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self, path: Optional[Path] = None):
+        if getattr(self, "_initialized", False):
+            return
+        self._path = path or _CATALOG_YAML
+        self._tools: Dict[str, ToolDef] = {}
+        self._capabilities: Dict[str, str] = {}
+        self._version: int = 0
+        self._initialized = True
+        self.reload()
+
+    # -- loading ------------------------------------------------------------
+
+    def reload(self) -> None:
+        """(Re)read the YAML. Safe to call at runtime; never raises on bad input."""
+        if not _YAML_AVAILABLE:
+            logger.error("tool_catalog: PyYAML unavailable — catalog is EMPTY")
+            return
+        if not self._path.exists():
+            logger.error("tool_catalog: %s not found — catalog is EMPTY", self._path)
+            return
+
+        try:
+            with open(self._path, "r", encoding="utf-8") as fh:
+                raw = yaml.safe_load(fh) or {}
+        except Exception as exc:
+            logger.error("tool_catalog: failed to parse %s: %s", self._path, exc)
+            return
+
+        self._version = int(raw.get("version", 0))
+        self._capabilities = dict(raw.get("capabilities") or {})
+
+        tools: Dict[str, ToolDef] = {}
+        for entry in raw.get("tools") or []:
+            tool = self._parse_tool(entry)
+            if tool is None:
+                continue
+            if tool.name in tools:
+                logger.error("tool_catalog: duplicate tool name %r — keeping first", tool.name)
+                continue
+            tools[tool.name] = tool
+
+        self._tools = tools
+        logger.info(
+            "tool_catalog: loaded %d tools (%d with markers) from %s",
+            len(tools), sum(1 for t in tools.values() if t.marker), self._path.name,
+        )
+
+    def _parse_tool(self, entry: Dict[str, Any]) -> Optional[ToolDef]:
+        """Validate one catalog entry. Returns None (and logs) on anything malformed.
+
+        A malformed entry must never take the whole catalog down — a single bad
+        tool should not silently disarm canvas + music for every tenant.
+        """
+        name = (entry or {}).get("name")
+        if not name:
+            logger.error("tool_catalog: entry with no name — skipped: %r", entry)
+            return None
+
+        execution = entry.get("execution")
+        if execution not in VALID_EXECUTION:
+            logger.error(
+                "tool_catalog: %s has invalid execution %r (expected one of %s) — skipped",
+                name, execution, sorted(VALID_EXECUTION),
+            )
+            return None
+
+        capability = entry.get("capability")
+        if not capability:
+            logger.error("tool_catalog: %s has no capability — skipped", name)
+            return None
+        if capability not in self._capabilities:
+            logger.warning(
+                "tool_catalog: %s uses capability %r not declared in capabilities: — "
+                "it will be gated out of every profile", name, capability,
+            )
+
+        if execution == "client" and not entry.get("event"):
+            logger.error("tool_catalog: client tool %s has no event — skipped", name)
+            return None
+        if execution.startswith("server") and not entry.get("handler"):
+            logger.error("tool_catalog: server tool %s has no handler — skipped", name)
+            return None
+
+        marker = self._parse_marker(name, entry.get("marker"), entry.get("event"))
+
+        return ToolDef(
+            name=name,
+            description=entry.get("description", ""),
+            execution=execution,
+            capability=capability,
+            params=entry.get("params") or {"type": "object", "properties": {}},
+            dangerous=bool(entry.get("dangerous", False)),
+            handler=entry.get("handler"),
+            event=entry.get("event"),
+            marker=marker,
+        )
+
+    def _parse_marker(
+        self, tool_name: str, raw: Any, event: Optional[str]
+    ) -> Optional[MarkerSpec]:
+        if not raw:            # `marker: null` or absent = tool has no legacy form
+            return None
+        pattern = raw.get("pattern")
+        if not pattern:
+            logger.error("tool_catalog: %s marker has no pattern — marker dropped", tool_name)
+            return None
+        try:
+            compiled = re.compile(pattern, re.IGNORECASE)
+        except re.error as exc:
+            logger.error("tool_catalog: %s marker regex invalid (%s) — marker dropped",
+                         tool_name, exc)
+            return None
+
+        groups = list(raw.get("groups") or [])
+        if compiled.groups != len(groups):
+            # This is the parity guard: a mismatch means the generated parser would
+            # bind params to the wrong capture group — worse than no marker at all.
+            logger.error(
+                "tool_catalog: %s marker declares %d groups but regex has %d — marker dropped",
+                tool_name, len(groups), compiled.groups,
+            )
+            return None
+
+        return MarkerSpec(
+            tool_name=tool_name,
+            form=raw.get("form", ""),
+            pattern=pattern,
+            groups=groups,
+            dedupe_key=raw.get("dedupe_key") or tool_name.upper(),
+            event=event,
+        )
+
+    # -- accessors ----------------------------------------------------------
+
+    @property
+    def version(self) -> int:
+        return self._version
+
+    def get(self, name: str) -> Optional[ToolDef]:
+        return self._tools.get(name)
+
+    def all_tools(self) -> List[ToolDef]:
+        return list(self._tools.values())
+
+    def capabilities(self) -> Dict[str, str]:
+        return dict(self._capabilities)
+
+    def allowed(
+        self,
+        caps: Optional[Iterable[str]] = None,
+        allow_dangerous: Optional[Iterable[str]] = None,
+    ) -> List[ToolDef]:
+        """Tools this profile may use.
+
+        caps            — capability allowlist. None means NONE (fail closed).
+        allow_dangerous — explicit per-tool opt-in for `dangerous: true` tools.
+                          Holding the capability is not sufficient.
+        """
+        cap_set: Set[str] = set(caps or ())
+        danger_set: Set[str] = set(allow_dangerous or ())
+        out = []
+        for tool in self._tools.values():
+            if tool.capability not in cap_set:
+                continue
+            if tool.dangerous and tool.name not in danger_set:
+                continue
+            out.append(tool)
+        return out
+
+    # -- projection 1: realtime function calling ----------------------------
+
+    def realtime_tools(
+        self,
+        caps: Optional[Iterable[str]] = None,
+        allow_dangerous: Optional[Iterable[str]] = None,
+    ) -> List[Dict[str, Any]]:
+        """tools[] array for a realtime session.update (Grok / OpenAI Realtime)."""
+        return [t.to_realtime() for t in self.allowed(caps, allow_dangerous)]
+
+    # -- projection 2: legacy marker protocol -------------------------------
+
+    def marker_specs(self) -> List[MarkerSpec]:
+        """Every tool's [MARKER] form.
+
+        NOT capability-filtered: text-streaming agents are gated by what their
+        system prompt tells them exists, and the parser must still recognise (and
+        strip) a marker it wasn't expecting rather than speak it aloud.
+        """
+        return [t.marker for t in self._tools.values() if t.marker]
+
+    def strip_patterns(self) -> List[str]:
+        """Regexes to remove marker text before display/TTS."""
+        return [m.pattern for m in self.marker_specs()]
+
+    # -- projection 3: prompt documentation ---------------------------------
+
+    def prompt_docs(
+        self,
+        caps: Optional[Iterable[str]] = None,
+        allow_dangerous: Optional[Iterable[str]] = None,
+        style: str = "marker",
+    ) -> str:
+        """The 'here are your tools' block for brains without native function calling.
+
+        style='marker'   → documents the [MARKER] form (text-streaming agents)
+        style='function' → documents tools by name (realtime agents that still
+                           benefit from prose guidance alongside tools[])
+        """
+        tools = self.allowed(caps, allow_dangerous)
+        if not tools:
+            return ""
+
+        lines = ["## Available tools", ""]
+        for tool in sorted(tools, key=lambda t: (t.capability, t.name)):
+            desc = " ".join(tool.description.split())
+            if style == "marker":
+                if not tool.marker:
+                    continue
+                lines.append(f"- `{tool.marker.form}` — {desc}")
+            else:
+                required = tool.params.get("required") or []
+                props = ", ".join(tool.params.get("properties", {}).keys()) or "no arguments"
+                req = f" (required: {', '.join(required)})" if required else ""
+                lines.append(f"- `{tool.name}({props})`{req} — {desc}")
+        if len(lines) == 2:
+            return ""
+        return "\n".join(lines)
+
+    # -- serialisation for the browser --------------------------------------
+
+    def to_client_json(
+        self,
+        caps: Optional[Iterable[str]] = None,
+        allow_dangerous: Optional[Iterable[str]] = None,
+    ) -> Dict[str, Any]:
+        """What GET /api/tools/catalog returns.
+
+        The browser needs the routing table (which tool is client-side and which
+        EventBridge event it maps to) plus the realtime tools[] to hand the model.
+        """
+        tools = self.allowed(caps, allow_dangerous)
+        return {
+            "version": self._version,
+            "capabilities": self._capabilities,
+            "realtime_tools": [t.to_realtime() for t in tools],
+            "routing": {
+                t.name: {
+                    "execution": t.execution,
+                    "event": t.event,
+                    "capability": t.capability,
+                    "dangerous": t.dangerous,
+                }
+                for t in tools
+            },
+            "markers": [
+                {
+                    "tool": m.tool_name,
+                    "pattern": m.pattern,
+                    "groups": m.groups,
+                    "dedupe_key": m.dedupe_key,
+                    "event": m.event,
+                }
+                for m in self.marker_specs()
+            ],
+        }
+
+
+# Singleton — import this
+catalog = ToolCatalog()

--- a/services/tool_jobs.py
+++ b/services/tool_jobs.py
@@ -1,0 +1,241 @@
+"""
+Durable job store for async voice-agent tools.
+
+Spec: docs/jambot/voice-agent-tool-bus.md §3
+
+A `server_async` tool (generate_song, code_task) must NOT block the voice
+conversation. It writes a job here, returns {job_id, status: "dispatched"}
+immediately so the agent says "on it" and keeps talking, and the real answer
+arrives later over /ws/agent-events.
+
+── WHY FILES AND NOT A QUEUE LIBRARY ──────────────────────────────────────────
+The OVU container has NO coding agent in it — `which claude` returns nothing;
+only python3 exists. So the executor CANNOT live in this process. It is a
+host-side worker (scripts/tool-job-worker.sh) that shares this directory via a
+bind mount. A plain-file spool is the interface between two processes that share
+a filesystem and nothing else — and it is the same shape as every other durable
+queue on this box (mesh inbox, SUDO-QUEUE, build triggers).
+
+It is also the security answer: the container never gains code execution. The
+worker runs on the host with a pinned model and a scoped working directory.
+
+── DURABILITY ─────────────────────────────────────────────────────────────────
+Jobs default to living beside the durable DB (services/paths.DB_PATH), which is
+documented there as bind-mounted precisely because the container's writable layer
+is WIPED on recreate. A job that vanishes on a container recreate would leave a
+voice agent that promised a result and can never deliver one — the exact
+silent-loss shape called out in memory `ack-must-come-from-receiver`.
+
+Override with TOOL_JOBS_DIR if you want them somewhere else.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from services.paths import DB_PATH
+
+logger = logging.getLogger(__name__)
+
+# Beside the durable DB by default — same bind-mount, same recreate survival.
+JOBS_DIR = Path(os.getenv("TOOL_JOBS_DIR", str(DB_PATH.parent / "tool-jobs")))
+
+# Job lifecycle
+QUEUED = "queued"      # written, waiting for the host worker
+RUNNING = "running"    # worker claimed it
+DONE = "done"          # finished, result present
+FAILED = "failed"      # finished, error present
+
+TERMINAL = {DONE, FAILED}
+
+# A job the worker claimed but never finished (worker killed, box rebooted) must
+# not hang the agent's promise forever.
+STALE_RUNNING_SECS = int(os.getenv("TOOL_JOB_STALE_SECS", "1800"))  # 30 min
+
+
+def _ensure_dir() -> None:
+    JOBS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _path(job_id: str) -> Path:
+    # job ids are generated here (uuid4 hex); reject anything else so a crafted
+    # id can never escape the jobs dir.
+    if not job_id or not all(c in "0123456789abcdef-" for c in job_id):
+        raise ValueError(f"invalid job id: {job_id!r}")
+    return JOBS_DIR / f"{job_id}.json"
+
+
+def _write_atomic(path: Path, data: Dict[str, Any]) -> None:
+    """Write via temp + os.replace so a reader never sees a half-written job.
+
+    The worker polls this directory; a torn read would look like a malformed job
+    and get skipped or, worse, re-run.
+    """
+    _ensure_dir()
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".tmp-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, ensure_ascii=False)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def create(
+    tool: str,
+    params: Dict[str, Any],
+    *,
+    tenant: Optional[str] = None,
+    user_id: Optional[str] = None,
+    profile: Optional[str] = None,
+    session_id: Optional[str] = None,
+    cwd: Optional[str] = None,
+    model: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Spool a new job. Returns the job dict (caller hands job_id to the agent)."""
+    job_id = uuid.uuid4().hex[:16]
+    now = time.time()
+    job = {
+        "id": job_id,
+        "tool": tool,
+        "params": params or {},
+        "status": QUEUED,
+        "created_at": now,
+        "updated_at": now,
+        # Provenance — every invocation must be auditable after the fact, not
+        # only gated before it (voice-agent-tool-bus.md §4).
+        "tenant": tenant,
+        "user_id": user_id,
+        "profile": profile,
+        "session_id": session_id,
+        # Execution scope for the host worker.
+        "cwd": cwd,
+        "model": model,
+        "result": None,
+        "error": None,
+    }
+    _write_atomic(_path(job_id), job)
+    logger.info(
+        "tool_jobs: queued %s tool=%s tenant=%s profile=%s", job_id, tool, tenant, profile
+    )
+    return job
+
+
+def get(job_id: str) -> Optional[Dict[str, Any]]:
+    try:
+        path = _path(job_id)
+    except ValueError:
+        return None
+    if not path.exists():
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception as exc:
+        logger.error("tool_jobs: unreadable job %s: %s", job_id, exc)
+        # An unreadable job is an ALERT, not a nothing — memory
+        # `monitors-that-report-unreadable-as-fine`.
+        return {"id": job_id, "status": FAILED, "error": f"job file unreadable: {exc}"}
+
+
+def update(job_id: str, **fields: Any) -> Optional[Dict[str, Any]]:
+    job = get(job_id)
+    if not job:
+        return None
+    job.update(fields)
+    job["updated_at"] = time.time()
+    _write_atomic(_path(job_id), job)
+    return job
+
+
+def finish(
+    job_id: str,
+    *,
+    summary: str,
+    detail: Optional[str] = None,
+    artifacts: Optional[List[str]] = None,
+    ok: bool = True,
+) -> Optional[Dict[str, Any]]:
+    """Mark a job terminal. `summary` is what the voice agent will SAY."""
+    return update(
+        job_id,
+        status=DONE if ok else FAILED,
+        result={
+            "summary": summary,
+            "detail": detail,
+            "artifacts": artifacts or [],
+        } if ok else None,
+        error=None if ok else summary,
+    )
+
+
+def list_jobs(
+    *,
+    status: Optional[str] = None,
+    tenant: Optional[str] = None,
+    session_id: Optional[str] = None,
+    since: float = 0.0,
+) -> List[Dict[str, Any]]:
+    """List jobs, newest first. Missing dir = empty list, not an error."""
+    _ensure_dir()
+    out: List[Dict[str, Any]] = []
+    for path in JOBS_DIR.glob("*.json"):
+        if path.name.startswith(".tmp-"):
+            continue
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                job = json.load(fh)
+        except Exception:
+            continue
+        if status and job.get("status") != status:
+            continue
+        if tenant and job.get("tenant") != tenant:
+            continue
+        if session_id and job.get("session_id") != session_id:
+            continue
+        if job.get("updated_at", 0) <= since:
+            continue
+        out.append(job)
+    out.sort(key=lambda j: j.get("updated_at", 0), reverse=True)
+    return out
+
+
+def reap_stale() -> List[str]:
+    """Fail jobs stuck in RUNNING past the stale window.
+
+    Without this, a worker killed mid-job leaves the agent holding a promise it
+    can never fulfil — and the user never finds out. Better a spoken failure than
+    silence.
+    """
+    reaped = []
+    cutoff = time.time() - STALE_RUNNING_SECS
+    for job in list_jobs(status=RUNNING):
+        if job.get("updated_at", 0) < cutoff:
+            finish(
+                job["id"],
+                summary=(
+                    f"The {job.get('tool')} job stalled and was cancelled after "
+                    f"{STALE_RUNNING_SECS // 60} minutes with no progress."
+                ),
+                ok=False,
+            )
+            reaped.append(job["id"])
+            logger.warning("tool_jobs: reaped stale job %s (tool=%s)", job["id"], job.get("tool"))
+    return reaped

--- a/services/tool_jobs.py
+++ b/services/tool_jobs.py
@@ -61,7 +61,27 @@ STALE_RUNNING_SECS = int(os.getenv("TOOL_JOB_STALE_SECS", "1800"))  # 30 min
 
 
 def _ensure_dir() -> None:
+    """Create the spool so BOTH sides of the bind mount can write it.
+
+    This directory is the interface between two processes with different uids:
+    this container runs as appuser (1001) and the host worker runs as mike
+    (1000). Whichever side creates it first owns it, and the default 0o775 then
+    locks the other one out — a 500 on every job create when the host got there
+    first, and a silently unprocessable spool when the container did.
+
+    Neither side can chown to the other without root, so the directory is made
+    world-writable, matching the convention the rest of the tenant's
+    openvoiceui/ tree already uses (canvas-pages, uploads) for exactly this
+    reason. The path itself is inside the tenant's own private volume.
+    """
     JOBS_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        if (JOBS_DIR.stat().st_mode & 0o777) != 0o777:
+            JOBS_DIR.chmod(0o777)
+    except OSError as exc:
+        # Not ours to chmod (created by the other uid) — log rather than fail;
+        # writes may still work if the modes already happen to allow it.
+        logger.warning("tool_jobs: could not widen %s permissions: %s", JOBS_DIR, exc)
 
 
 def _path(job_id: str) -> Path:
@@ -77,6 +97,13 @@ def _write_atomic(path: Path, data: Dict[str, Any]) -> None:
 
     The worker polls this directory; a torn read would look like a malformed job
     and get skipped or, worse, re-run.
+
+    The explicit chmod is load-bearing, not tidiness. `tempfile.mkstemp` creates
+    with mode 0o600 by design, so a job written by this container (appuser, 1001)
+    was UNREADABLE to the host worker (mike, 1000) even with the spool directory
+    world-writable — every job sat queued forever while the worker logged
+    "unreadable job" once a minute. A spool shared across two uids has to be
+    readable by both, at the file level as well as the directory level.
     """
     _ensure_dir()
     fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".tmp-", suffix=".json")
@@ -85,6 +112,7 @@ def _write_atomic(path: Path, data: Dict[str, Any]) -> None:
             json.dump(data, fh, indent=2, ensure_ascii=False)
             fh.flush()
             os.fsync(fh.fileno())
+        os.chmod(tmp, 0o666)  # see docstring — mkstemp's 0600 locks out the worker
         os.replace(tmp, path)
     except Exception:
         try:

--- a/src/adapters/xai-realtime.js
+++ b/src/adapters/xai-realtime.js
@@ -22,6 +22,7 @@
  */
 
 import { AgentEvents, AgentActions } from '../core/EventBridge.js';
+import { toolBridge } from '../shell/tool-bridge.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -138,6 +139,7 @@ export const XAIRealtimeAdapter = {
      * xAI handles STT + LLM + TTS internally — no separate STT provider needed.
      */
     capabilities: [
+        'tools',            // native function calling via the Voice Agent Tool Bus
         'canvas',
     ],
 
@@ -160,6 +162,7 @@ export const XAIRealtimeAdapter = {
     _destroyed:       false,
     _unsubscribers:   [],
     _sessionReady:    false,         // True after session.created received
+    _instructions:    '',            // Full instruction string incl. tool guidance
 
     // ─────────────────────────────────────────────────────────────────────────
     // INIT
@@ -186,6 +189,21 @@ export const XAIRealtimeAdapter = {
             }
         } catch (err) {
             console.warn('[xAI-Realtime] Config check failed:', err.message);
+        }
+
+        // Tool bus — loads the capability-filtered catalog for this profile and
+        // opens the job-completion stream. Must finish before _onSessionCreated
+        // fires, since session.update carries the tools[] array.
+        // Spec: docs/jambot/voice-agent-tool-bus.md
+        try {
+            await toolBridge.init(bridge, {
+                profileId: this._config.profile_id || this._config.id || 'xai-realtime',
+                sessionId: this._config.session_id || null,
+            });
+        } catch (err) {
+            // Never block voice on the tool bus. A Grok that can talk but not act
+            // beats a Grok that won't connect.
+            console.error('[xAI-Realtime] Tool bus init failed — continuing without tools:', err);
         }
 
         // Subscribe to UI → Agent actions
@@ -260,6 +278,10 @@ export const XAIRealtimeAdapter = {
 
         this._unsubscribers.forEach(unsub => unsub());
         this._unsubscribers = [];
+
+        // Closes the SSE job stream. Without this a profile switch leaks a
+        // connection that keeps announcing jobs into a dead bridge.
+        try { toolBridge.destroy(); } catch (_) {}
 
         if (this._audioContext) {
             try { await this._audioContext.close(); } catch (_) {}
@@ -409,6 +431,18 @@ export const XAIRealtimeAdapter = {
                 this._bridge.emit(AgentEvents.MOOD,          { mood: 'happy' });
                 break;
 
+            // ── Function calling (Voice Agent Tool Bus) ──────────────────────
+            // The OpenAI Realtime protocol streams arguments as deltas, then
+            // emits .done with the complete JSON string. We only act on .done —
+            // acting on partial JSON would fire tools on truncated arguments.
+            case 'response.function_call_arguments.done':
+                this._handleFunctionCall(msg);
+                break;
+
+            case 'response.function_call_arguments.delta':
+                // Ignored by design — see above.
+                break;
+
             case 'error': {
                 const errMsg = msg.error?.message || msg.message || 'Unknown xAI error';
                 const errCode = msg.error?.code   || msg.code    || '';
@@ -429,28 +463,57 @@ export const XAIRealtimeAdapter = {
         this._sessionReady = true;
 
         // Get system_prompt from profile config
-        const instructions = this._config.system_prompt
+        let instructions = this._config.system_prompt
             || 'You are Grok, a witty and helpful voice assistant created by xAI. Be conversational, clear, and concise.';
 
-        this._sendJSON({
-            type: 'session.update',
-            session: {
-                modalities:   ['audio', 'text'],
-                instructions,
-                voice:        'Celeste',
-                input_audio_format:  'pcm16',
-                output_audio_format: 'pcm16',
-                input_audio_transcription: {
-                    model: 'whisper-1',
-                },
-                turn_detection: {
-                    type:                 'server_vad',
-                    threshold:            0.5,
-                    prefix_padding_ms:    300,
-                    silence_duration_ms:  600,
-                },
+        // Tools the profile has granted. A tool absent from this array is one the
+        // model never learns exists — capability gating by omission
+        // (docs/jambot/voice-agent-tool-bus.md §4).
+        const tools = toolBridge.realtimeTools();
+
+        if (tools.length) {
+            // Realtime models need to be told HOW to behave around async tools,
+            // not just that they exist. Without this they tend to go silent and
+            // wait for a result that arrives minutes later on a different turn.
+            instructions +=
+                '\n\nYou have tools. Call them instead of describing what you would do. ' +
+                'Some tools return immediately with a job id instead of a result — when that ' +
+                'happens, say briefly that you have started it and CARRY ON with the ' +
+                'conversation. Do not wait or go quiet. You will be told the outcome when it ' +
+                'finishes, and you should relay it in one short sentence when it arrives.';
+        }
+
+        const session = {
+            modalities:   ['audio', 'text'],
+            instructions,
+            voice:        'Celeste',
+            input_audio_format:  'pcm16',
+            output_audio_format: 'pcm16',
+            input_audio_transcription: {
+                model: 'whisper-1',
             },
-        });
+            turn_detection: {
+                type:                 'server_vad',
+                threshold:            0.5,
+                prefix_padding_ms:    300,
+                silence_duration_ms:  600,
+            },
+        };
+
+        if (tools.length) {
+            session.tools       = tools;
+            session.tool_choice = 'auto';
+            console.log(`[xAI-Realtime] Offering ${tools.length} tool(s):`,
+                        tools.map(t => t.name).join(', '));
+        }
+
+        // Remember the FULL instruction string. _sendContextUpdate rebuilds
+        // instructions from scratch; without this it would silently drop the
+        // async-tool behaviour guidance above on the first context inject, and
+        // the model would start going quiet on dispatched jobs again.
+        this._instructions = instructions;
+
+        this._sendJSON({ type: 'session.update', session });
 
         this._bridge.emit(AgentEvents.CONNECTED);
         this._bridge.emit(AgentEvents.STATE_CHANGED, { state: 'listening' });
@@ -471,13 +534,69 @@ export const XAIRealtimeAdapter = {
     },
 
     /**
+     * Execute a tool the model asked for and hand the result back.
+     *
+     * Protocol (OpenAI Realtime, which xAI implements):
+     *   in  ← response.function_call_arguments.done { call_id, name, arguments }
+     *   out → conversation.item.create { type: 'function_call_output', call_id, output }
+     *   out → response.create            (so the model speaks about the result)
+     *
+     * `output` MUST be a string — the API rejects a bare object.
+     *
+     * Every path here returns something. A tool call left unanswered wedges the
+     * conversation: the model waits on a call_id that never resolves and the
+     * user hears silence. Failures are reported as results, not swallowed.
+     */
+    async _handleFunctionCall(msg) {
+        const callId = msg.call_id || msg.item_id;
+        const name   = msg.name;
+
+        if (!callId || !name) {
+            console.warn('[xAI-Realtime] Malformed function call — ignoring:', msg);
+            return;
+        }
+
+        console.log(`[xAI-Realtime] → tool call: ${name}`, msg.arguments);
+
+        let outcome;
+        try {
+            outcome = await toolBridge.invoke(name, msg.arguments);
+        } catch (err) {
+            console.error(`[xAI-Realtime] Tool "${name}" threw:`, err);
+            outcome = { ok: false, error: err.message || 'Tool execution failed.' };
+        }
+
+        const output = outcome.ok
+            ? JSON.stringify({ ok: true, result: outcome.result, job_id: outcome.job_id })
+            : JSON.stringify({ ok: false, error: outcome.error });
+
+        this._sendJSON({
+            type: 'conversation.item.create',
+            item: {
+                type:    'function_call_output',
+                call_id: callId,
+                output,
+            },
+        });
+
+        this._sendJSON({ type: 'response.create' });
+
+        this._bridge.emit(AgentEvents.TOOL_CALLED, {
+            name,
+            params: {},
+            result: outcome.ok ? outcome.result : outcome.error,
+        });
+    },
+
+    /**
      * Silently update the session instructions with new context.
      * Does NOT trigger a response — purely injects background info.
      */
     _sendContextUpdate(text) {
         if (!text) return;
-        const instructions = this._config.system_prompt
-            ? `${this._config.system_prompt}\n\n[Context update]: ${text}`
+        const base = this._instructions || this._config.system_prompt || '';
+        const instructions = base
+            ? `${base}\n\n[Context update]: ${text}`
             : text;
 
         this._sendJSON({

--- a/src/shell/tool-bridge.js
+++ b/src/shell/tool-bridge.js
@@ -1,0 +1,383 @@
+/**
+ * tool-bridge.js — Voice Agent Tool Bus, client half.
+ *
+ * Spec: docs/jambot/voice-agent-tool-bus.md
+ * Framework: future-dev-plans/17-MULTI-AGENT-FRAMEWORK.md
+ *
+ * Three jobs:
+ *
+ *   1. Fetch the capability-filtered tool catalog so an adapter can hand
+ *      `realtimeTools()` to a realtime model in session.update.
+ *   2. Execute a tool call. Client-side tools become AgentEvents on the
+ *      EventBridge (the same events ClawdBotAdapter emits, so every existing
+ *      shell bridge handles them unchanged). Server-side tools go to
+ *      POST /api/tools/invoke.
+ *   3. Listen on the /api/tools/events SSE stream and turn a finished async job
+ *      into AgentActions.FORCE_MESSAGE — which every adapter already implements
+ *      — so the live voice agent SPEAKS the conclusion.
+ *
+ * Job 3 is the whole point. A voice agent that dispatches a four-minute build
+ * must not block; it says "on it", keeps talking, and gets interrupted with the
+ * answer when it lands.
+ *
+ * Usage (from an adapter's init):
+ *   import { toolBridge } from '../shell/tool-bridge.js';
+ *   await toolBridge.init(bridge, { profileId: 'xai-realtime', sessionId });
+ *   const tools = toolBridge.realtimeTools();
+ *   ...
+ *   const result = await toolBridge.invoke(name, args);
+ */
+
+import { AgentEvents, AgentActions } from '../core/EventBridge.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Client-side tool handlers
+// ─────────────────────────────────────────────────────────────────────────────
+// Each returns the object handed back to the model as the function result.
+// Keep the returns terse and factual — the model reads them out loud.
+//
+// These deliberately emit the SAME AgentEvents that ClawdBotAdapter emits from
+// its [MARKER] parser, so canvas-bridge / music-bridge / sounds-bridge need no
+// changes and both agent classes drive identical UI behaviour.
+
+const CLIENT_HANDLERS = {
+    open_canvas_page: (bridge, p) => {
+        const page = (p.page || '').trim();
+        if (!page) return { ok: false, error: 'No page name given.' };
+        bridge.emit(AgentEvents.CANVAS_CMD, { action: 'present', url: page });
+        return { ok: true, result: `Displaying "${page}".` };
+    },
+
+    open_canvas_menu: (bridge) => {
+        bridge.emit(AgentEvents.CANVAS_CMD, { action: 'menu' });
+        return { ok: true, result: 'Page picker opened.' };
+    },
+
+    screenshot_canvas: (bridge) => {
+        bridge.emit(AgentEvents.CANVAS_CMD, { action: 'screenshot' });
+        return { ok: true, result: 'Screenshot requested.' };
+    },
+
+    play_music: (bridge, p) => {
+        const track = (p.track || '').trim() || null;
+        bridge.emit(AgentEvents.MUSIC_PLAY, { action: 'play', track });
+        return { ok: true, result: track ? `Playing "${track}".` : 'Music playing.' };
+    },
+
+    stop_music: (bridge) => {
+        bridge.emit(AgentEvents.MUSIC_PLAY, { action: 'stop' });
+        return { ok: true, result: 'Music stopped.' };
+    },
+
+    next_track: (bridge) => {
+        bridge.emit(AgentEvents.MUSIC_PLAY, { action: 'skip' });
+        return { ok: true, result: 'Skipped.' };
+    },
+
+    play_spotify: (bridge, p) => {
+        const track = (p.track || '').trim();
+        if (!track) return { ok: false, error: 'No track given.' };
+        bridge.emit(AgentEvents.MUSIC_PLAY, {
+            action: 'play', track, artist: (p.artist || '').trim(), source: 'spotify',
+        });
+        return { ok: true, result: `Playing "${track}" on Spotify.` };
+    },
+
+    play_sound: (bridge, p) => {
+        const sound = (p.sound || '').trim();
+        if (!sound) return { ok: false, error: 'No sound given.' };
+        bridge.emit(AgentEvents.PLAY_SOUND, { sound, type: 'dj' });
+        return { ok: true, result: `Played ${sound}.` };
+    },
+
+    register_face: (bridge, p) => {
+        const name = (p.name || '').trim();
+        if (!name) return { ok: false, error: 'No name given.' };
+        bridge.emit(AgentEvents.TOOL_CALLED, { name: 'register_face', params: { name }, result: null });
+        return { ok: true, result: `Registering the visible face as ${name}.` };
+    },
+
+    sleep: (bridge) => {
+        bridge.emit(AgentActions.END_SESSION, {});
+        return { ok: true, result: 'Going to sleep.' };
+    },
+};
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ToolBridge
+// ─────────────────────────────────────────────────────────────────────────────
+
+class ToolBridge {
+    constructor() {
+        this._bridge = null;
+        this._profileId = null;
+        this._sessionId = null;
+        this._catalog = null;
+        this._eventSource = null;
+        this._destroyed = false;
+        this._reconnectTimer = null;
+        this._reconnectDelay = 1000;
+        // Highest job updated_at we have already surfaced. Handed back on
+        // reconnect as ?since= so a completion that lands during the gap is
+        // replayed rather than lost.
+        this._watermark = 0;
+        this._pendingJobs = new Map();   // job_id -> tool name, for nicer phrasing
+    }
+
+    // -- lifecycle ----------------------------------------------------------
+
+    async init(bridge, { profileId, sessionId } = {}) {
+        this._bridge = bridge;
+        this._profileId = profileId || null;
+        this._sessionId = sessionId || null;
+        this._destroyed = false;
+
+        await this._loadCatalog();
+        this._openEventStream();
+
+        const n = this._catalog?.realtime_tools?.length || 0;
+        console.log(`[ToolBridge] Ready — ${n} tool(s) granted to profile "${this._profileId}"`);
+    }
+
+    destroy() {
+        this._destroyed = true;
+        clearTimeout(this._reconnectTimer);
+        this._closeEventStream();
+        this._catalog = null;
+        this._pendingJobs.clear();
+    }
+
+    // -- catalog ------------------------------------------------------------
+
+    async _loadCatalog() {
+        try {
+            const qs = this._profileId ? `?profile=${encodeURIComponent(this._profileId)}` : '';
+            const res = await fetch(`/api/tools/catalog${qs}`);
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            this._catalog = await res.json();
+        } catch (err) {
+            // Fail CLOSED. An empty catalog means the model is told it has no
+            // tools — strictly better than guessing a default set it may not be
+            // authorised for.
+            console.error('[ToolBridge] Catalog load failed — no tools will be offered:', err);
+            this._catalog = { realtime_tools: [], routing: {}, markers: [] };
+        }
+    }
+
+    /** tools[] array for a realtime session.update. */
+    realtimeTools() {
+        return this._catalog?.realtime_tools || [];
+    }
+
+    /** Routing metadata for one tool, or null if it isn't granted. */
+    routing(name) {
+        return this._catalog?.routing?.[name] || null;
+    }
+
+    hasTools() {
+        return this.realtimeTools().length > 0;
+    }
+
+    // -- invocation ---------------------------------------------------------
+
+    /**
+     * Execute a tool call.
+     * @param {string} name
+     * @param {object|string} args - parsed object, or the raw JSON string a
+     *   realtime API sends in function_call_arguments.
+     * @returns {Promise<object>} result object to hand back to the model
+     */
+    async invoke(name, args) {
+        let params = args;
+        if (typeof args === 'string') {
+            try {
+                params = args.trim() ? JSON.parse(args) : {};
+            } catch (err) {
+                return { ok: false, error: `Could not parse arguments: ${err.message}` };
+            }
+        }
+        params = params || {};
+
+        const route = this.routing(name);
+        if (!route) {
+            // Either hallucinated, or real but not granted. Same answer either
+            // way — do not leak that a gated tool exists.
+            console.warn(`[ToolBridge] Rejected ungranted tool: ${name}`);
+            return { ok: false, error: `Tool "${name}" is not available.` };
+        }
+
+        this._bridge?.emit(AgentEvents.TOOL_CALLED, { name, params, result: null });
+
+        if (route.execution === 'client') {
+            const handler = CLIENT_HANDLERS[name];
+            if (!handler) {
+                console.error(`[ToolBridge] Catalog lists client tool "${name}" with no handler`);
+                return { ok: false, error: `Tool "${name}" is not wired up.` };
+            }
+            try {
+                return handler(this._bridge, params);
+            } catch (err) {
+                console.error(`[ToolBridge] Client handler "${name}" threw:`, err);
+                return { ok: false, error: `That failed: ${err.message}` };
+            }
+        }
+
+        return this._invokeServer(name, params);
+    }
+
+    async _invokeServer(name, params) {
+        try {
+            const res = await fetch('/api/tools/invoke', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    tool: name,
+                    params,
+                    profile: this._profileId,
+                    session_id: this._sessionId,
+                }),
+            });
+            const data = await res.json().catch(() => ({}));
+
+            if (!res.ok) {
+                return { ok: false, error: data.error || `Server returned ${res.status}.` };
+            }
+
+            if (data.status === 'dispatched') {
+                this._pendingJobs.set(data.job_id, name);
+                return {
+                    ok: true,
+                    status: 'dispatched',
+                    job_id: data.job_id,
+                    result: data.message,
+                };
+            }
+
+            return { ok: true, result: data.result };
+
+        } catch (err) {
+            console.error(`[ToolBridge] Server tool "${name}" failed:`, err);
+            return { ok: false, error: `Could not reach the server: ${err.message}` };
+        }
+    }
+
+    // -- server → agent push -------------------------------------------------
+
+    _openEventStream() {
+        if (this._destroyed) return;
+        this._closeEventStream();
+
+        const params = new URLSearchParams();
+        if (this._sessionId) params.set('session_id', this._sessionId);
+        if (this._watermark) params.set('since', String(this._watermark));
+
+        const url = `/api/tools/events?${params.toString()}`;
+
+        try {
+            this._eventSource = new EventSource(url);
+        } catch (err) {
+            console.error('[ToolBridge] Could not open event stream:', err);
+            this._scheduleReconnect();
+            return;
+        }
+
+        this._eventSource.onopen = () => {
+            this._reconnectDelay = 1000;
+            console.log('[ToolBridge] Job event stream connected');
+        };
+
+        this._eventSource.onmessage = (evt) => this._onServerEvent(evt);
+
+        this._eventSource.onerror = () => {
+            // EventSource retries on its own, but we close and reopen so the
+            // ?since= watermark advances — its native retry would replay from
+            // the original URL and re-announce jobs the agent already spoke.
+            if (this._destroyed) return;
+            console.warn('[ToolBridge] Job event stream dropped — reconnecting');
+            this._closeEventStream();
+            this._scheduleReconnect();
+        };
+    }
+
+    _scheduleReconnect() {
+        clearTimeout(this._reconnectTimer);
+        this._reconnectTimer = setTimeout(() => this._openEventStream(), this._reconnectDelay);
+        this._reconnectDelay = Math.min(this._reconnectDelay * 2, 30000);
+    }
+
+    _closeEventStream() {
+        if (this._eventSource) {
+            try { this._eventSource.close(); } catch (_) {}
+            this._eventSource = null;
+        }
+    }
+
+    _onServerEvent(evt) {
+        let msg;
+        try {
+            msg = JSON.parse(evt.data);
+        } catch (_) {
+            return;
+        }
+
+        if (msg.at && msg.at > this._watermark) this._watermark = msg.at;
+
+        switch (msg.type) {
+            case 'connected':
+                break;
+
+            case 'reconnect':
+                this._closeEventStream();
+                this._openEventStream();
+                break;
+
+            case 'job.done':
+            case 'job.failed':
+                this._announceJob(msg);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Interrupt the live conversation with a finished job.
+     *
+     * FORCE_MESSAGE (not CONTEXT_UPDATE) is deliberate: the agent PROMISED the
+     * user an answer, so it must speak — a silent context inject would leave the
+     * promise unfulfilled from the user's point of view. Every adapter
+     * implements FORCE_MESSAGE (xai-realtime.js:195, hume-evi.js:119,
+     * elevenlabs-*.js, ClawdBotAdapter.js:87).
+     */
+    _announceJob(msg) {
+        const tool = msg.tool || this._pendingJobs.get(msg.job_id) || 'task';
+        this._pendingJobs.delete(msg.job_id);
+
+        this._bridge?.emit(AgentEvents.TOOL_CALLED, {
+            name: tool,
+            params: { job_id: msg.job_id },
+            result: msg.summary,
+        });
+
+        const artifacts = (msg.artifacts || []).length
+            ? ` Files touched: ${msg.artifacts.join(', ')}.`
+            : '';
+
+        const text = msg.ok
+            ? `[TOOL RESULT] The "${tool}" job you started has finished. ` +
+              `Result: ${msg.summary}${artifacts} ` +
+              `Tell the user this now, in one short spoken sentence.`
+            : `[TOOL RESULT] The "${tool}" job you started FAILED. ` +
+              `Reason: ${msg.summary} ` +
+              `Tell the user briefly and offer to try again.`;
+
+        console.log(`[ToolBridge] Job ${msg.job_id} ${msg.ok ? 'done' : 'failed'} — announcing`);
+        this._bridge?.emit(AgentActions.FORCE_MESSAGE, { text });
+    }
+}
+
+// Singleton — one bus per page, like every other shell bridge.
+export const toolBridge = new ToolBridge();
+export { ToolBridge, CLIENT_HANDLERS };


### PR DESCRIPTION
Tenants picked a canvas style from the gallery, and then the quote their customer received looked nothing like the website that customer had just come from. **"Match my website"** derives the style from the client's real site instead.

## How it works

The work runs on the **host** — this container has no browser and no coding agent — so the picker spools onto the existing durable tool-job bus:

```
POST /api/canvas/styles/from-website        -> tool_jobs.create('brand_style')
GET  /api/canvas/styles/from-website        -> latest job (resume after reload)
GET  /api/canvas/styles/from-website/<id>   -> poll
```

Host side is `scripts/brand-style/` in MIKE-AI, split three ways because "have an agent look at the site and pick colours" produces confident *unreadable* results — brand colours are chosen for signage and then get read at 14px:

| stage | what it does |
|---|---|
| **measure** | headless Chrome, **no model**. Area-weighted background census, ink-weighted text census, role-sampled computed styles, `:root` vars, logo palette. |
| **judge** | model + vision. Picks the closest of the 18 presets and assigns colours to *roles*. Screenshots inform personality only. |
| **repair** | WCAG-repairs every fg/bg pair before the style can be saved. The preset keeps all structural craft; only brand identity changes. |

The demo/starter page for a brand style is a neutral customer-facing **estimate**, not the base preset's demo — a spray-foam contractor previewing as "VOLTAGE ACTION PARK" undercuts the moment the feature exists to create.

## Two pre-existing bugs fixed along the way

**`font-import` was an inert token.** Templates load faces with `@import url(...)` inside `<style>`, so changing `--font-display` set a family the browser never downloaded and the page silently fell through to a system font. This has been breaking **clone-and-customize** for anyone who changed typography, not just generated styles.

**The tool-job spool was unusable across the uid boundary.** It is written by two processes with different uids — this container (`appuser`, 1001) and the host worker (`mike`, 1000) — and `tempfile.mkstemp` creates files at **0600**, so every job the container spooled was unreadable to the worker. The voice tool bus had never executed a single job. `_ensure_dir` now widens the directory and `_write_atomic` chmods each job to 0666.

## Notes

- The picker keeps **no client-side state** — the server owns the job, so a refresh mid-review resumes and two tabs agree.
- SSRF: the tenant types a URL the *host* then opens with host network access, so every resolved address is checked (loopback/private/link-local/reserved) in the worker.
- Bot walls are detected and refused rather than measured — a Cloudflare challenge page renders fine and would otherwise become a design system built from "Just a moment…".

Docs: `docs/jambot/canvas-style-system.md` (MIKE-AI).