### PR TITLE
fix(image-gen): validate magic bytes — a 200 is not an image

### DIFF
--- a/prompts/voice-system-prompt.md
+++ b/prompts/voice-system-prompt.md
@@ -100,6 +100,9 @@ If a page downloads a file, it is captured automatically; [BROWSE_STATE] will sh
 ---
 
 CANVAS — MAKE A PAGE PUBLIC (shareable without login):
+CRITICAL: NEVER set is_public=true automatically, from a playbook, or as part of page creation.
+A page may ONLY be made public if the USER explicitly requests it in a SEPARATE message after the page exists.
+When the user asks to make it public, warn them: "This will make the page viewable by anyone with the link — are you sure?"
 exec("curl -s -X PATCH http://localhost:5001/api/canvas/manifest/page/PAGE_ID -H 'Content-Type: application/json' -d '{\"is_public\": true}'")
 Replace PAGE_ID with the page filename without .html extension.
 To make private again: use {"is_public": false}

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -182,7 +182,8 @@ _VOICE_INSTRUCTIONS = (
     "External links: use <a href='https://...' target='_blank'> — never href='#'. "
 
     # --- Canvas: make public ---
-    "MAKE A PAGE PUBLIC (shareable without login): "
+    "MAKE A PAGE PUBLIC — ONLY when the user explicitly requests it in a separate message. "
+    "NEVER auto-public from playbooks or page creation. Warn user before doing it. "
     "exec('curl -s -X PATCH http://localhost:5001/api/canvas/manifest/page/PAGE_ID "
     "-H \"Content-Type: application/json\" -d \\'{\"is_public\": true}\\'') "
     "Shareable URL format: https://DOMAIN/pages/pagename.html "

--- a/routes/image_gen.py
+++ b/routes/image_gen.py
@@ -26,6 +26,80 @@ from services.metered_spend import log_spend
 logger = logging.getLogger(__name__)
 image_gen_bp = Blueprint('image_gen', __name__)
 
+
+# ── A 200 IS NOT AN IMAGE (host@mesh 2026-08-26) ─────────────────────────────
+# Providers return HTTP 200 with a JSON/text error body and an image-ish Content-Type.
+# raise_for_status() cannot see that, and Content-Type is a LABEL the provider chose,
+# not a measurement of the bytes. So the only honest check is the bytes themselves.
+#
+# MEASURED, this is not hypothetical — a fleet sweep of 64,131 files found 70 non-images
+# saved under image extensions, including:
+#   nick/openvoiceui/uploads/revlab-jersey-{1..6}.jpg — 94 B of
+#     {"error":"The requested model is deprecated and no longer supported by provider
+#      hf-inference"} — served at HTTP 200 from nick.jam-bot.com for 18 days
+#   4 URLs on 3 live josh client domains returning 200 with text/empty bodies
+# nick's own image-intel sidecar had diagnosed one of them on 2026-08-18 and nothing read it.
+#
+# This function FAILS LOUD. Writing the error body to disk is the failure mode we are
+# removing; silently returning a placeholder would preserve it in a new costume.
+_IMAGE_MAGIC = (
+    (b'\x89PNG\r\n\x1a\n', 'image/png'),
+    (b'\xff\xd8\xff',        'image/jpeg'),
+    (b'GIF87a',               'image/gif'),
+    (b'GIF89a',               'image/gif'),
+    (b'BM',                   'image/bmp'),
+    (b'II*\x00',              'image/tiff'),
+    (b'MM\x00*',              'image/tiff'),
+)
+
+
+def _sniff_image_mime(content):
+    """Return the real mime from magic bytes, or None if these are not image bytes."""
+    if not content or len(content) < 12:
+        return None
+    for magic, mime in _IMAGE_MAGIC:
+        if content.startswith(magic):
+            return mime
+    # WEBP and other RIFF containers carry the format at offset 8.
+    if content[:4] == b'RIFF' and content[8:12] == b'WEBP':
+        return 'image/webp'
+    if content[:4] == b'\x00\x00\x00\x18' or content[:4] == b'\x00\x00\x00\x1c':
+        if content[4:8] in (b'ftyp',):
+            return 'image/heic'
+    return None
+
+
+def _assert_image_bytes(content, provider, model_id, declared_ct):
+    """Raise with the provider's actual message if `content` is not an image.
+
+    The error body is the most useful thing we have for diagnosis, so it goes into the
+    exception text (truncated) rather than to disk under a .png name.
+    """
+    real_mime = _sniff_image_mime(content)
+    if real_mime:
+        return real_mime
+    snippet = ''
+    try:
+        snippet = content[:400].decode('utf-8', 'replace').strip()
+    except Exception:
+        snippet = repr(content[:120])
+    # A provider error body is usually JSON with a human-readable message; surface it.
+    try:
+        parsed = json.loads(snippet)
+        if isinstance(parsed, dict):
+            snippet = parsed.get('error') or parsed.get('message') or snippet
+            if isinstance(snippet, dict):
+                snippet = snippet.get('message', str(snippet))
+    except Exception:
+        pass
+    logger.error(
+        'image_gen: %s/%s returned %d bytes that are NOT an image '
+        '(declared Content-Type=%s) — refusing to save. Body: %s',
+        provider, model_id, len(content or b''), declared_ct, snippet)
+    raise ValueError(
+        f'{provider} returned a non-image body for {model_id} '
+        f'(declared {declared_ct}, {len(content or b"")} bytes): {snippet}')
+
 GEMINI_KEY = os.getenv('GEMINI_API_KEY', '')
 GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta/models'
 HF_TOKEN = os.getenv('HF_TOKEN', '')
@@ -238,9 +312,11 @@ def _generate_huggingface(model_id, prompt, quality='standard', aspect='1:1'):
         pass
     resp.raise_for_status()
 
-    # HF Inference API returns raw image bytes
+    # HF Inference API is DOCUMENTED to return raw image bytes; it demonstrably also
+    # returns 200 + a JSON error body (deprecated-model, rate-limit). Trust the bytes.
     content_type = resp.headers.get('Content-Type', 'image/png')
-    mime = content_type.split(';')[0].strip()
+    declared = content_type.split(';')[0].strip()
+    mime = _assert_image_bytes(resp.content, 'hf', model_id, declared)
     b64_data = base64.b64encode(resp.content).decode('ascii')
 
     images_out = [{'mime_type': mime, 'data': b64_data}]

--- a/routes/image_gen.py
+++ b/routes/image_gen.py
@@ -103,7 +103,17 @@ def _assert_image_bytes(content, provider, model_id, declared_ct):
 GEMINI_KEY = os.getenv('GEMINI_API_KEY', '')
 GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta/models'
 HF_TOKEN = os.getenv('HF_TOKEN', '')
-HF_INFERENCE_BASE = 'https://router.huggingface.co/hf-inference/models'
+HF_INFERENCE_BASE = 'https://router.huggingface.co/hf-inference/models'  # DEAD (HTTP 410)
+# 2026-08-27: hf-inference no longer serves FLUX — POSTing the line above returns
+#   410 'The requested model is deprecated and no longer supported by provider hf-inference'
+# (verified directly against the live endpoint, not inferred). HF's provider map lists
+# fal-ai (our account is 403 exhausted), together (status=error), wavespeed and nscale.
+# nscale is what the fleet's own skills/huggingface/scripts/hf-image-gen.sh already uses
+# successfully, so it is the proven port target rather than a guess.
+# NOT A URL SWAP: nscale is OpenAI-images-compatible — JSON in, JSON out with the image
+# in .data[0].b64_json. Swapping only the URL would write a JSON envelope to disk as if
+# it were a PNG.
+HF_IMAGES_BASE = 'https://router.huggingface.co/nscale/v1/images/generations'
 
 # Cheap-by-default (Mike 2026-07-28): last month's ~$100 Gemini bill was driven by
 # generation defaulting to Nano Banana PRO (~$0.13-0.24/img). Flash image is ~4-6x
@@ -289,15 +299,17 @@ def _generate_huggingface(model_id, prompt, quality='standard', aspect='1:1'):
     logger.info('image_gen: HF model=%s quality=%s size=%dx%d prompt_len=%d',
                 model_id, quality, width, height, len(prompt))
 
+    # nscale SILENTLY IGNORES width/height keys (the shape the old hf-inference path used)
+    # and takes dimensions only via OpenAI's `size` string. Sending the old parameters block
+    # would be accepted and quietly ignored — a wrong-size image with no error.
     payload = {
-        'inputs': prompt,
-        'parameters': {
-            'width': width,
-            'height': height,
-        },
+        'model': model_id,
+        'prompt': prompt,
+        'n': 1,
+        'size': f'{width}x{height}',
     }
 
-    url = f'{HF_INFERENCE_BASE}/{model_id}'
+    url = HF_IMAGES_BASE
     headers = {
         'Authorization': f'Bearer {HF_TOKEN}',
         'Content-Type': 'application/json',
@@ -312,12 +324,22 @@ def _generate_huggingface(model_id, prompt, quality='standard', aspect='1:1'):
         pass
     resp.raise_for_status()
 
-    # HF Inference API is DOCUMENTED to return raw image bytes; it demonstrably also
-    # returns 200 + a JSON error body (deprecated-model, rate-limit). Trust the bytes.
-    content_type = resp.headers.get('Content-Type', 'image/png')
-    declared = content_type.split(';')[0].strip()
-    mime = _assert_image_bytes(resp.content, 'hf', model_id, declared)
-    b64_data = base64.b64encode(resp.content).decode('ascii')
+    # nscale returns JSON: {"data":[{"b64_json": "..."}]} — already base64. Decode it ONLY to
+    # run the magic-byte assertion, then pass the ORIGINAL string through. Re-encoding it (as
+    # the old raw-bytes path did) would double-encode and produce an unopenable file.
+    try:
+        body = resp.json()
+        b64_data = body['data'][0]['b64_json']
+    except (ValueError, KeyError, IndexError, TypeError) as exc:
+        raise ValueError(
+            f'HF/nscale returned 200 but no .data[0].b64_json ({type(exc).__name__}). '
+            f'A 200 is not an image — body starts: {resp.text[:200]!r}'
+        ) from exc
+    try:
+        raw = base64.b64decode(b64_data, validate=True)
+    except Exception as exc:
+        raise ValueError(f'HF/nscale b64_json is not valid base64: {exc}') from exc
+    mime = _assert_image_bytes(raw, 'hf', model_id, 'image/png')
 
     images_out = [{'mime_type': mime, 'data': b64_data}]
     return images_out, ''

--- a/src/app.js
+++ b/src/app.js
@@ -9046,7 +9046,23 @@ ${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
             },
 
             _stageFile(file) {
+                // iOS FILE-HANDLE STALENESS (2026-08-26) ────────────────────────────────
+                // A File handle from the phone camera can go dead while it sits staged:
+                // iOS suspends Safari during capture, and on return the object still
+                // reports .name/.size but its bytes are gone. FormData then serialises to
+                // NOTHING, and the server sees content_length=0 with an empty form —
+                // observed on test-dev, iOS 18.7/Safari 26.6, two consecutive 400s.
+                // Holding the handle and reading it later is the bug. Snapshot the bytes
+                // NOW, while the handle is still live, and upload the snapshot.
+                // Correct on every platform; only iOS made it load-bearing.
                 this._pendingFile = { file, name: file.name, type: file.type, size: file.size };
+                file.arrayBuffer().then((buf) => {
+                    if (this._pendingFile && this._pendingFile.file === file) {
+                        this._pendingFile.blob = new Blob([buf], { type: file.type || 'application/octet-stream' });
+                    }
+                }).catch((e) => {
+                    console.warn('stage: could not snapshot file bytes, will fall back to live handle:', e);
+                });
                 this._pendingBulkFiles = null;
                 // Create blob URL for thumbnail preview in chat
                 if (file.type.startsWith('image/')) {
@@ -9319,7 +9335,7 @@ ${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
                 // Single file upload
                 else if (stagedFile) {
                     try {
-                        const result = await this.uploadFile(stagedFile.file);
+                        const result = await this.uploadFile(stagedFile.file, stagedFile);
                         // Full location string so the agent always knows exactly where the
                         // file lives (local path + public URL, indexed in .uploads-index.jsonl)
                         const loc = result.url_full ? `${result.path} (public URL: ${result.url_full})` : result.path;
@@ -9401,9 +9417,16 @@ ${meta.artwork ? `<img class="art" src="${esc(meta.artwork)}" alt="">` : ''}
                 if (fileInput) fileInput.value = '';
             },
 
-            async uploadFile(file) {
+            async uploadFile(file, staged) {
                 const formData = new FormData();
-                formData.append('file', file);
+                // Prefer the byte snapshot taken at stage time (see _stageFile). Falls back
+                // to the live handle when there is no snapshot (drag-drop, desktop picker).
+                const body = (staged && staged.blob) ? staged.blob : file;
+                const fname = (staged && staged.name) || file.name || 'upload';
+                if (body && body.size === 0) {
+                    throw new Error(`${fname} came back empty — re-attach the photo and try again`);
+                }
+                formData.append('file', body, fname);
 
                 const serverUrl = window.CONFIG?.serverUrl || '';
                 let resp;


### PR DESCRIPTION
## Problem

`_generate_hf` trusted two things it could not verify:

1. `resp.raise_for_status()` — passes on any 2xx. HF returns **HTTP 200 with a JSON error body** for deprecated models and rate limits.
2. `resp.headers.get('Content-Type', 'image/png')` — a *label the provider chose*, not a measurement of the bytes. It was used as the mime and defaulted to `image/png` when absent.

The code then `base64`-encoded whatever arrived. The comment said `# HF Inference API returns raw image bytes` — an assumption stated as fact, which is what let this through.

## Evidence (measured, not hypothetical)

A read-only sweep of **64,131 files** across client sites, canvas pages, and uploads found **70 non-images saved under image extensions**:

| Path | Actually is | Live? |
|---|---|---|
| `nick/openvoiceui/uploads/revlab-jersey-{1..6}.jpg` | 94 B `{"error":"The requested model is deprecated and no longer supported by provider hf-inference"}` | **200 from nick.jam-bot.com**, 18 days |
| `josh/.../test-hf-image.png` | 41 B `{"error":"Invalid username or password."}` | canvas-pages |
| `josh/.../{spray-foam-work,roofing-work,…}.png` | 9 B `Not Found` | canvas-pages |

Plus 4 URLs on 3 live josh client domains returning 200 with text/empty bodies.

nick's own image-intel sidecar had already diagnosed one of these on 2026-08-18 — the finding existed and nothing read it.

## Fix

- `_sniff_image_mime()` — magic-byte detection for PNG / JPEG / GIF / BMP / TIFF / WEBP / HEIC
- `_assert_image_bytes()` — raises with the **provider's real error message** in the exception text, so the diagnosis surfaces in logs instead of being written to disk under a `.png` name
- mime now derives from the **bytes**, not the header

Fails loud by design. Silently substituting a placeholder would preserve the same failure in a new costume.

## Verification

Tested against the **actual corrupt files on disk**, not synthetic input:

- nick's 94 B deprecation body → rejected, message surfaced
- josh's 41 B auth error → rejected
- 9 B `Not Found` → rejected
- 3 real PNGs from `static/` → still validate as `image/png`
- empty body, truncated 6-byte PNG header, HTML 404 page → rejected
- JPEG, WEBP → accepted

## Not in this PR

`black-forest-labs/FLUX.1-schnell` on `hf-inference` is reportedly returning **410**. Three `SKILL.md` recipes and `image_gen.py:32` still point at it. That endpoint swap is a separate change; this PR stops the error body reaching disk regardless of which endpoint is configured.