### PR TITLE
fix(transcripts): make a failing transcript writer visible instead of silent

### DIFF
--- a/routes/transcripts.py
+++ b/routes/transcripts.py
@@ -402,7 +402,15 @@ def save_conversation_turn(
         return f'transcripts/{date_str}/{filename}'
 
     except Exception as exc:
-        _transcript_logger.getLogger(__name__).debug(
-            f'save_conversation_turn failed (non-critical): {exc}'
+        # WAS logger.debug (invisible in normal operation). A transcript writer that
+        # silently stops is indistinguishable from a tenant who simply had no
+        # conversations -- which is exactly how tenant `ica` lost every dialogue turn
+        # from 2026-08-18 onward while its conversation_request events kept arriving.
+        # Nobody could see it, and the nightly reflection just reported an empty day.
+        # The write itself stays non-fatal (a failed transcript must never break a live
+        # voice call), but it is now VISIBLE and names the path so it is actionable.
+        _transcript_logger.getLogger(__name__).warning(
+            f'save_conversation_turn FAILED for session={session_id} '
+            f'dir={TRANSCRIPTS_DIR}: {type(exc).__name__}: {exc}'
         )
         return None


### PR DESCRIPTION
`save_conversation_turn()` logged failures at **DEBUG** and returned `None`. A transcript writer that silently stops is indistinguishable from a tenant who simply had no conversations.

Not hypothetical: tenant `ica` has written **no dialogue turns since 2026-08-18** while its `conversation_request` and `tts_sentence` events kept arriving through 08-27. Real conversations, no saved turns, nothing in any log, and a nightly reflection reporting an empty day. It surfaced only because that tenant's own agent escalated three times.

The write stays non-fatal — a failed transcript must never break a live voice call — but it is now a `WARNING` naming the session, the resolved directory and the exception type.

Verified by forcing a real failure (unwritable `TRANSCRIPTS_DIR`): returns `None` without raising, emits the warning, includes the path.

This does **not** explain ica's root cause. It is the instrument needed to find it — the reason nobody could diagnose it is that this handler threw the evidence away.