### PR TITLE
feat(vision): chat singles read synchronously via Gemini; async pipeline becomes fallback

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -1383,6 +1383,66 @@ def _conversation_inner():
                     except Exception as _ie:
                         logger.debug('Could not read .image-intel cache: %s', _ie)
                 if _upload_desc is None:
+                    # SYNC GEMINI FIRST (Mike, 2026-08-18): an image attached to the chat
+                    # transcript is a "single" — the user is looking at it NOW and the agent
+                    # must read it in THIS turn, not tell them to wait 30s for the background
+                    # vision agent. Gemini reads it synchronously; the mesh queue below
+                    # survives only as the fallback when Gemini fails. Bulk uploads never
+                    # pass through here (no image_path on a chat turn) — they are swept by
+                    # the host-side auto-processor into .image-intel in the background.
+                    _gem_key = os.environ.get('GEMINI_API_KEY', '')
+                    if _gem_key:
+                        try:
+                            import requests as _rq
+                            _mime = {
+                                '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
+                                '.webp': 'image/webp', '.gif': 'image/gif',
+                            }.get(_img_file.suffix.lower(), 'image/jpeg')
+                            _b64 = base64.b64encode(_img_file.read_bytes()).decode()
+                            _gr = _rq.post(
+                                'https://generativelanguage.googleapis.com/v1beta/models/'
+                                f'gemini-2.5-flash:generateContent?key={_gem_key}',
+                                json={'contents': [{'parts': [
+                                    {'inline_data': {'mime_type': _mime, 'data': _b64}},
+                                    {'text': 'Describe this image concisely but completely: subjects, '
+                                             'objects, layout, any visible text (transcribe it), and '
+                                             'anything a user would likely ask about. Plain prose.'},
+                                ]}]},
+                                timeout=20,
+                            )
+                            _gr.raise_for_status()
+                            _gtxt = (_gr.json()['candidates'][0]['content']['parts'][0]['text'] or '').strip()
+                            if _gtxt:
+                                _upload_desc = (
+                                    f'{_gtxt} (Image file: uploads/{_img_file.name}; OpenClaw path '
+                                    f'/home/node/.openclaw/workspace/uploads/{_img_file.name} if the '
+                                    'image tool is ever needed — it rejects /app/runtime/uploads/.)'
+                                )
+                                logger.info('Chat image read synchronously via Gemini: %s', _img_file.name)
+                                # Write the .image-intel sidecar so later turns hit the cache
+                                # and the background sweeper knows this file is done.
+                                try:
+                                    import hashlib as _hl
+                                    import json as _json
+                                    _intel_path.parent.mkdir(exist_ok=True)
+                                    _intel_path.write_text(_json.dumps({
+                                        'schema': 1,
+                                        'file': _img_file.name,
+                                        'tenant': os.getenv('JAMBOT_TENANT', ''),
+                                        'sha256': _hl.sha256(_img_file.read_bytes()).hexdigest(),
+                                        'size': _img_file.stat().st_size,
+                                        'source': 'gemini-sync',
+                                        'original_name': _img_file.name,
+                                        'analyzed_at': datetime.utcnow().isoformat() + 'Z',
+                                        'analysis': {'description': _gtxt, 'keywords': [],
+                                                     'text_in_image': ''},
+                                    }, indent=1))
+                                except Exception as _we:
+                                    logger.debug('Could not write gemini-sync sidecar: %s', _we)
+                        except Exception as _ge:
+                            logger.warning('Sync Gemini vision failed (%s) — falling back to '
+                                           'vision@mesh queue for %s', _ge, _img_file.name)
+                if _upload_desc is None:
                     # No cache yet — route to vision@mesh via openclaw container (has mesh-send + mesh mount)
                     # Non-blocking: mesh task, vision agent writes .image-intel sidecar async
                     # OVU runs inside Docker; mesh-send isn't in this image but openclaw-<tenant> has it.


### PR DESCRIPTION
## Spec (Mike, 2026-08-18)
Images attached to the chat transcript (singles) must be read **immediately** with Gemini vision in the same turn. The async vision@mesh pipeline stays for background/bulk processing — the agent should never be told to wait on a chat image again.

## Change
- `routes/conversation.py`: when a chat turn carries `image_path` and no `.image-intel` cache exists, call `gemini-2.5-flash` synchronously (inline base64, 20s timeout) and inject the description into this turn's context. Writes a compatible `.image-intel` sidecar (`source: gemini-sync`) so later turns cache-hit and the background sweeper skips the file.
- The existing vision@mesh queue path is untouched and now serves only as fallback (Gemini error / no key).
- Bulk uploads are handled host-side by a new sweeper cron (MIKE-AI repo) that queues any uploaded image lacking a sidecar — agents never touch those live.

## Verification
- `py_compile` clean.
- Gemini call shape live-verified against a real test-dev upload (HTTP 200, correct description).
- Behavioral canary after image roll: upload in chat → description in same turn, no 'wait 30 seconds', no path narration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)