### PR TITLE
fix(vision): uploaded-image context gives the agent the real workspace path + forbids self-analysis

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1433,13 +1433,31 @@ def _conversation_inner():
                         except Exception as _se:
                             logger.warning('Failed to queue vision task to vision@mesh: %s', _se)
                     # Do not promise an analysis that was never queued.
+                    # The path matters as much as the status: without it, agents guess
+                    # (/app/runtime/uploads/ is readable by exec/read but REJECTED by the
+                    # image tool, whose media roots are hardcoded to workspace paths) and
+                    # burn a minute copying files around narrating paths over TTS.
                     if _queued:
-                        _upload_desc = 'Image is being analyzed now. Ask me about it in about 30 seconds.'
+                        _upload_desc = (
+                            f'Image saved in your workspace uploads folder: uploads/{_img_file.name} '
+                            f'(OpenClaw: /home/node/.openclaw/workspace/uploads/{_img_file.name}; '
+                            f'Hermes: /workspace/uploads/{_img_file.name}). A background vision agent '
+                            'is analyzing it right now — the result arrives in about 30 seconds. Do '
+                            'NOT analyze the image yourself, do NOT run the image tool on it, and do '
+                            'NOT copy or move the file. Tell the user you are taking a look; the '
+                            'analysis will be in your context on their next message. If you ever do '
+                            'need the image tool on an upload, it only accepts workspace paths like '
+                            'the above — it rejects /app/runtime/uploads/.'
+                        )
                         logger.info('Image routed to vision@mesh: %s', _img_file.name)
                     else:
-                        _upload_desc = ('Image saved, but automatic analysis could not be started. '
-                                        'Tell the user the image is saved and that you cannot '
-                                        'describe it right now.')
+                        _upload_desc = (
+                            f'Image saved in your workspace uploads folder: uploads/{_img_file.name} '
+                            f'(OpenClaw: /home/node/.openclaw/workspace/uploads/{_img_file.name}; '
+                            f'Hermes: /workspace/uploads/{_img_file.name}), but automatic analysis '
+                            'could not be started. If the user asks about it, run the image tool on '
+                            'that exact workspace path — the image tool rejects /app/runtime/uploads/.'
+                        )
                 context_parts.append(f'[UPLOADED IMAGE ANALYSIS: {_upload_desc}]')
             else:
                 logger.warning('Uploaded image not found or too large: %s', image_path)


### PR DESCRIPTION
## Problem
On image upload, the agent's turn context said only *"Image is being analyzed now. Ask me about it in about 30 seconds"* — no file path, no instruction not to analyze it itself. The agent then tried the TOOLS.md-documented `/app/runtime/uploads/` (rejected — the openclaw `image` tool's media roots are hardcoded and don't include it), guessed wrong paths, found a STALE image from an old session, copied and analyzed possibly the wrong file while narrating every path over TTS, and the stalled image call dropped the OVUI↔openclaw websocket, restarting the run. (test-dev, 2026-08-16 15:37 UTC — full forensics in docs/PREP-upload-image-vision-fix-2026-08-16.md on MIKE-AI.)

## Fix
Both upload context strings now name the image-tool-valid workspace path (`/home/node/.openclaw/workspace/uploads/<file>`); the queued-analysis branch explicitly forbids self-analysis while the vision pipeline runs; the no-queue branch names the one valid path for manual analysis.

## Verification
`py_compile` clean. Behavioral canary on test-dev follows the merge (upload → new context string in logs, zero `image failed`, cached analysis injected on follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)