### PR TITLE
release: 2026.9.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openvoiceui",
-  "version": "2026.6.9",
+  "version": "2026.9.7",
   "description": "Voice-powered AI assistant platform \u2014 connect any LLM, any TTS, with a live web canvas, music generation, and agent orchestration",
   "bin": {
     "openvoiceui": "cli/index.js"


### PR DESCRIPTION
CalVer `YYYY.M.D` per `RELEASING.md`. Bundles all work since `v2026.7.15` (88 non-merge commits).

Also closes a version-reporting drift: `package.json` was still `2026.6.9` because the `v2026.7.15` release was tagged without bumping it. `server.py:550` reads that file into `_VERSION_INFO`, so the app has been self-reporting `2026.6.9` since June — verified on a live container before this change.