### PR TITLE
perf: manifest ETag + conditional fetch for desktop poll

### DIFF
--- a/default-pages/desktop.html
+++ b/default-pages/desktop.html
@@ -1030,12 +1030,15 @@ async function loadState() {
 /* ══════════════════════════════════════════════════════════════
    MANIFEST SYNC — fetch pages dynamically from server
    ══════════════════════════════════════════════════════════════ */
+let _manifestEtag = null; // last ETag seen — server 304s when content is unchanged
 async function fetchManifest(forceSync) {
   if (_stateDirty && !forceSync) return; // unsaved local changes — don't clobber
   try {
     const url = '/api/canvas/manifest' + (forceSync ? '?sync=1' : '');
-    const resp = await fetch(url);
+    const resp = await fetch(url, _manifestEtag ? { headers: { 'If-None-Match': _manifestEtag } } : undefined);
+    if (resp.status === 304) return; // manifest unchanged — skip re-parse/re-render
     if (!resp.ok) { console.warn('[desktop] manifest fetch failed:', resp.status); return; }
+    _manifestEtag = resp.headers.get('ETag');
     const data = await resp.json();
 
     // Categories to hide from desktop (system UI, empty, etc.)

--- a/routes/canvas.py
+++ b/routes/canvas.py
@@ -6,6 +6,7 @@ and manifest management helpers that other modules (e.g. server.py's
 conversation handler) need via direct import.
 """
 
+import hashlib
 import html as html_module
 import json
 import logging
@@ -1200,7 +1201,21 @@ def get_canvas_manifest():
         manifest = sync_canvas_manifest()
     else:
         manifest = load_canvas_manifest()
-    response = jsonify(manifest)
+    # Content-hash ETag so 30s pollers (desktop.html) can skip re-downloading
+    # and re-parsing an unchanged manifest. `last_updated` is excluded: the 60s
+    # auto-sync re-stamps it on every save even when nothing changed, and no
+    # client renders it — including it would mean the ETag never matches.
+    # Clients send If-None-Match manually (Cache-Control stays no-store so no
+    # proxy/browser HTTP cache is involved).
+    _hashable = {k: v for k, v in manifest.items() if k != 'last_updated'}
+    etag = '"' + hashlib.md5(
+        json.dumps(_hashable, sort_keys=True, separators=(',', ':')).encode()
+    ).hexdigest() + '"'
+    if request.headers.get('If-None-Match') == etag:
+        response = Response(status=304)
+    else:
+        response = jsonify(manifest)
+    response.headers['ETag'] = etag
     response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
     response.headers['Pragma'] = 'no-cache'
     response.headers['Expires'] = '0'

--- a/tests/test_routes_canvas.py
+++ b/tests/test_routes_canvas.py
@@ -83,6 +83,34 @@ class TestCanvasHelpers:
 
 
 # ---------------------------------------------------------------------------
+# API: /api/canvas/manifest GET — ETag / conditional fetch (#235)
+# ---------------------------------------------------------------------------
+
+class TestCanvasManifestEtag:
+    def test_manifest_sends_etag(self, canvas_client):
+        resp = canvas_client.get("/api/canvas/manifest")
+        assert resp.status_code == 200
+        assert resp.headers.get("ETag", "").startswith('"')
+
+    def test_matching_if_none_match_returns_304(self, canvas_client):
+        first = canvas_client.get("/api/canvas/manifest")
+        etag = first.headers["ETag"]
+        second = canvas_client.get(
+            "/api/canvas/manifest", headers={"If-None-Match": etag}
+        )
+        assert second.status_code == 304
+        assert second.headers["ETag"] == etag
+        assert second.get_data() == b""
+
+    def test_stale_if_none_match_returns_full_body(self, canvas_client):
+        resp = canvas_client.get(
+            "/api/canvas/manifest", headers={"If-None-Match": '"bogus-etag"'}
+        )
+        assert resp.status_code == 200
+        assert isinstance(resp.get_json(), dict)
+
+
+# ---------------------------------------------------------------------------
 # API: /api/canvas/context GET
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #235 (remaining half — DOM element reuse already shipped, see issue audit comment).

- `GET /api/canvas/manifest` sends a content-hash ETag and answers `If-None-Match` with 304 + empty body.
- Hash excludes `last_updated`: the 60s auto-sync re-stamps it on every save even when nothing changed, so including it would make the tag never match (no client renders it).
- `desktop.html` `fetchManifest()` sends `If-None-Match` from the last seen tag and returns early on 304 — no JSON re-parse, no icon re-render on the 30s poll when nothing changed.
- Cache-Control stays `no-store`; the conditional exchange is handled in app JS, so no proxy/browser HTTP cache involvement.

Tested: `tests/test_routes_canvas.py` 20/20 in the app container, incl. new `TestCanvasManifestEtag` (etag present · 304 on match · full body on stale tag). Inline desktop script passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)