### PR TITLE
fix(vision): uploaded-image context names workspace path + forbids self-analysis

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1433,13 +1433,31 @@ def _conversation_inner():
                         except Exception as _se:
                             logger.warning('Failed to queue vision task to vision@mesh: %s', _se)
                     # Do not promise an analysis that was never queued.
+                    # The path matters as much as the status: without it, agents guess
+                    # (/app/runtime/uploads/ is readable by exec/read but REJECTED by the
+                    # image tool, whose media roots are hardcoded to workspace paths) and
+                    # burn a minute copying files around narrating paths over TTS.
                     if _queued:
-                        _upload_desc = 'Image is being analyzed now. Ask me about it in about 30 seconds.'
+                        _upload_desc = (
+                            f'Image saved in your workspace uploads folder: uploads/{_img_file.name} '
+                            f'(OpenClaw: /home/node/.openclaw/workspace/uploads/{_img_file.name}; '
+                            f'Hermes: /workspace/uploads/{_img_file.name}). A background vision agent '
+                            'is analyzing it right now — the result arrives in about 30 seconds. Do '
+                            'NOT analyze the image yourself, do NOT run the image tool on it, and do '
+                            'NOT copy or move the file. Tell the user you are taking a look; the '
+                            'analysis will be in your context on their next message. If you ever do '
+                            'need the image tool on an upload, it only accepts workspace paths like '
+                            'the above — it rejects /app/runtime/uploads/.'
+                        )
                         logger.info('Image routed to vision@mesh: %s', _img_file.name)
                     else:
-                        _upload_desc = ('Image saved, but automatic analysis could not be started. '
-                                        'Tell the user the image is saved and that you cannot '
-                                        'describe it right now.')
+                        _upload_desc = (
+                            f'Image saved in your workspace uploads folder: uploads/{_img_file.name} '
+                            f'(OpenClaw: /home/node/.openclaw/workspace/uploads/{_img_file.name}; '
+                            f'Hermes: /workspace/uploads/{_img_file.name}), but automatic analysis '
+                            'could not be started. If the user asks about it, run the image tool on '
+                            'that exact workspace path — the image tool rejects /app/runtime/uploads/.'
+                        )
                 context_parts.append(f'[UPLOADED IMAGE ANALYSIS: {_upload_desc}]')
             else:
                 logger.warning('Uploaded image not found or too large: %s', image_path)


### PR DESCRIPTION
The injected uploaded-image context carried no file path and no wait instruction, so voice agents ran the openclaw image tool themselves, guessed paths (`/app/runtime/uploads/` is readable by exec/read but rejected by the image tool — its media roots are hardcoded to workspace dirs), copied stale files, and narrated paths over TTS until the blocked event loop dropped the OVUI↔openclaw WS.

Both context branches now name the exact workspace upload path and instruct the agent not to self-analyze (queued) / to use the one image-tool-valid path (no-queue). One file, +22/-4.