### PR TITLE
feat(canvas): land the Code Blocks source — terminal (PTY/WS) + Monaco editor

### DIFF
--- a/app.py
+++ b/app.py
@@ -228,6 +228,8 @@ def create_app(config_override: dict = None):
             '/favicon.ico',     # Browser favicon request — before auth
             '/ws/clawdbot',     # WebSocket — browsers can't send Clerk token in WS headers;
                                 # handler secures itself via CLAWDBOT_AUTH_TOKEN to the gateway
+            '/ws/terminal',     # Terminal PTY WebSocket — handler self-authenticates via
+                                # the __session cookie or X-Agent-Key before spawning a shell
             '/openclaw-ui',     # WebSocket upgrade for OpenClaw Control UI proxy (no trailing slash)
             '/ws/browse-stream', # WebSocket — co-browsing screencast (#154); handler self-auths
                                  # via Clerk token + injects the service key server-side

--- a/default-pages/monaco-editor.html
+++ b/default-pages/monaco-editor.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="page-icon" content="📝">
+<title>Code Editor</title>
+<style>
+  :root { --bg:#1e1e1e; --panel:#252526; --border:#333; --accent:#0e639c; --accent2:#1177bb; --text:#ccc; --muted:#888; }
+  * { box-sizing:border-box; }
+  html,body { margin:0; height:100%; background:var(--bg); color:var(--text); font-family:-apple-system,Segoe UI,Roboto,sans-serif; }
+  /* position:fixed + inset:0 fills the viewport edge-to-edge, ignoring the
+     canvas system's injected body{padding:25px} so nothing overflows/clips. */
+  #app { position:fixed; inset:0; display:flex; overflow:hidden; }
+  #sidebar { width:240px; min-width:130px; max-width:45%; flex:none; background:var(--panel); border-right:1px solid var(--border); display:flex; flex-direction:column; }
+  @media (max-width:640px){ #sidebar { width:150px; } }
+  #sbhead { padding:10px 12px; font-size:11px; letter-spacing:.08em; text-transform:uppercase; color:var(--muted); display:flex; align-items:center; justify-content:space-between; border-bottom:1px solid var(--border); }
+  #sbhead button { background:none; border:none; color:var(--muted); cursor:pointer; font-size:15px; line-height:1; padding:2px 5px; border-radius:4px; }
+  #sbhead button:hover { background:#333; color:#fff; }
+  #tree { flex:1; overflow:auto; padding:4px 0; }
+  .node { padding:3px 12px; font-size:13px; cursor:pointer; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; user-select:none; }
+  .node:hover { background:#2a2d2e; }
+  .node.active { background:#37373d; color:#fff; }
+  .node.dir { color:#bdbdbd; font-weight:500; }
+  .node .ic { display:inline-block; width:16px; opacity:.8; }
+  .empty { padding:16px 12px; color:var(--muted); font-size:12px; line-height:1.5; }
+  #main { flex:1; display:flex; flex-direction:column; min-width:0; }
+  #toolbar { height:38px; flex:none; background:var(--panel); border-bottom:1px solid var(--border); display:flex; align-items:center; gap:8px; padding:0 10px; }
+  #path { flex:1; font-size:12px; color:var(--muted); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  #path .dirty { color:#e2c08d; }
+  .btn { background:var(--accent); color:#fff; border:none; border-radius:4px; padding:5px 12px; font-size:12px; cursor:pointer; }
+  .btn:hover { background:var(--accent2); }
+  .btn.ghost { background:#3a3d41; }
+  .btn.ghost:hover { background:#45494e; }
+  .btn:disabled { opacity:.4; cursor:default; }
+  #editor { flex:1; min-height:0; }
+  #welcome { flex:1; display:flex; align-items:center; justify-content:center; flex-direction:column; color:var(--muted); gap:10px; }
+  #welcome h2 { color:#bbb; font-weight:500; margin:0; }
+  #toast { position:fixed; bottom:16px; right:16px; background:#333; color:#fff; padding:8px 14px; border-radius:6px; font-size:13px; opacity:0; transition:opacity .2s; pointer-events:none; box-shadow:0 4px 14px rgba(0,0,0,.4); }
+  #toast.show { opacity:1; }
+</style>
+</head>
+<body>
+<div id="app">
+  <div id="sidebar">
+    <div id="sbhead">
+      <span>Workspace</span>
+      <span>
+        <button id="newBtn" title="New file">＋</button>
+        <button id="refreshBtn" title="Refresh">⟳</button>
+      </span>
+    </div>
+    <div id="tree"></div>
+  </div>
+  <div id="main">
+    <div id="toolbar">
+      <span id="path">No file open</span>
+      <button class="btn" id="saveBtn" disabled>Save</button>
+    </div>
+    <div id="editor"></div>
+    <div id="welcome">
+      <div style="font-size:40px">📝</div>
+      <h2>Code Editor</h2>
+      <div>Select a file on the left, or create one with ＋</div>
+    </div>
+  </div>
+</div>
+<div id="toast"></div>
+
+<script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs/loader.js"></script>
+<script>
+const $ = s => document.querySelector(s);
+let editor = null, current = null, dirty = false, savedValue = '';
+
+const LANG = {js:'javascript',mjs:'javascript',cjs:'javascript',ts:'typescript',jsx:'javascript',tsx:'typescript',
+  py:'python',rb:'ruby',go:'go',rs:'rust',java:'java',c:'c',h:'c',cpp:'cpp',cc:'cpp',cs:'csharp',php:'php',
+  html:'html',htm:'html',css:'css',scss:'scss',json:'json',yaml:'yaml',yml:'yaml',toml:'ini',ini:'ini',
+  md:'markdown',markdown:'markdown',sh:'shell',bash:'shell',sql:'sql',xml:'xml',svg:'xml',dockerfile:'dockerfile'};
+function langFor(path){ const n=path.toLowerCase(); if(n.endsWith('dockerfile'))return 'dockerfile';
+  const ext=n.split('.').pop(); return LANG[ext]||'plaintext'; }
+
+function toast(msg){ const t=$('#toast'); t.textContent=msg; t.classList.add('show'); clearTimeout(t._t); t._t=setTimeout(()=>t.classList.remove('show'),1800); }
+
+function setDirty(d){ dirty=d; $('#saveBtn').disabled = !current || !d;
+  if(current){ $('#path').innerHTML = current + (d?' <span class="dirty">●</span>':''); } }
+
+async function loadTree(){
+  const tree=$('#tree');
+  try{
+    const r=await fetch('/api/workspace/tree',{credentials:'include'});
+    const j=await r.json();
+    const entries=(j.entries||[]).sort((a,b)=>{
+      if(a.type!==b.type) return a.type==='dir'?-1:1;
+      return a.path.localeCompare(b.path);
+    });
+    if(!entries.length){ tree.innerHTML='<div class="empty">Empty workspace.<br>Click ＋ to create your first file.</div>'; return; }
+    tree.innerHTML='';
+    for(const e of entries){
+      const depth=e.path.split('/').length-1;
+      const div=document.createElement('div');
+      div.className='node '+e.type;
+      div.style.paddingLeft=(12+depth*12)+'px';
+      div.innerHTML='<span class="ic">'+(e.type==='dir'?'📁':'📄')+'</span>'+e.name;
+      if(e.type==='file'){ div.onclick=()=>openFile(e.path,div); if(e.path===current) div.classList.add('active'); }
+      tree.appendChild(div);
+    }
+  }catch(err){ tree.innerHTML='<div class="empty">Failed to load workspace.</div>'; }
+}
+
+async function openFile(path,node){
+  if(dirty && !confirm('Discard unsaved changes?')) return;
+  try{
+    const r=await fetch('/api/workspace/file?path='+encodeURIComponent(path),{credentials:'include'});
+    const j=await r.json();
+    if(!r.ok){ toast(j.error||'Could not open'); return; }
+    current=path; savedValue=j.content;
+    $('#welcome').style.display='none'; $('#editor').style.display='block';
+    if(!editor) await initMonaco();
+    editor.setModel(monaco.editor.createModel(j.content, langFor(path)));
+    setDirty(false);
+    document.querySelectorAll('.node.active').forEach(n=>n.classList.remove('active'));
+    if(node) node.classList.add('active');
+  }catch(err){ toast('Error opening file'); }
+}
+
+async function save(){
+  if(!current) return;
+  const content=editor.getValue();
+  try{
+    const r=await fetch('/api/workspace/file',{method:'POST',credentials:'include',
+      headers:{'Content-Type':'application/json'},body:JSON.stringify({path:current,content})});
+    const j=await r.json();
+    if(!r.ok||!j.ok){ toast(j.error||'Save failed'); return; }
+    savedValue=content; setDirty(false); toast('Saved '+current);
+  }catch(err){ toast('Save failed'); }
+}
+
+async function newFile(){
+  const path=prompt('New file path (relative to workspace):','untitled.txt');
+  if(!path) return;
+  try{
+    const r=await fetch('/api/workspace/file',{method:'POST',credentials:'include',
+      headers:{'Content-Type':'application/json'},body:JSON.stringify({path:path.trim(),content:''})});
+    const j=await r.json();
+    if(!r.ok||!j.ok){ toast(j.error||'Could not create'); return; }
+    await loadTree(); openFile(path.trim());
+  }catch(err){ toast('Could not create'); }
+}
+
+function initMonaco(){
+  return new Promise(resolve=>{
+    require.config({paths:{vs:'https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs'}});
+    require(['vs/editor/editor.main'],()=>{
+      editor=monaco.editor.create($('#editor'),{theme:'vs-dark',automaticLayout:true,fontSize:13,
+        minimap:{enabled:false},scrollBeyondLastLine:false,value:''});
+      editor.onDidChangeModelContent(()=>{ setDirty(editor.getValue()!==savedValue); });
+      editor.addCommand(monaco.KeyMod.CtrlCmd|monaco.KeyCode.KeyS,()=>save());
+      resolve();
+    });
+  });
+}
+
+$('#saveBtn').onclick=save;
+$('#newBtn').onclick=newFile;
+$('#refreshBtn').onclick=loadTree;
+window.addEventListener('beforeunload',e=>{ if(dirty){ e.preventDefault(); e.returnValue=''; } });
+loadTree();
+</script>
+</body>
+</html>

--- a/default-pages/terminal.html
+++ b/default-pages/terminal.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="page-icon" content="🖥️">
+<title>Terminal</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+<style>
+  html,body { margin:0; height:100%; background:#0a0a0a; }
+  /* position:fixed + inset:0 fills the viewport, ignoring the canvas
+     system's injected body{padding:25px} so the terminal sits flush. */
+  #app { position:fixed; inset:0; display:flex; flex-direction:column; background:#0a0a0a; }
+  #bar { height:30px; flex:none; display:flex; align-items:center; gap:8px; padding:0 10px;
+    background:#181818; border-bottom:1px solid #2a2a2a; font:12px -apple-system,Segoe UI,sans-serif; color:#888; }
+  #dot { width:9px; height:9px; border-radius:50%; background:#666; flex:none; }
+  #dot.on { background:#3fb950; } #dot.off { background:#f85149; }
+  #bar .sp { flex:1; }
+  #bar button { background:#262626; color:#ccc; border:1px solid #333; border-radius:4px; font-size:11px; padding:3px 9px; cursor:pointer; }
+  #bar button:hover { background:#303030; }
+  #term { flex:1; min-height:0; padding:6px 8px; }
+  .xterm .xterm-viewport::-webkit-scrollbar { width:6px; }
+  .xterm .xterm-viewport::-webkit-scrollbar-thumb { background:#3a3a42; border-radius:99px; }
+</style>
+</head>
+<body>
+<div id="app">
+  <div id="bar">
+    <span id="dot"></span><span id="status">Connecting…</span>
+    <span class="sp"></span>
+    <button id="reconnect">Reconnect</button>
+  </div>
+  <div id="term"></div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+<script>
+const $ = s => document.querySelector(s);
+let term, fit, ws, closedByUs = false;
+
+function setStatus(state, text){
+  $('#dot').className = state==='on'?'on':(state==='off'?'off':'');
+  $('#status').textContent = text;
+}
+
+function sendResize(){
+  if(!fit || !ws || ws.readyState!==1) return;
+  try { fit.fit(); ws.send(JSON.stringify({type:'resize', cols:term.cols, rows:term.rows})); } catch(e){}
+}
+
+function connect(){
+  closedByUs = false;
+  const proto = location.protocol==='https:' ? 'wss' : 'ws';
+  ws = new WebSocket(proto+'://'+location.host+'/ws/terminal');
+  setStatus('', 'Connecting…');
+  ws.onopen = () => { setStatus('on','Connected'); term.focus(); setTimeout(sendResize, 60); };
+  ws.onmessage = (e) => {
+    // control frames arrive as JSON {type:'error'|...}; shell output is raw text
+    if(e.data && e.data[0]==='{'){
+      try { const j=JSON.parse(e.data); if(j.type==='error'){ term.write('\r\n\x1b[31m['+j.message+']\x1b[0m\r\n'); return; } } catch(_){}
+    }
+    term.write(e.data);
+  };
+  ws.onclose = () => { setStatus('off', closedByUs?'Disconnected':'Connection closed'); };
+  ws.onerror = () => { setStatus('off','Connection error'); };
+}
+
+function init(){
+  term = new Terminal({ cursorBlink:true, fontSize:13, fontFamily:'ui-monospace,Menlo,Consolas,monospace',
+    theme:{ background:'#0a0a0a', foreground:'#d4d4d4', cursor:'#d4d4d4' }, scrollback:5000, convertEol:false });
+  fit = new FitAddon.FitAddon();
+  term.loadAddon(fit);
+  term.open($('#term'));
+  fit.fit();
+  term.onData(d => { if(ws && ws.readyState===1) ws.send(JSON.stringify({type:'input', data:d})); });
+  window.addEventListener('resize', sendResize);
+  new ResizeObserver(sendResize).observe($('#term'));
+  $('#reconnect').onclick = () => { closedByUs=true; try{ws && ws.close();}catch(e){} term.reset(); connect(); };
+  connect();
+}
+
+if(window.Terminal && window.FitAddon) init();
+else window.addEventListener('load', init);
+</script>
+</body>
+</html>

--- a/routes/canvas.py
+++ b/routes/canvas.py
@@ -42,7 +42,7 @@ from services.canvas_versioning import (
 # Constants
 # ---------------------------------------------------------------------------
 
-from services.paths import APP_ROOT as _APP_ROOT, CANVAS_MANIFEST_PATH, CANVAS_PAGES_DIR, WORKSPACE_DIR
+from services.paths import APP_ROOT as _APP_ROOT, CANVAS_MANIFEST_PATH, CANVAS_PAGES_DIR, WORKSPACE_DIR, CODE_WORKSPACE_DIR
 CANVAS_SSE_PORT = int(os.getenv('CANVAS_SSE_PORT', '3030'))
 CANVAS_SESSION_PORT = int(os.getenv('CANVAS_SESSION_PORT', '3002'))
 BRAIN_EVENTS_PATH = Path('/tmp/openvoiceui-events.jsonl')
@@ -860,7 +860,7 @@ def canvas_pages_proxy(path):
         # inside the app's own iframe and the parent page already handled authentication.
         # The iframe may not have the Clerk __session cookie on cross-subdomain visits.
         _is_html = path.endswith('.html')
-        _OS_PAGES = {'desktop.html', 'file-explorer.html'}
+        _OS_PAGES = {'desktop.html', 'file-explorer.html', 'monaco-editor.html', 'terminal.html'}
         if CANVAS_REQUIRE_AUTH and _is_html and path not in _OS_PAGES:
             page_id = Path(path).stem
             manifest = load_canvas_manifest()
@@ -983,11 +983,12 @@ def canvas_pages_proxy(path):
                     # maps.googleapis.com + maps.gstatic.com: required by the `maps` skill's
                     # Google Maps JS canvas pages. Omitting them silently blanks every map
                     # (console-only CSP violation). Found 2026-07-24. Do NOT re-strip.
+                    # cdn.jsdelivr.net in style-src: Monaco/xterm stylesheets (Code Blocks).
                     "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://games.jam-bot.com https://maps.googleapis.com https://maps.gstatic.com blob:; "
-                    "style-src 'unsafe-inline' https://games.jam-bot.com https://fonts.googleapis.com; "
+                    "style-src 'unsafe-inline' https://games.jam-bot.com https://fonts.googleapis.com https://cdn.jsdelivr.net; "
                     "img-src 'self' data: blob: https:; "
                     "media-src 'self' blob: https:; "
-                    "font-src 'self' https://fonts.gstatic.com; "
+                    "font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net; "
                     "connect-src 'self' blob: https://games.jam-bot.com "
                         "https://*.jam-bot.com wss://*.jam-bot.com "
                         "https://api.openai.com https://generativelanguage.googleapis.com "
@@ -1594,6 +1595,112 @@ def canvas_data_write(filename):
         return jsonify({'ok': True})
     except Exception as exc:
         logger.error(f'canvas_data write error: {exc}')
+        return jsonify({'error': str(exc)}), 500
+
+
+# ---------------------------------------------------------------------------
+# Workspace file API — backs the Monaco code-editor canvas block.
+# Scoped to WORKSPACE_DIR (/app/runtime/workspace). NOT under the public
+# /api/canvas/ prefix, so the global Clerk before_request gate protects every
+# read/write when auth is enabled. _safe_canvas_path blocks traversal.
+# ---------------------------------------------------------------------------
+_WORKSPACE_MAX_BYTES = 5 * 1024 * 1024  # 5MB per-file ceiling for the editor
+_WORKSPACE_SKIP_SEGMENTS = {'.git', 'node_modules', '__pycache__', '.cache'}
+
+
+def _workspace_root() -> Path:
+    CODE_WORKSPACE_DIR.mkdir(parents=True, exist_ok=True)
+    return CODE_WORKSPACE_DIR
+
+
+@canvas_bp.route('/api/workspace/tree', methods=['GET'])
+def workspace_tree():
+    """Return the workspace file tree (relative paths, dirs + files)."""
+    root = _workspace_root()
+    entries = []
+    try:
+        for p in sorted(root.rglob('*')):
+            rel = p.relative_to(root)
+            parts = rel.parts
+            if any(seg in _WORKSPACE_SKIP_SEGMENTS for seg in parts):
+                continue
+            if len(parts) > 12:  # avoid pathological deep trees
+                continue
+            try:
+                is_dir = p.is_dir()
+                entries.append({
+                    'path': str(rel),
+                    'name': p.name,
+                    'type': 'dir' if is_dir else 'file',
+                    'size': 0 if is_dir else p.stat().st_size,
+                })
+            except OSError:
+                continue
+    except Exception as exc:
+        logger.error(f'workspace_tree error: {exc}')
+        return jsonify({'error': str(exc)}), 500
+    return jsonify({'root': 'workspace', 'entries': entries})
+
+
+@canvas_bp.route('/api/workspace/file', methods=['GET'])
+def workspace_file_read():
+    """Read a single workspace file as UTF-8 text for the editor."""
+    rel = request.args.get('path', '').strip()
+    if not rel:
+        return jsonify({'error': 'path required'}), 400
+    resolved = _safe_canvas_path(str(_workspace_root()), rel)
+    if resolved is None or not resolved.exists() or not resolved.is_file():
+        return jsonify({'error': 'not found'}), 404
+    if resolved.stat().st_size > _WORKSPACE_MAX_BYTES:
+        return jsonify({'error': 'file too large to edit'}), 413
+    try:
+        content = resolved.read_text(encoding='utf-8')
+    except UnicodeDecodeError:
+        return jsonify({'error': 'binary file — not editable'}), 415
+    return jsonify({'path': rel, 'content': content})
+
+
+@canvas_bp.route('/api/workspace/file', methods=['POST'])
+def workspace_file_write():
+    """Create or overwrite a workspace file (also creates parent dirs)."""
+    data = request.get_json(silent=True) or {}
+    rel = (data.get('path') or '').strip()
+    content = data.get('content')
+    if not rel or content is None:
+        return jsonify({'error': 'path and content required'}), 400
+    if not isinstance(content, str):
+        return jsonify({'error': 'content must be a string'}), 400
+    if len(content.encode('utf-8')) > _WORKSPACE_MAX_BYTES:
+        return jsonify({'error': 'content too large'}), 413
+    resolved = _safe_canvas_path(str(_workspace_root()), rel)
+    if resolved is None:
+        return jsonify({'error': 'invalid path'}), 400
+    if resolved.exists() and resolved.is_dir():
+        return jsonify({'error': 'path is a directory'}), 400
+    try:
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        resolved.write_text(content, encoding='utf-8')
+        return jsonify({'ok': True, 'path': rel, 'bytes': len(content.encode('utf-8'))})
+    except Exception as exc:
+        logger.error(f'workspace_file_write error: {exc}')
+        return jsonify({'error': str(exc)}), 500
+
+
+@canvas_bp.route('/api/workspace/mkdir', methods=['POST'])
+def workspace_mkdir():
+    """Create a directory inside the workspace."""
+    data = request.get_json(silent=True) or {}
+    rel = (data.get('path') or '').strip()
+    if not rel:
+        return jsonify({'error': 'path required'}), 400
+    resolved = _safe_canvas_path(str(_workspace_root()), rel)
+    if resolved is None:
+        return jsonify({'error': 'invalid path'}), 400
+    try:
+        resolved.mkdir(parents=True, exist_ok=True)
+        return jsonify({'ok': True, 'path': rel})
+    except Exception as exc:
+        logger.error(f'workspace_mkdir error: {exc}')
         return jsonify({'error': str(exc)}), 500
 
 

--- a/server.py
+++ b/server.py
@@ -2342,6 +2342,122 @@ def browse_stream_websocket(ws):
 
 
 # ---------------------------------------------------------------------------
+# Terminal — PTY over WebSocket (backs the terminal canvas block)
+# ---------------------------------------------------------------------------
+# Spawns a login shell inside THIS container, cwd'd to the dedicated code
+# sandbox (CODE_WORKSPACE_DIR). Gated by the Clerk __session cookie (same as
+# /ws/clawdbot) OR the internal X-Agent-Key. Pure-Python pty — no node-pty.
+
+@sock.route("/ws/terminal")
+def terminal_websocket(ws):
+    import pty, select, struct, fcntl, termios, signal, threading
+    from services.auth import verify_clerk_token, get_token_from_request
+    from services.paths import CODE_WORKSPACE_DIR
+
+    # --- auth: valid Clerk session OR internal agent key ---
+    token = get_token_from_request()
+    user_id = verify_clerk_token(token) if token else None
+    agent_key = os.getenv("AGENT_API_KEY", "").strip()
+    has_agent_key = bool(agent_key) and request.headers.get("X-Agent-Key") == agent_key
+    if not user_id and not has_agent_key:
+        logger.warning("Terminal WS rejected — no valid Clerk token / agent key")
+        try:
+            ws.send(json.dumps({"type": "error", "message": "Unauthorized"}))
+            ws.close()
+        except Exception:
+            pass
+        return
+    logger.info(f"Terminal WS authenticated: user={user_id or 'agent-key'}")
+
+    try:
+        CODE_WORKSPACE_DIR.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        pass
+
+    pid, master_fd = pty.fork()
+    if pid == 0:
+        # --- child: become the login shell ---
+        os.environ["TERM"] = "xterm-256color"
+        try:
+            os.chdir(str(CODE_WORKSPACE_DIR))
+        except Exception:
+            pass
+        shell = os.environ.get("SHELL") or "/bin/bash"
+        try:
+            os.execvp(shell, [shell, "-l"])
+        except Exception:
+            try:
+                os.execvp("/bin/sh", ["/bin/sh"])
+            except Exception:
+                os._exit(1)
+
+    # --- parent: bridge pty <-> websocket ---
+    stop = threading.Event()
+
+    def _pty_to_ws():
+        while not stop.is_set():
+            try:
+                r, _, _ = select.select([master_fd], [], [], 0.2)
+                if master_fd in r:
+                    data = os.read(master_fd, 65536)
+                    if not data:
+                        break
+                    ws.send(data.decode("utf-8", "replace"))
+            except (OSError, ValueError):
+                break
+            except Exception:
+                break
+        stop.set()
+        try:
+            ws.close()
+        except Exception:
+            pass
+
+    reader = threading.Thread(target=_pty_to_ws, daemon=True)
+    reader.start()
+
+    try:
+        while not stop.is_set():
+            msg = ws.receive()
+            if msg is None:
+                break
+            try:
+                data = json.loads(msg)
+            except Exception:
+                continue
+            mtype = data.get("type")
+            if mtype == "input":
+                try:
+                    os.write(master_fd, data.get("data", "").encode("utf-8"))
+                except OSError:
+                    break
+            elif mtype == "resize":
+                try:
+                    cols = max(1, int(data.get("cols", 80)))
+                    rows = max(1, int(data.get("rows", 24)))
+                    fcntl.ioctl(master_fd, termios.TIOCSWINSZ,
+                                struct.pack("HHHH", rows, cols, 0, 0))
+                except Exception:
+                    pass
+    except Exception as e:
+        logger.error(f"Terminal WS error: {e}")
+    finally:
+        stop.set()
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except Exception:
+            pass
+        try:
+            os.close(master_fd)
+        except Exception:
+            pass
+        try:
+            os.waitpid(pid, 0)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
 # Game Library API
 # ---------------------------------------------------------------------------
 # Serves game catalog data to canvas pages (same-origin, no CORS needed).

--- a/services/paths.py
+++ b/services/paths.py
@@ -26,6 +26,10 @@ VOICE_CLONES_DIR = RUNTIME_DIR / "voice-clones"
 VOICE_SESSION_FILE = str(RUNTIME_DIR / ".voice-session-counter")
 ACTIVE_PROFILE_FILE = RUNTIME_DIR / "profiles" / ".active-profile"
 WORKSPACE_DIR = Path(os.getenv('WORKSPACE_DIR', str(RUNTIME_DIR / 'workspace')))
+# Dedicated, isolated sandbox for the Monaco editor + terminal canvas blocks.
+# Deliberately NOT the shared WORKSPACE_DIR (agent data tree) — kept separate so
+# the code blocks have a clean, reversible root. Widen to the agent workspace later.
+CODE_WORKSPACE_DIR = Path(os.getenv('CODE_WORKSPACE_DIR', str(RUNTIME_DIR / 'code-workspace')))
 
 # Camera Capture — server-authoritative photo/album storage
 CAPTURES_DIR = Path(os.getenv("CAPTURES_DIR", str(RUNTIME_DIR / "captures")))


### PR DESCRIPTION
## The missing source of a LIVE feature
Code Blocks (Monaco editor + xterm/PTY canvas pages) has been LIVE on test-dev since 2026-06-06 and has its own overview doc (docs/jambot/code-blocks-system-overview.md) — but its source never landed in main: no `/ws/terminal`, no `CODE_WORKSPACE_DIR`, no default-pages/{terminal,monaco-editor}.html anywhere in the repo. The only copy lived as commit 64c3f3e on `feat/agent-terminal-canvas` (whose 5 other commits were June TTS fixes that landed via #328). Found during the 2026-08-18 branch-archaeology pass.

## What this PR does
Cherry-picks 64c3f3e onto current main with two conflict resolutions:
- **routes/canvas.py CSP**: union — keeps main's maps.googleapis/gstatic entries (DO-NOT-RE-STRIP, 2026-07-24) and adds cdn.jsdelivr.net to style-src for Monaco/xterm stylesheets.
- **server.py**: main and the branch appended different WS routes at the same anchor (xai-realtime/browse-stream vs terminal PTY) with identical cleanup tails; resolved by transplanting the complete 116-line terminal section from the branch after main's routes, before the Game Library API section.

py_compile clean on both files; default pages + /api/workspace/* + CODE_WORKSPACE_DIR path plumbing all present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)