### PR TITLE
fix(gateway): boot warm-up retries until the gateway answers; entrypoint waits for the gateway port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,5 @@ ENV HOST=0.0.0.0
 
 EXPOSE 5001
 
+ENTRYPOINT ["./entrypoint.sh"]
 CMD ["python3", "server.py"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Waits for the OpenClaw gateway's TCP port to accept connections before
+# starting the Flask app. Docker restarts sibling containers without
+# compose `depends_on` ordering (e.g. after a host reboot), so
+# openvoiceui can otherwise come up before openclaw is listening — the
+# boot warm-up thread in server.py now retries indefinitely, but starting
+# the app only after the port answers avoids the failed-attempt noise in
+# the common case. Bounded: proceeds after 120s regardless, since
+# server.py's warm-up and per-request lazy connect are the real fallback
+# and must never be blocked forever by this wait.
+#
+# Reads CLAWDBOT_GATEWAY_URL (ws://host:port[/path]) — the same env var
+# server.py and services/gateways/openclaw.py read. If unset, skips the
+# wait entirely.
+
+set -e
+
+GATEWAY_URL="${CLAWDBOT_GATEWAY_URL:-}"
+
+if [ -n "$GATEWAY_URL" ]; then
+    # Strip scheme, then trailing path, then split host:port.
+    HOSTPORT=$(echo "$GATEWAY_URL" | sed -E 's#^wss?://##' | cut -d/ -f1)
+    GW_HOST=$(echo "$HOSTPORT" | cut -d: -f1)
+    GW_PORT=$(echo "$HOSTPORT" | cut -d: -f2)
+
+    if [ -n "$GW_HOST" ] && [ -n "$GW_PORT" ]; then
+        WAITED=0
+        MAX_WAIT=120
+        LAST_LOG=-10
+        while ! python3 -c "
+import socket, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.settimeout(2)
+try:
+    s.connect(('$GW_HOST', $GW_PORT))
+except Exception:
+    sys.exit(1)
+finally:
+    s.close()
+" 2>/dev/null; do
+            if [ "$WAITED" -ge "$MAX_WAIT" ]; then
+                echo "entrypoint: gateway $GW_HOST:$GW_PORT not up after ${MAX_WAIT}s — starting anyway (lazy connect will retry)"
+                break
+            fi
+            if [ $((WAITED - LAST_LOG)) -ge 10 ]; then
+                echo "entrypoint: waiting for gateway $GW_HOST:$GW_PORT ... (${WAITED}s)"
+                LAST_LOG=$WAITED
+            fi
+            sleep 2
+            WAITED=$((WAITED + 2))
+        done
+    fi
+fi
+
+exec "$@"

--- a/server.py
+++ b/server.py
@@ -1827,19 +1827,39 @@ def _warm_gateway_connection():
     """Open the persistent gateway WS at boot (it is otherwise lazy — first
     chat.send opens it). Without this, subagent completions that land after a
     server restart but before the first user message are invisible to the
-    orphan-continuation watcher."""
+    orphan-continuation watcher.
+
+    Docker restarts a container's dependencies without compose `depends_on`
+    ordering, so on a host reboot the openvoiceui container can come up
+    before its openclaw gateway is listening. `_ensure_connected()` only
+    makes 5 attempts before raising — without a retry here, the persistent
+    WS never opens and stays down until a user turn happens to call
+    `_ensure_connected()` lazily. So retry indefinitely in the background;
+    once a lazy connect (or a later warm-up attempt) succeeds,
+    `_ensure_connected()` short-circuits on `_connected` being True, so this
+    loop's next pass is a cheap no-op and simply returns.
+    """
     try:
         from services.gateway_manager import gateway_manager as _gm
+        from services.warmup_retry import retry_until_success
         _gw = _gm.get('openclaw')
         if _gw is None or not _gw.is_configured():
             return
         _conn = _gw._router._get_connection(None)
         _conn._ensure_started()
-        asyncio.run_coroutine_threadsafe(
-            _conn._ensure_connected(), _conn._loop).result(timeout=30)
-        logger.info("Gateway WS warmed at boot — orphan completion watcher live")
+
+        def _connect():
+            asyncio.run_coroutine_threadsafe(
+                _conn._ensure_connected(), _conn._loop).result(timeout=30)
+
+        def _log(msg):
+            logger.warning(f"Gateway boot warm-up {msg}")
+
+        attempts = retry_until_success(_connect, time.sleep, _log)
+        logger.info(f"Gateway WS warmed at boot after {attempts} attempt(s) — "
+                    f"orphan completion watcher live")
     except Exception as e:
-        logger.warning(f"Gateway boot warm-up failed (will connect lazily): {e}")
+        logger.warning(f"Gateway boot warm-up failed permanently (will connect lazily): {e}")
 
 
 threading.Thread(target=_warm_gateway_connection,

--- a/services/warmup_retry.py
+++ b/services/warmup_retry.py
@@ -1,0 +1,25 @@
+"""
+Generic retry-until-success loop, used by server.py's gateway boot warm-up.
+
+Split into its own module (no side effects on import) so it can be unit
+tested without pulling in server.py's module-level app/thread setup or
+gateway_manager's module-level gateway registration.
+"""
+
+
+def retry_until_success(connect_fn, sleep_fn, log, delay_seconds=30):
+    """Call `connect_fn()` repeatedly until it does not raise, sleeping
+    `delay_seconds` (via `sleep_fn`) between attempts and reporting each
+    failure through `log`. Returns the 1-based attempt number that
+    succeeded. Never gives up — callers that need a cap should wrap this
+    in their own bounded loop.
+    """
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            connect_fn()
+            return attempt
+        except Exception as e:
+            log(f"attempt {attempt} failed ({e}) — retrying in {delay_seconds}s")
+            sleep_fn(delay_seconds)

--- a/tests/test_warmup_retry.py
+++ b/tests/test_warmup_retry.py
@@ -1,0 +1,61 @@
+"""
+Tests for services.warmup_retry.retry_until_success — the gateway boot
+warm-up retry loop (server.py's _warm_gateway_connection). Docker restarts
+containers without compose `depends_on` ordering, so openvoiceui can come
+up before its openclaw gateway is listening; this loop is what keeps the
+boot warm-up from giving up after the underlying connect's fixed 5
+attempts.
+"""
+
+from services.warmup_retry import retry_until_success
+
+
+def test_retries_until_success_then_stops():
+    calls = {"connect": 0, "sleep": 0}
+    logs = []
+
+    def connect_fn():
+        calls["connect"] += 1
+        if calls["connect"] < 3:
+            raise RuntimeError("Failed to connect to Gateway after 5 attempts")
+        # third call succeeds
+
+    def sleep_fn(seconds):
+        calls["sleep"] += 1
+
+    attempt = retry_until_success(connect_fn, sleep_fn, logs.append)
+
+    assert attempt == 3
+    assert calls["connect"] == 3
+    assert calls["sleep"] == 2
+    assert len(logs) == 2
+    assert "attempt 1 failed" in logs[0]
+    assert "attempt 2 failed" in logs[1]
+
+
+def test_succeeds_immediately_without_sleeping():
+    calls = {"connect": 0, "sleep": 0}
+
+    def connect_fn():
+        calls["connect"] += 1
+
+    def sleep_fn(seconds):
+        calls["sleep"] += 1
+
+    attempt = retry_until_success(connect_fn, sleep_fn, lambda msg: None)
+
+    assert attempt == 1
+    assert calls["connect"] == 1
+    assert calls["sleep"] == 0
+
+
+def test_uses_given_delay_seconds():
+    delays = []
+
+    def connect_fn():
+        if len(delays) < 1:
+            raise RuntimeError("boom")
+
+    retry_until_success(connect_fn, delays.append, lambda msg: None, delay_seconds=5)
+
+    assert delays == [5]


### PR DESCRIPTION
## Summary

Measured 2026-09-08 07:03Z host reboot: all 28 tenant openvoiceui containers started before their openclaw gateway was listening (Docker restarts sibling containers without compose `depends_on` ordering). `server.py`'s `_warm_gateway_connection()` called `_ensure_connected()` once, which makes a fixed 5 attempts (backoff 2/4/8/16s) then raises — the warmup logged "will connect lazily" and never retried. The persistent gateway WS stayed down until a user turn happened to call `_ensure_connected()`; one tenant reconnected that way at 14:02Z, 27 stayed down for 8h53m. Proactive pushes (orphan-continuation watcher, `/ws/clawdbot` broadcasts) depend on that link.

## Changes

- `server.py` (`_warm_gateway_connection`, ~L1826-1863): retries the boot warm-up indefinitely (30s between attempts) instead of giving up after one round of 5. A later lazy connect from a real user turn is harmless — `_ensure_connected()` short-circuits once `_connected` is `True`, so the warm-up loop's next pass just returns.
- `services/warmup_retry.py` (new): the retry loop extracted into its own side-effect-free module so it's unit-testable without pulling in `server.py`'s module-level app/thread setup.
- `entrypoint.sh` (new) + `Dockerfile`: waits up to 120s for `CLAWDBOT_GATEWAY_URL`'s host:port to accept a TCP connection before exec'ing `python3 server.py`. Skips the wait if the env var is unset, and always proceeds after 120s — the server-side retry above is the real fallback, this just avoids the failed-attempt noise in the common case.
- `tests/test_warmup_retry.py` (new): 3 tests against a fake connect function (fails twice then succeeds, succeeds immediately, custom delay). `python -m pytest tests/test_warmup_retry.py -q` → `3 passed`.

No behaviour change once connected.