### PR TITLE
Jingle length honesty + single Gemini vision path (key out of the URL)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,8 @@ app/static/canvas-pages/
 # never committed. The committed template is .platform-oauth.env.example.
 .platform-oauth.env
 routes/song_tagger.py
+
+# Dated pre-change backups (never-delete convention). The existing `*.bak` rule
+# does NOT match these: `vision.py.bak-pre-gemini-20260906T023605Z` has a suffix
+# AFTER .bak, so it showed as untracked and looked like pending work.
+*.bak-*

--- a/routes/suno.py
+++ b/routes/suno.py
@@ -719,6 +719,36 @@ def _action_sfx(_q, body: dict):
         return jsonify({'action': 'error', 'response': f"Couldn't reach Suno API: {exc}"})
 
 
+# ── JINGLE LENGTH HONESTY (host@mesh 2026-09-06, Mike's request) ──────────────
+# Suno's jingle recipe is NOT length-deterministic. Measured over the whole task
+# log: 13 jingle requests -> 72 generations, only 16 came back <=20s. That is a
+# 22% hit rate, with the SAME parameters returning 9.2s and 167.8s on adjacent
+# attempts. The skill doc's own row calls this recipe "v1 untested".
+#
+# The defect was ours, not Suno's: nothing checked the length, so a 44s and a
+# 139s clip were both saved and announced as finished jingles. Mike had to be the
+# duration check himself, by listening, four times in a row. A system that
+# reports success on output that misses the spec it was handed is the same
+# failure as a form POST returning 200 on a lead it never stored.
+#
+# We do NOT auto-retry — each attempt costs credits, and at a 22% hit rate that
+# is ~4 generations per usable jingle. We tell the truth and OFFER.
+JINGLE_TARGET_MAX_S = 20.0
+
+def _jingle_length_note(kind: str, duration, title: str) -> str:
+    """Return '' when the clip is a usable jingle, else an honest note + retry offer."""
+    if kind != 'jingle':
+        return ''
+    try:
+        secs = float(duration or 0)
+    except (TypeError, ValueError):
+        return ''
+    if secs <= 0 or secs <= JINGLE_TARGET_MAX_S:
+        return ''
+    return (f" Heads up: this one came back {secs:.0f}s, longer than the short jingle"
+            f" you asked for. Suno doesn't always hit an exact length — it's a bit of a"
+            f" lottery on short clips. Want me to try again?")
+
 def _action_jingle(_q, body: dict):
     """Generate a 10-15 second vocal-logo jingle of a brand name.
 
@@ -927,7 +957,10 @@ def _action_status(job_id: str):
             'song_id': job.get('song_id', ''),
             'title': job.get('title', 'Generated Track'),
             'url': job.get('url', ''),
-            'response': f"Done! '{job.get('title', 'your track')}' is ready to spin!",
+            'response': (f"Done! '{job.get('title', 'your track')}' is ready to spin!"
+                         + _jingle_length_note(job.get('kind', 'song'),
+                                               job.get('duration', 0),
+                                               job.get('title', 'your track'))),
         })
 
     elapsed = time.time() - job['created_at']
@@ -1089,7 +1122,9 @@ def _action_status(job_id: str):
                             'song_id': song_id,
                             'title': song_title,
                             'url': f'{_url_base}/{filename}',
-                            'response': f"Done! '{song_title}' is ready to spin!",
+                            'response': (f"Done! '{song_title}' is ready to spin!"
+                                         + _jingle_length_note(kind, duration, song_title)),
+                            'duration_seconds': round(float(duration or 0), 1),
                         })
 
                     return jsonify({'action': 'status', 'status': 'complete_no_audio', 'response': 'Song generated but audio unavailable.'})

--- a/routes/vision.py
+++ b/routes/vision.py
@@ -81,8 +81,18 @@ VISION_MODELS = [
     {'id': 'glm-4v-plus',   'label': 'GLM-4V Plus (Legacy · Paid)',     'provider': 'zai'},
 ]
 
-DEFAULT_VISION_MODEL    = os.environ.get('VISION_MODEL', 'glm-4.6v')
-DEFAULT_VISION_PROVIDER = 'zai'
+# Gemini is THE vision provider for this stack (Mike, 2026-09-06), matching the openclaw
+# media chain in openclaw.json which is confirmed working on the same test images.
+#
+# ⚠️ DO NOT point this at Z.AI/GLM. GLM models ARE vision-capable, but the endpoint we are
+# mandated to use (api.z.ai/api/anthropic) SILENTLY STRIPS IMAGE CONTENT — measured 2026-05-05
+# against one screenshot on glm-5.1 / glm-5 / glm-5-turbo / glm-4.5v: every one confidently
+# described a desktop that does not exist. The same glm-4.5v on the native paas/v4 endpoint was
+# correct. A stripped image does not error; the model confabulates, which is worse than a failure.
+# Until openclaw's zaiProvider routes image requests via paas/v4, Z.AI is text-only here.
+DEFAULT_VISION_MODEL    = os.environ.get('VISION_MODEL', 'gemini-flash-latest')
+DEFAULT_VISION_FALLBACK = os.environ.get('VISION_MODEL_FALLBACK', 'gemini-pro-latest')
+DEFAULT_VISION_PROVIDER = 'google'
 
 
 def _get_vision_model() -> tuple[str, str]:
@@ -154,62 +164,82 @@ def _call_vision_via_claude(container_img_path: str, prompt: str) -> str:
     return result
 
 
-def _call_vision(image_b64: str, prompt: str, model: str | None = None, file_path: str | None = None) -> str:
-    """
-    Send an image + prompt to the configured vision model and return the text response.
-
-    For uploaded image files (file_path provided): routes through headless Claude Code
-    subscription via docker run — no Groq/Gemini/OpenAI, no marginal cost.
-    For camera frames (no file_path): uses Groq qwen3.6-27b as before.
-
-    image_b64 may be a raw base64 string or a data-URI (data:image/jpeg;base64,...).
-    """
-    # Uploaded files: use Claude subscription (image-intel system pattern)
-    if file_path:
-        return _call_vision_via_claude(file_path, prompt)
-
-    # Camera frames: Groq path (in-memory frames have no on-disk path)
-    # Strip data-URI prefix if present
-    if image_b64.startswith('data:'):
-        image_b64 = image_b64.split(',', 1)[1]
-
-    api_key = os.environ.get('GROQ_API_KEY', '')
-    if not api_key:
-        raise ValueError('GROQ_API_KEY is not set — cannot call vision model for camera frame')
-
-    vision_model = os.environ.get('GROQ_VISION_MODEL', 'qwen/qwen3.6-27b')
-
-    payload = {
-        'model': vision_model,
-        'messages': [{
-            'role': 'user',
-            'content': [
-                {'type': 'image_url',
-                 'image_url': {'url': f'data:image/png;base64,{image_b64}'}},
-                {'type': 'text', 'text': prompt},
-            ],
-        }],
-        'max_tokens': 1500,
-        # qwen3 is a reasoning model — without this its <think> tokens eat the
-        # budget and can leak into the returned description
-        'reasoning_format': 'hidden',
-    }
-
+def _gemini_vision(image_b64: str, mime: str, prompt: str, model: str) -> str:
+    """One Gemini generateContent call. Raises on non-2xx so the caller can fall back."""
+    key = os.environ.get('GEMINI_API_KEY', '')
+    if not key:
+        raise ValueError('GEMINI_API_KEY is not set — cannot call vision model')
+    # KEY GOES IN A HEADER, NEVER THE URL. Gemini accepts ?key= as a query param, but requests'
+    # HTTPError message embeds the full URL — so a single 404 on a bad model name writes the live
+    # GEMINI_API_KEY into the log, the exception, and any transcript that captures it. Measured
+    # 2026-09-06: a fallback test did exactly that. x-goog-api-key keeps it out of every error path.
     resp = requests.post(
-        'https://api.groq.com/openai/v1/chat/completions',
-        headers={
-            'Authorization': f'Bearer {api_key}',
-            'Content-Type': 'application/json',
-        },
-        json=payload,
-        timeout=30,
+        f'https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent',
+        headers={'x-goog-api-key': key},
+        json={'contents': [{'parts': [
+            {'text': prompt},
+            {'inline_data': {'mime_type': mime, 'data': image_b64}},
+        ]}]},
+        timeout=60,
     )
     resp.raise_for_status()
-    text = (resp.json()['choices'][0]['message']['content'] or '').strip()
-    # Defense in depth: strip any <think> block if reasoning_format was ignored
-    if '</think>' in text:
-        text = text.rsplit('</think>', 1)[1].strip()
-    return text
+    cands = resp.json().get('candidates') or []
+    if not cands:
+        raise RuntimeError('gemini returned no candidates')
+    return (cands[0]['content']['parts'][0].get('text') or '').strip()
+
+
+def _call_vision(image_b64: str, prompt: str, model: str | None = None, file_path: str | None = None) -> str:
+    """
+    Send an image + prompt to Gemini and return the text response.
+
+    ONE path for uploads and camera frames alike (2026-09-06). What this replaced, and why:
+
+      * uploaded files spawned a whole container per image —
+        `docker run --rm -v /mnt:/mnt:ro jambot/openclaw:latest claude -p --model claude-sonnet-5`
+        — a container launch, a 90s timeout, and the entire /mnt tree (every tenant's data and
+        .platform-keys.env) bind-mounted in, to look at one picture. Retained below as
+        _call_vision_via_claude() for reference; no longer called.
+      * camera frames were hardcoded to Groq qwen3.6-27b, bypassing the configured provider
+        entirely — while this stack's standing rule is that Groq is STT/TTS only.
+      * _get_vision_model() was read and its result DISCARDED: the `model` argument existed and
+        was never used, so the configured vision model had no effect on anything.
+
+    image_b64 may be raw base64 or a data-URI. file_path (a path inside this container) is read
+    from disk when no base64 is supplied.
+    """
+    mime = 'image/png'
+
+    if not image_b64 and file_path:
+        p = Path(file_path)
+        if not p.is_file():
+            raise FileNotFoundError(f'vision: no such image {file_path}')
+        image_b64 = base64.b64encode(p.read_bytes()).decode()
+        ext = p.suffix.lower()
+        mime = {'.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.webp': 'image/webp',
+                '.gif': 'image/gif'}.get(ext, 'image/png')
+
+    if image_b64.startswith('data:'):
+        head, image_b64 = image_b64.split(',', 1)
+        if ';' in head and ':' in head:
+            mime = head.split(':', 1)[1].split(';', 1)[0] or mime
+
+    if not image_b64:
+        raise ValueError('vision: no image supplied (need image_b64 or file_path)')
+
+    primary = model or _get_vision_model()[0]
+    chain = [m for m in (primary, DEFAULT_VISION_FALLBACK) if m]
+    last = None
+    for m in chain:
+        try:
+            return _gemini_vision(image_b64, mime, prompt, m)
+        except Exception as exc:            # try the next model in the chain
+            last = exc
+            # Scrub any key= / api-key that a library put in the message before it is logged.
+            msg = re.sub(r'(key=|api[-_]?key["\':\s]+)[A-Za-z0-9._\-]{8,}', r'\1<redacted>',
+                         str(exc), flags=re.I)
+            logger.warning('vision: %s failed (%s) — trying next in chain', m, msg[:200])
+    raise RuntimeError(f'all vision models failed; last error: {last}')
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Three commits, three files.

**`08057ac` fix(vision)** — one Gemini path for uploads and camera frames. Moves the API key out of the URL query string into an `x-goog-api-key` header, and removes a container-per-image plus a hardcoded Groq call that were never the configured provider.

**`7a36430` chore** — gitignore dated `.bak-<label>-<ts>` backups.

**`2a6dd02` feat(suno)** — jingle length honesty. Suno's jingle recipe is not length-deterministic: measured across the whole task log, 13 jingle requests produced 72 generations and only 16 came back at or under 20s. A 22% hit rate, with identical parameters returning 9.2s and 167.8s on adjacent attempts. Nothing checked the length, so 44s and 139s clips were both saved and announced as finished jingles — the user had to be the duration check, by listening, four times.

The completion response now states the real length and offers a retry rather than taking one, since each attempt costs credits:

> Heads up: this one came back 45s, longer than the short jingle you asked for. Suno doesn't always hit an exact length — it's a bit of a lottery on short clips. Want me to try again?

Both completion sites are covered (poller and already-complete), and the poller response now carries `duration_seconds` so callers never infer length from the file.

Verified against the real durations from the reported session: 9.2 / 9.9 / 13.7 / 20.0 stay quiet; 44.7 / 139.8 / 167.8 warn; `kind=song` stays quiet at 139.8s; `None` and `0` stay quiet.