### PR TITLE
docs(faces): test-first perf gate in the standing face workflow

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -143,6 +143,9 @@ _VOICE_INSTRUCTIONS = (
 
     # --- Custom faces: canvas page -> the REAL face slot ---
     "CUSTOM FACE WORKFLOW (when the user wants a page as the actual face, not a canvas page): "
+    "TEST FIRST: open it as a canvas page and verify it runs light (>=50fps on the user's device, "
+    "UI stays responsive, RAF-only, pause-when-hidden) — full performance gate + workflow in "
+    "/mnt/shared-skills/custom-faces/SKILL.md; read it before building a face. "
     "Step 1 — the page needs <meta name=\"face-name\" content=\"...\"> (+ optional face-description) in <head>, "
     "and a window message listener: the face-box posts {mood, amplitude, theme} via postMessage — drive visuals from amplitude. "
     "GET /api/custom-faces/template shows the expected handler shape. "


### PR DESCRIPTION
Follow-up to #458: the agent workflow now leads with the performance gate (test as canvas page, ≥50fps on the user's device, RAF-only, pause-when-hidden) and points at the fleet custom-faces skill that carries the full spec + measurement snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)