### PR TITLE
fix(canvas): agent-driven canvas close — [CANVAS_CLOSE] + shell-level CANVAS_ACTION verbs

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -137,6 +137,7 @@ _VOICE_INSTRUCTIONS = (
     "ONLY the [CANVAS:page-id] tag works to open pages. "
     "Repeating [CANVAS:same-page] on an already-open page forces a refresh. "
     "[CANVAS_MENU] — opens the page picker so the user can browse all pages. "
+    "[CANVAS_CLOSE] — closes/hides the canvas (use when the user asks to close, hide, or dismiss the canvas or a stuck page). "
     "[CANVAS_URL:https://example.com] — loads an external URL in the canvas iframe "
     "(only sites that allow iframe embedding). "
 
@@ -1050,6 +1051,7 @@ def clean_for_tts(text: str) -> str:
 
     # Remove canvas/task/music triggers (handled by frontend, not spoken)
     text = re.sub(r'\[CANVAS_MENU\]', '', text, flags=re.IGNORECASE)
+    text = re.sub(r'\[CANVAS_CLOSE\]', '', text, flags=re.IGNORECASE)
     text = re.sub(r'\[CANVAS:[^\]]*\]', '', text, flags=re.IGNORECASE)
     text = re.sub(r'\[CANVAS_URL:[^\]]*\]', '', text, flags=re.IGNORECASE)
     text = re.sub(r'\[MUSIC_PLAY(?::[^\]]*)?\]', '', text, flags=re.IGNORECASE)

--- a/src/app.js
+++ b/src/app.js
@@ -101,6 +101,15 @@ connectAiradio();
                 const iframe = document.getElementById('canvas-iframe');
                 window.ActionConsole?.addEntry?.('system', `Canvas action: ${action}`);
                 window.AgentActivityChip?.handleTag?.('canvas_action', action);
+                // Shell-level verbs act on the SHELL, never the page. Posting these
+                // into the iframe was a structural no-op: the page has no handler,
+                // and the shell's own 'close' case only fires on messages FROM pages.
+                // (2026-08-18: phatty/Hart — agent emitted close, canvas stayed open.)
+                if (action === 'close') { CanvasControl.hide(); return; }
+                if (action === 'menu') { CanvasControl.showMenu(); return; }
+                if (action === 'navigate' && (payload?.page || payload?.pageId)) {
+                    CanvasControl.showPageById(payload.page || payload.pageId); return;
+                }
                 if (iframe && !flushHooked) {
                     flushHooked = true;
                     // one tick past `load` so the page's inline listener-registration ran
@@ -4266,6 +4275,9 @@ connectAiradio();
                         await window.CanvasMenu?.loadManifest();
                     } catch (e) { console.warn('[Canvas] manifest sync failed:', e); }
                     CanvasControl.showPage?.(pageName);
+                } else if (/\[CANVAS_CLOSE\]/i.test(rawText)) {
+                    AgentActivityChip.handleTag('canvas_close');
+                    CanvasControl.hide?.();
                 } else if (/\[CANVAS_MENU\]/i.test(rawText)) {
                     AgentActivityChip.handleTag('canvas_menu');
                     CanvasControl.showMenu?.() || document.getElementById('canvas-menu-button')?.click();
@@ -4504,7 +4516,7 @@ connectAiradio();
                             .replace(/```[\s\S]*?```/g, '')        // complete generic fences
                             .replace(/```html[\s\S]*/gi, '')       // unclosed html fence (streaming)
                             .replace(/```[\s\S]*/g, '')            // unclosed generic fence (streaming)
-                            .replace(/\[CANVAS_MENU\]/gi, '')
+                            .replace(/\[CANVAS_MENU\]/gi, '').replace(/\[CANVAS_CLOSE\]/gi, '')
                             .replace(/\[CANVAS:[^\]]*\]/gi, '')
                             .replace(/\[CANVAS_URL:[^\]]*\]/gi, '')
                             .replace(/\[BROWSE_ACTION:\{[\s\S]*?\}\]/gi, '')
@@ -4549,6 +4561,14 @@ connectAiradio();
                             catch (e) { console.error(`[tag:${label}] handler failed:`, e); }
                         };
                         text = normalizeActionTags(text);
+                        // Check for [CANVAS_CLOSE] — first-class agent close verb (2026-08-18)
+                        if (/\[CANVAS_CLOSE\]/i.test(text) && !canvasCommandsProcessed.has('CANVAS_CLOSE')) {
+                            canvasCommandsProcessed.add('CANVAS_CLOSE');
+                            console.log('[Canvas] CANVAS_CLOSE trigger detected');
+                            ActionConsole.addEntry('system', 'Canvas: closing');
+                            AgentActivityChip.handleTag('canvas_close');
+                            _tag('canvas_close', () => CanvasControl.hide?.());
+                        }
                         // Check for [CANVAS_MENU]
                         if (/\[CANVAS_MENU\]/i.test(text) && !canvasCommandsProcessed.has('CANVAS_MENU')) {
                             canvasCommandsProcessed.add('CANVAS_MENU');


### PR DESCRIPTION
## Problem
The agent has no way to close the canvas. The standing-instruction vocabulary offers `[CANVAS:page]`, `[CANVAS_MENU]`, `[CANVAS_URL]` — no close verb. Agents improvise `[CANVAS_ACTION:{"action":"close"}]`, which `dispatch()` posts **into** the page iframe; nothing in any page handles it, and the shell's own `case 'close'` only fires on messages **from** pages. Result: agent close commands are a structural no-op on every tenant (surfaced 2026-08-18 by phatty/Hart Support — file explorer stuck open through repeated close attempts while the agent kept confirming it was closing it).

## Fix
- `dispatch()` in the CANVAS_ACTION module now executes shell-level verbs (`close`, `menu`, `navigate`) against the shell directly (`CanvasControl.hide()` etc.) instead of posting them into the iframe. Page-level actions are unchanged.
- New first-class `[CANVAS_CLOSE]` tag: handled in the stream tag processor and the proactive-message handler, stripped from displayed text (app.js) and from TTS text (conversation.py), and documented in the standing instructions so agents stop improvising.

## Verification
- `node --check src/app.js` clean, `py_compile routes/conversation.py` clean.
- Existing behaviors untouched: page-originated `canvas-action` messages, `[CANVAS:page]`, `[CANVAS_MENU]` paths unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)