### PR TITLE
fix(canvas): manifest save failures return 500, not a false 200

### DIFF
--- a/routes/canvas.py
+++ b/routes/canvas.py
@@ -323,8 +323,13 @@ def load_canvas_manifest() -> dict:
     }
 
 
-def save_canvas_manifest(manifest: dict) -> None:
-    """Save manifest directly (Docker bind-mounted files don't support atomic rename)."""
+def save_canvas_manifest(manifest: dict) -> bool:
+    """Save manifest directly (Docker bind-mounted files don't support atomic rename).
+
+    Returns True on success, False on failure. Callers that turn this into an
+    HTTP response MUST check the result — a swallowed write failure previously
+    rendered as an HTTP 200 while the manifest silently failed to persist.
+    """
     manifest['last_updated'] = datetime.now().isoformat()
     try:
         data = json.dumps(manifest, indent=2)
@@ -332,8 +337,10 @@ def save_canvas_manifest(manifest: dict) -> None:
             f.write(data)
         _manifest_cache['data'] = copy.deepcopy(manifest)
         _manifest_cache['mtime'] = CANVAS_MANIFEST_PATH.stat().st_mtime
+        return True
     except Exception as exc:
         logging.getLogger(__name__).error(f'Failed to save canvas manifest: {exc}')
+        return False
 
 
 def suggest_category(title: str, content: str = '') -> str:
@@ -1314,7 +1321,8 @@ def handle_page_metadata(page_id):
                 except Exception as exc:
                     logger.warning(f'Failed to archive file {filename}: {exc}')
 
-            save_canvas_manifest(manifest)
+            if not save_canvas_manifest(manifest):
+                return jsonify({'status': 'error', 'error': 'manifest write failed — see server log'}), 500
             _notify_brain('canvas_page_deleted', page_id=page_id, title=page_title, filename=filename)
 
             try:
@@ -1403,7 +1411,8 @@ def handle_page_metadata(page_id):
                     if page_id not in manifest['categories'][new_cat]['pages']:
                         manifest['categories'][new_cat]['pages'].append(page_id)
 
-        save_canvas_manifest(manifest)
+        if not save_canvas_manifest(manifest):
+            return jsonify({'status': 'error', 'error': 'manifest write failed — see server log'}), 500
         return jsonify({'status': 'ok', 'page': page})
 
 
@@ -1429,7 +1438,8 @@ def handle_category():
                 'color': data.get('color', '#4a9eff'),
                 'pages': [],
             }
-            save_canvas_manifest(manifest)
+            if not save_canvas_manifest(manifest):
+                return jsonify({'status': 'error', 'error': 'manifest write failed — see server log'}), 500
             return jsonify({'status': 'ok', 'category': manifest['categories'][cat_id]})
 
         # PATCH
@@ -1440,7 +1450,8 @@ def handle_category():
         for field in ['name', 'icon', 'color']:
             if field in data:
                 manifest['categories'][cat_id][field] = data[field]
-        save_canvas_manifest(manifest)
+        if not save_canvas_manifest(manifest):
+            return jsonify({'status': 'error', 'error': 'manifest write failed — see server log'}), 500
         return jsonify({'status': 'ok', 'category': manifest['categories'][cat_id]})
 
 
@@ -1852,11 +1863,15 @@ def restore_page_version(page_id, timestamp):
         return jsonify({'error': 'Version not found or restore failed'}), 404
 
     # Update manifest modified time
+    manifest_save_ok = True
     with _manifest_lock:
         manifest = load_canvas_manifest()
         if page_id in manifest.get('pages', {}):
             manifest['pages'][page_id]['modified'] = datetime.now().isoformat()
-            save_canvas_manifest(manifest)
+            manifest_save_ok = save_canvas_manifest(manifest)
+
+    if not manifest_save_ok:
+        return jsonify({'status': 'error', 'error': 'manifest write failed — see server log'}), 500
 
     return jsonify({
         'status': 'ok',

--- a/tests/test_routes_canvas.py
+++ b/tests/test_routes_canvas.py
@@ -179,3 +179,59 @@ class TestCanvasUpdate:
                 content_type="application/json",
             )
         assert resp.status_code in (200, 500)
+
+
+# ---------------------------------------------------------------------------
+# save_canvas_manifest() return value — a write failure must surface as a
+# result the caller can check, not a silent None (fleet-wide bug 2026-09-08:
+# [Errno 13] Permission denied on the bind-mounted manifest was swallowed and
+# every route still returned HTTP 200/'ok').
+# ---------------------------------------------------------------------------
+
+class TestSaveCanvasManifestReturnValue:
+    def test_returns_true_on_success(self, tmp_path, monkeypatch):
+        from routes import canvas
+        manifest_path = tmp_path / "canvas-manifest.json"
+        monkeypatch.setattr(canvas, "CANVAS_MANIFEST_PATH", manifest_path)
+        result = canvas.save_canvas_manifest({"pages": {}, "categories": {}})
+        assert result is True
+        assert manifest_path.exists()
+
+    def test_returns_false_on_write_failure(self, tmp_path, monkeypatch):
+        from routes import canvas
+        # Parent directory doesn't exist -> open() raises, caught by save_canvas_manifest
+        manifest_path = tmp_path / "missing-dir" / "canvas-manifest.json"
+        monkeypatch.setattr(canvas, "CANVAS_MANIFEST_PATH", manifest_path)
+        result = canvas.save_canvas_manifest({"pages": {}, "categories": {}})
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# API: PATCH /api/canvas/manifest/page/<page_id> — manifest write failure
+# must return 500, never a false 200/'ok'.
+# ---------------------------------------------------------------------------
+
+class TestHandlePageMetadataManifestWrite:
+    def test_patch_returns_500_when_manifest_write_fails(self, canvas_client):
+        manifest = {"pages": {"test-page": {"display_name": "Test"}}, "categories": {}}
+        with patch("routes.canvas.load_canvas_manifest", return_value=manifest), \
+             patch("routes.canvas.save_canvas_manifest", return_value=False):
+            resp = canvas_client.patch(
+                "/api/canvas/manifest/page/test-page",
+                json={"display_name": "New Name"},
+            )
+        assert resp.status_code == 500
+        data = resp.get_json()
+        assert data["status"] == "error"
+
+    def test_patch_returns_200_when_manifest_write_succeeds(self, canvas_client):
+        manifest = {"pages": {"test-page": {"display_name": "Test"}}, "categories": {}}
+        with patch("routes.canvas.load_canvas_manifest", return_value=manifest), \
+             patch("routes.canvas.save_canvas_manifest", return_value=True):
+            resp = canvas_client.patch(
+                "/api/canvas/manifest/page/test-page",
+                json={"display_name": "New Name"},
+            )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "ok"


### PR DESCRIPTION
save_canvas_manifest() swallowed write exceptions and returned None; every route caller then returned {'status':'ok'} regardless of whether the write succeeded.

Measured fleet-wide today: 14 tenants got `[Errno 13] Permission denied` writing `/app/runtime/canvas-manifest.json` on every PATCH (icon positions, page visibility, categories) while the browser and agent API both saw HTTP 200.

save_canvas_manifest() now returns bool; the route handlers that turn a save into an HTTP response (page metadata PATCH/DELETE, category POST/PATCH, version restore) check it and return 500 with a generic error on failure.

No behaviour change on the success path.