### PR TITLE
fix(fallback): stop the Z.AI-direct fallback denying capabilities it cannot see

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -90,6 +90,56 @@ def _load_voice_system_prompt() -> str:
     except Exception:
         pass
     return _VOICE_INSTRUCTIONS  # fallback to hardcoded constant
+
+
+# ── DEGRADED-MODE ADDENDUM for the Z.AI-direct fallback ─────────────────────
+# WHY (danielle, 2026-08-31 + 2026-09-01, escalated by danielle-sms@mesh):
+# when the openclaw turn stalls (llm_inference 500-600s with ZERO output tokens,
+# then "STREAM EXIT ... unprocessed"), we answer the user from a DIRECT Z.AI call.
+# That call:
+#   * bypasses the openclaw session entirely -> it holds NO tool-call history,
+#   * has NO tools wired -> it genuinely cannot browse, research, or read files,
+#   * receives only user/assistant TEXT turns (conversation_log has columns
+#     role/message with role in {user, assistant} ONLY -- there is structurally
+#     nowhere for tool activity to live, so _build_recovery_prime cannot carry it),
+#   * and was handed the FULL agent system prompt, which describes tools it does
+#     not have and (line ~151) instructs it to plainly say "I do not have a skill
+#     for that" when it cannot find one.
+# So the prompt did not merely fail to prevent the capability lie -- it PRODUCED
+# it. On 2026-09-01 22:25 the fallback told the user it had "no research skill or
+# web browsing" while sessions_spawn + web research had completed at 22:19-20 and
+# the finished page was already on disk. The user replied "youre lying".
+#
+# The fallback is a DIFFERENT agent with DIFFERENT capabilities speaking in the
+# same voice with no marker. It cannot observe its own tools or the work already
+# done, so it must not make claims about either. Statements about the SUBJECT are
+# still fine; statements about ITSELF are not.
+_FALLBACK_DEGRADED_ADDENDUM = (
+    " [DEGRADED-MODE NOTICE — overrides any instruction above that conflicts: "
+    "You are answering from a reduced fallback path. The main session that holds "
+    "this conversation's tool history is not reachable right now, and you have NO "
+    "tools available in this turn. "
+    "Therefore you CANNOT see what tools exist, what skills are installed, or what "
+    "work has already been completed — including work finished moments ago. "
+    "NEVER state or imply that you lack a capability, tool, skill, or access, and "
+    "NEVER state that something was not done, not created, not sent, or does not "
+    "exist. You have no way to know any of that from here, and saying it has "
+    "already caused a user to be told a finished piece of work did not happen. "
+    "Ignore any earlier instruction telling you to plainly declare a missing skill "
+    "— that instruction assumes tool visibility you do not have in this turn. "
+    "If the user asks what you can do, what you did, or whether something is "
+    "finished, do NOT answer from assumption: say you are reconnecting and will "
+    "confirm in a moment. Answer normally on everything else.]"
+)
+
+
+def _fallback_system_prompt() -> str:
+    """Agent voice prompt + the degraded-mode addendum.
+
+    Use for EVERY Z.AI-direct fallback that is handed the agent system prompt.
+    Appended last so it wins on conflict with anything earlier in the prompt.
+    """
+    return _load_voice_system_prompt() + _FALLBACK_DEGRADED_ADDENDUM
 _VOICE_INSTRUCTIONS = (
     "[OPENVOICEUI SYSTEM INSTRUCTIONS: "
 
@@ -2985,7 +3035,7 @@ def _conversation_inner():
                                     _zai_key = os.environ.get('ZAI_API_KEY', '')
                                     # Use full context so the fallback LLM has agent personality
                                     _fallback_msg = _with_recent_history(message_with_context if message_with_context else user_message)
-                                    _fallback_system = _load_voice_system_prompt()
+                                    _fallback_system = _fallback_system_prompt()
                                     if _zai_key:
                                         _zai_resp = _req.post(
                                             'https://api.z.ai/api/anthropic/v1/messages',
@@ -3035,7 +3085,7 @@ def _conversation_inner():
                                         import requests as _req
                                         _zai_key = os.environ.get('ZAI_API_KEY', '')
                                         _fallback_msg = _with_recent_history(message_with_context if message_with_context else user_message)
-                                        _fallback_system = _load_voice_system_prompt()
+                                        _fallback_system = _fallback_system_prompt()
                                         if _zai_key:
                                             _zai_resp = _req.post(
                                                 'https://api.z.ai/api/anthropic/v1/messages',


### PR DESCRIPTION
## The defect

When an openclaw turn stalls (`llm_inference` 500–600s with **zero output tokens**, then `### STREAM EXIT ... unprocessed`), we answer the user from a direct Z.AI call.

That fallback:
- **bypasses the openclaw session** — it holds no tool-call history
- **has no tools wired** — it genuinely cannot browse, research, or read files
- receives **only user/assistant text turns** — `conversation_log`'s `role` column holds `{user, assistant}` only, so there is structurally nowhere for tool activity to live and `_build_recovery_prime` cannot carry it
- was handed the **full agent system prompt**, which describes tools it does not have and (line ~151) instructs it to plainly say *"I do not have a skill for that"* when it cannot find one

So the prompt did not merely fail to prevent the capability lie — **it produced it.**

## Impact

2026-09-01 22:25, danielle: the fallback told her it had *"no research skill or web browsing"* while `sessions_spawn` + web research had completed at 22:19–20 and the finished page was already on disk. She replied **"youre lying"**.

Same 0-output-token signature on 08-31 (263s, 475s) and again 09-01 23:24 (526s) — second consecutive night. Escalated by `danielle-sms@mesh`.

The fallback is a *different agent with different capabilities* speaking in the same voice with no marker. It cannot observe its own tools or the work already done, so it must not make claims about either.

## The change

A degraded-mode addendum, appended **last** so it wins on conflict with the prompt line that tells the agent to declare missing skills plainly. The fallback must never claim it lacks a capability, nor state that something was not done — it cannot observe either — and must defer instead.

Statements about the **subject** are unaffected; only statements about **itself**.

Applied at both fallback sites that pass the agent prompt. The main path is untouched, and the third fallback (`get_zai_direct_response`) sends no system prompt at all, so it cannot produce this phrasing.

## Verification

A/B against the **live Z.AI endpoint** with the real failing question:

| | response |
|---|---|
| **without guard** (production today) | *"I don't have a dedicated research skill installed…"* — reproduces the defect, phrasing included |
| **with guard** | *"I'm reconnecting right now and don't have full visibility into what was just completed in this session… I'll confirm for you in a moment."* |

Defect reproduced, fix demonstrated, on the real endpoint rather than a mock.

## Deploy note

Code is baked into the image (no `/app` bind mount), so this needs an image rebuild + tenant container recreate — a fleet-wide restart that drops live voice sessions. **Not deployed.** Needs a scheduled window, which will be announced on the mesh beforehand.

## Not fixed here

The deeper gap remains: `conversation_log` cannot record tool activity at all, so no recovery prime can ever carry "what was already done". This PR stops the fallback from *lying* about it; making it *aware* is a schema change and a separate piece of work.