### PR TITLE
fix(zai): direct Z.AI calls fall back to secondary key on cap 429

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -10,8 +10,9 @@ NEVER Groq — Groq is TTS only, never for LLM.
 import logging
 import os
 
-import requests
 from flask import Blueprint, jsonify, request
+
+from services.zai_direct import zai_messages_post
 
 logger = logging.getLogger(__name__)
 
@@ -26,18 +27,13 @@ def chat_complete():
         return jsonify({'error': 'No message provided'}), 400
 
     api_key = os.environ.get('ZAI_API_KEY', '')
-    if not api_key:
+    fallback_key = os.environ.get('ZAI_FALLBACK_API_KEY', '')
+    if not api_key and not fallback_key:
         return jsonify({'error': 'ZAI_API_KEY not configured'}), 500
 
     try:
-        r = requests.post(
-            'https://api.z.ai/api/anthropic/v1/messages',
-            headers={
-                'x-api-key': api_key,
-                'anthropic-version': '2023-06-01',
-                'content-type': 'application/json',
-            },
-            json={
+        r = zai_messages_post(
+            {
                 'model': 'glm-5-turbo',
                 'messages': [{'role': 'user', 'content': message}],
                 'max_tokens': 1024,

--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -3031,20 +3031,15 @@ def _conversation_inner():
 
                                 # 4. Z.AI direct fallback for this message (NEVER Groq — Groq is TTS only)
                                 try:
-                                    import requests as _req
+                                    from services.zai_direct import zai_messages_post
                                     _zai_key = os.environ.get('ZAI_API_KEY', '')
+                                    _zai_fb_key = os.environ.get('ZAI_FALLBACK_API_KEY', '')
                                     # Use full context so the fallback LLM has agent personality
                                     _fallback_msg = _with_recent_history(message_with_context if message_with_context else user_message)
                                     _fallback_system = _fallback_system_prompt()
-                                    if _zai_key:
-                                        _zai_resp = _req.post(
-                                            'https://api.z.ai/api/anthropic/v1/messages',
-                                            headers={
-                                                'x-api-key': _zai_key,
-                                                'anthropic-version': '2023-06-01',
-                                                'content-type': 'application/json',
-                                            },
-                                            json={
+                                    if _zai_key or _zai_fb_key:
+                                        _zai_resp = zai_messages_post(
+                                            {
                                                 'model': 'glm-5-turbo',
                                                 'max_tokens': 1500,
                                                 'system': _fallback_system,

--- a/services/zai_direct.py
+++ b/services/zai_direct.py
@@ -1,0 +1,86 @@
+"""
+services/zai_direct.py — direct Z.AI Anthropic-dialect call with A/B key fallback.
+
+Two call sites (routes/chat.py, routes/conversation.py) hit Z.AI directly with
+only ZAI_API_KEY (account A) and no fallback to ZAI_FALLBACK_API_KEY (account
+B / zai_fb in services/ai_providers.py) when account A hits its weekly/monthly
+cap (Z.AI error 1310, HTTP 429). This module centralizes that call so both
+sites retry once against the fallback key on a cap-exhaustion response.
+
+NEVER Groq — Groq is TTS only, never for LLM. NEVER log key values.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+ZAI_MESSAGES_URL = 'https://api.z.ai/api/anthropic/v1/messages'
+
+
+def _is_cap_exhausted(resp: requests.Response) -> bool:
+    """True if this response indicates the Z.AI account hit its weekly/monthly cap."""
+    if resp.status_code == 429:
+        return True
+    try:
+        body_text = resp.text or ''
+    except Exception:
+        body_text = ''
+    return '1310' in body_text or 'Limit Exhausted' in body_text
+
+
+def zai_messages_post(
+    payload: Dict[str, Any],
+    timeout: float = 30,
+    session: Optional[requests.Session] = None,
+) -> requests.Response:
+    """
+    POST to the Z.AI Anthropic-messages endpoint using ZAI_API_KEY (account A).
+    On a cap-exhaustion response (HTTP 429 / body contains "1310" or "Limit
+    Exhausted"), retries ONCE using ZAI_FALLBACK_API_KEY (account B) if that
+    env var is set. Returns whichever requests.Response came back last —
+    callers keep their existing status-code / raise_for_status handling.
+
+    Raises the same way the two callers already do today if neither key is
+    configured: a RuntimeError naming the missing env var (never a key value).
+    """
+    poster = session.post if session is not None else requests.post
+
+    primary_key = os.environ.get('ZAI_API_KEY', '')
+    fallback_key = os.environ.get('ZAI_FALLBACK_API_KEY', '')
+
+    if not primary_key and not fallback_key:
+        raise RuntimeError('ZAI_API_KEY not configured')
+
+    headers_base = {
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+    }
+
+    if primary_key:
+        resp = poster(
+            ZAI_MESSAGES_URL,
+            headers={**headers_base, 'x-api-key': primary_key},
+            json=payload,
+            timeout=timeout,
+        )
+        if not _is_cap_exhausted(resp):
+            return resp
+        if not fallback_key:
+            return resp
+        logger.warning('### Z.AI account A cap exhausted — retrying with fallback key (zai_fb)')
+    else:
+        logger.warning('### ZAI_API_KEY not set — using fallback key (zai_fb) directly')
+
+    resp = poster(
+        ZAI_MESSAGES_URL,
+        headers={**headers_base, 'x-api-key': fallback_key},
+        json=payload,
+        timeout=timeout,
+    )
+    return resp

--- a/tests/test_zai_direct.py
+++ b/tests/test_zai_direct.py
@@ -1,0 +1,67 @@
+"""
+tests/test_zai_direct.py — Z.AI direct-call A/B fallback (services/zai_direct.py).
+
+Covers the 2026-09-09 defect: routes/chat.py and routes/conversation.py called
+Z.AI directly with ONLY ZAI_API_KEY and no fallback to ZAI_FALLBACK_API_KEY
+when account A hit its weekly cap (HTTP 429 / error 1310).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.zai_direct import zai_messages_post
+
+
+def _mk_response(status_code, text=''):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    return resp
+
+
+@patch.dict('os.environ', {'ZAI_API_KEY': 'key-a', 'ZAI_FALLBACK_API_KEY': 'key-b'})
+@patch('services.zai_direct.requests.post')
+def test_429_then_fallback_succeeds(mock_post):
+    mock_post.side_effect = [
+        _mk_response(429, '{"error":{"code":1310,"message":"Weekly Limit Exhausted"}}'),
+        _mk_response(200, '{"content":[{"text":"ok"}]}'),
+    ]
+
+    resp = zai_messages_post({'model': 'glm-5-turbo', 'messages': []}, timeout=30)
+
+    assert mock_post.call_count == 2
+    first_headers = mock_post.call_args_list[0].kwargs['headers']
+    second_headers = mock_post.call_args_list[1].kwargs['headers']
+    assert first_headers['x-api-key'] == 'key-a'
+    assert second_headers['x-api-key'] == 'key-b'
+    assert resp.status_code == 200
+
+
+@patch.dict('os.environ', {'ZAI_API_KEY': 'key-a', 'ZAI_FALLBACK_API_KEY': 'key-b'})
+@patch('services.zai_direct.requests.post')
+def test_200_first_try_no_fallback_call(mock_post):
+    mock_post.return_value = _mk_response(200, '{"content":[{"text":"ok"}]}')
+
+    resp = zai_messages_post({'model': 'glm-5-turbo', 'messages': []}, timeout=30)
+
+    assert mock_post.call_count == 1
+    assert mock_post.call_args.kwargs['headers']['x-api-key'] == 'key-a'
+    assert resp.status_code == 200
+
+
+@patch.dict('os.environ', {'ZAI_API_KEY': 'key-a', 'ZAI_FALLBACK_API_KEY': ''}, clear=False)
+@patch('services.zai_direct.requests.post')
+def test_429_no_fallback_env_propagates_429(mock_post):
+    mock_post.return_value = _mk_response(429, '{"error":{"code":1310}}')
+
+    resp = zai_messages_post({'model': 'glm-5-turbo', 'messages': []}, timeout=30)
+
+    assert mock_post.call_count == 1
+    assert resp.status_code == 429
+
+
+@patch.dict('os.environ', {'ZAI_API_KEY': '', 'ZAI_FALLBACK_API_KEY': ''}, clear=False)
+def test_no_keys_configured_raises():
+    with pytest.raises(RuntimeError):
+        zai_messages_post({'model': 'glm-5-turbo', 'messages': []}, timeout=30)


### PR DESCRIPTION
Measured 2026-09-09 03:05Z: Z.AI account A hit its weekly cap. The openclaw gateway chain falls back to account B (zai_fb), but two OpenVoiceUI code paths call Z.AI directly with only ZAI_API_KEY and no fallback, so they failed with HTTP 429 (Z.AI error 1310 "Weekly/Monthly Limit Exhausted") until reset:

- routes/chat.py — `/api/chat` direct completion call
- routes/conversation.py — the Z.AI direct fallback used after a double-empty LLM response

services/ai_providers.py already defines both providers (`zai` / ZAI_API_KEY, `zai_fb` / ZAI_FALLBACK_API_KEY, same baseUrl) but nothing wired the second one into these two direct calls.

Adds `services/zai_direct.py:zai_messages_post()` — tries ZAI_API_KEY first, retries once against ZAI_FALLBACK_API_KEY on a 429 or a body containing "1310"/"Limit Exhausted", logs one warning naming which key tier was used (never logs key values). Both call sites now go through it; behavior on the success path (payload, timeout, error handling) is unchanged.