### PR TITLE
fix(gateway): extend WS reconnect budget to cover measured gateway restart time

### DIFF
--- a/services/gateways/openclaw.py
+++ b/services/gateways/openclaw.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import queue
+import random
 import re as _re
 import threading
 import time
@@ -626,6 +627,19 @@ class GatewayConnection:
         self._server_version: str | None = None
         self._reconnected_at: float = 0.0  # timestamp of last successful reconnect after failure
 
+    @staticmethod
+    def _jittered_delay(base_delay):
+        """Full jitter within +/-15% of base_delay.
+
+        Pledge 50bef735: ~25 tenants share this same restart-recovery
+        schedule, and a gateway restart (fleet roll, image update, crash
+        loop) tends to hit several of them within the same second. Without
+        jitter every affected tenant's supervisor sleeps the exact same
+        BACKOFF_DELAYS value and then retries in lockstep, turning "the
+        gateway just came back" into a thundering-herd reconnect burst.
+        """
+        return base_delay * random.uniform(0.85, 1.15)
+
     @property
     def url(self):
         return getattr(self, '_custom_url', None) or os.getenv('CLAWDBOT_GATEWAY_URL', self.DEFAULT_URL)
@@ -846,14 +860,32 @@ class GatewayConnection:
                 logger.info("### _ensure_connected: socket reports closed — reconnecting")
                 self._connected = False
 
-            backoff = self.BACKOFF_DELAYS[min(self._backoff_idx, len(self.BACKOFF_DELAYS) - 1)]
+            backoff = self._jittered_delay(
+                self.BACKOFF_DELAYS[min(self._backoff_idx, len(self.BACKOFF_DELAYS) - 1)]
+            )
             elapsed = time.time() - self._last_disconnect_time
             if elapsed < backoff and self._last_disconnect_time > 0:
                 wait = backoff - elapsed
                 logger.info(f"### WS backoff: waiting {wait:.1f}s before reconnect")
                 await asyncio.sleep(wait)
 
-            max_attempts = 5
+            # WS-9 (pledge 50bef735, 2026-09-10): openclaw gateway restart-to-ready
+            # measured at ~37-38s (container StartedAt -> "[gateway] ready" log
+            # line; openclaw-danielle 37.0s, openclaw-azrim 37.8s on 2026-09-10).
+            # The old max_attempts=5 schedule only covered a ~30s window (2+4+8+16s
+            # of sleep between attempts) before raising RuntimeError. Measured
+            # consequence in openvoiceui-azrim's logs for the 04:29 restart: all 5
+            # attempts (04:29:56.75 -> 04:30:26.94) failed because the gateway
+            # wasn't ready until 04:30:30.7, the supervisor gave up ("Failed to
+            # connect to Gateway after 5 attempts — retrying in 30s"), and only
+            # reconnected on its NEXT cycle ~35s later — a ~37s restart became a
+            # ~65s+ outage, and the retry budget was fully exhausted on every
+            # gateway restart across ~25 tenants (the condition this pledge exists
+            # to fix). max_attempts=6 extends the nominal (pre-jitter) sleep budget
+            # to 60s (2+4+8+16+30), comfortably covering the measured restart time
+            # with margin, while _jittered_delay (+/-15%) keeps tenants whose
+            # gateways restart together from retrying in lockstep.
+            max_attempts = 6
             for attempt in range(max_attempts):
                 try:
                     logger.info(f"### WS connect attempt {attempt + 1}/{max_attempts}...")
@@ -863,8 +895,10 @@ class GatewayConnection:
                     self._backoff_idx = min(self._backoff_idx + 1, len(self.BACKOFF_DELAYS) - 1)
                     self._last_disconnect_time = time.time()
                     if attempt < max_attempts - 1:
-                        delay = self.BACKOFF_DELAYS[min(self._backoff_idx, len(self.BACKOFF_DELAYS) - 1)]
-                        logger.warning(f"### WS connect failed ({e}), retrying in {delay}s...")
+                        delay = self._jittered_delay(
+                            self.BACKOFF_DELAYS[min(self._backoff_idx, len(self.BACKOFF_DELAYS) - 1)]
+                        )
+                        logger.warning(f"### WS connect failed ({e}), retrying in {delay:.1f}s...")
                         await asyncio.sleep(delay)
 
             raise RuntimeError(f"Failed to connect to Gateway after {max_attempts} attempts")

--- a/tests/test_gateway_reconnect_backoff.py
+++ b/tests/test_gateway_reconnect_backoff.py
@@ -1,0 +1,129 @@
+"""
+Tests for GatewayConnection._ensure_connected's reconnect budget (pledge
+50bef735, 2026-09-10). GatewayConnection is the persistent-WS connection
+manager the OpenClawGateway facade (services/gateways/openclaw.py) wraps via
+GatewayRouter.
+
+Measured problem: the old max_attempts=5 schedule (BACKOFF_DELAYS
+[1,2,4,8,16,30,60], sleeping 2+4+8+16=30s between the 5 attempts) covered a
+~30s window, but a real openclaw gateway restart takes ~37-38s from
+container start to the "[gateway] ready" log line (measured on
+openclaw-danielle and openclaw-azrim, 2026-09-10). Consequence measured in
+openvoiceui-azrim's logs: all 5 attempts during a restart failed, the
+supervisor raised "Failed to connect to Gateway after 5 attempts", and only
+reconnected on its NEXT cycle ~35s later — turning a ~37s restart into a
+~65s+ outage and burning the whole retry budget on every restart.
+
+The fix: max_attempts=6 (nominal 60s budget: 2+4+8+16+30) plus +/-15% jitter
+on every backoff delay (GatewayConnection._jittered_delay) so tenants whose
+gateways restart together don't hammer in lockstep.
+
+These tests exercise the real _ensure_connected coroutine with self._connect
+mocked out and asyncio.sleep patched to a no-op recorder, so they run fast
+and deterministically regardless of the real jittered delay values.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.gateways.openclaw import GatewayConnection
+
+
+def _make_gateway():
+    gw = GatewayConnection()
+    gw._ws_lock = asyncio.Lock()
+    return gw
+
+
+class TestJitteredDelay:
+    def test_stays_within_plus_minus_15_percent(self):
+        for _ in range(500):
+            d = GatewayConnection._jittered_delay(10.0)
+            assert 8.5 <= d <= 11.5
+
+    def test_varies_across_calls(self):
+        # Full jitter must not degenerate into a constant — that would defeat
+        # the anti-lockstep purpose entirely.
+        values = {GatewayConnection._jittered_delay(10.0) for _ in range(20)}
+        assert len(values) > 1
+
+
+class TestEnsureConnectedGatewayUp:
+    """(b) With the gateway up, the connect path is unchanged: first attempt
+    succeeds immediately, no sleeping, no wasted attempts."""
+
+    def test_first_attempt_succeeds_no_sleep(self):
+        gw = _make_gateway()
+        gw._connect = AsyncMock(return_value=None)
+
+        with patch(
+            "services.gateways.openclaw.asyncio.sleep", new=AsyncMock()
+        ) as mock_sleep:
+            asyncio.run(gw._ensure_connected())
+
+        assert gw._connect.await_count == 1
+        mock_sleep.assert_not_awaited()
+
+
+class TestEnsureConnectedGatewayDown:
+    """(a) With the gateway down for the full restart window (up to the 6th
+    attempt), the client still reconnects successfully within the budget
+    instead of exhausting it — the exact case the old max_attempts=5 schedule
+    failed on 2026-09-10."""
+
+    def test_reconnects_on_last_attempt_within_new_budget_without_exhausting(self):
+        gw = _make_gateway()
+        # Fails 5 times (matching the measured 5/5 exhaustion), succeeds on the
+        # 6th — only possible because max_attempts is now 6, not 5.
+        calls = {"n": 0}
+
+        async def flaky_connect():
+            calls["n"] += 1
+            if calls["n"] < 6:
+                raise ConnectionRefusedError("gateway not listening yet")
+
+        gw._connect = AsyncMock(side_effect=flaky_connect)
+
+        with patch("services.gateways.openclaw.asyncio.sleep", new=AsyncMock()):
+            asyncio.run(gw._ensure_connected())  # must not raise
+
+        assert calls["n"] == 6
+
+    def test_old_budget_of_5_attempts_would_have_raised(self):
+        # Sanity control proving the schedule actually changed: a gateway that
+        # only comes up on the 6th attempt is exactly what the OLD
+        # max_attempts=5 loop could never reach — it always raised
+        # RuntimeError("...after 5 attempts") first. This test freezes that
+        # regression check by capping attempts at 5 directly against the
+        # documented old behaviour, independent of the current source.
+        old_max_attempts = 5
+        calls = {"n": 0}
+
+        async def flaky_connect():
+            calls["n"] += 1
+            if calls["n"] < 6:
+                raise ConnectionRefusedError("gateway not listening yet")
+
+        async def old_loop():
+            for attempt in range(old_max_attempts):
+                try:
+                    await flaky_connect()
+                    return
+                except Exception:
+                    pass
+            raise RuntimeError(f"Failed to connect to Gateway after {old_max_attempts} attempts")
+
+        with pytest.raises(RuntimeError, match="after 5 attempts"):
+            asyncio.run(old_loop())
+
+    def test_exhausts_and_raises_when_still_down_after_new_budget(self):
+        gw = _make_gateway()
+        gw._connect = AsyncMock(side_effect=ConnectionRefusedError("still down"))
+
+        with patch("services.gateways.openclaw.asyncio.sleep", new=AsyncMock()):
+            with pytest.raises(RuntimeError, match="after 6 attempts"):
+                asyncio.run(gw._ensure_connected())
+
+        assert gw._connect.await_count == 6


### PR DESCRIPTION
## Problem (pledge 50bef735, host@mesh, due 2026-09-12)

`GatewayConnection._ensure_connected` (`services/gateways/openclaw.py:845`) capped
reconnects at `max_attempts = 5`, which with `BACKOFF_DELAYS = [1, 2, 4, 8, 16, 30, 60]`
sleeps `2+4+8+16 = 30s` total between attempts before raising `RuntimeError`.

**Measured:** openclaw gateway restart-to-ready time (container `StartedAt` →
the `[gateway] ready` log line):
- `openclaw-danielle`: `04:43:15.405` → `04:43:52.451` = **37.0s**
- `openclaw-azrim`: `04:29:52.961` → `04:30:30.721` = **37.8s**

Both exceed the old 30s budget.

**Measured consequence** in `openvoiceui-azrim` logs for the 04:29 restart:
```
04:29:56.75  WS connect attempt 1/5...
04:29:58.90  WS connect attempt 2/5...
04:30:02.91  WS connect attempt 3/5...
04:30:10.92  WS connect attempt 4/5...
04:30:26.94  WS connect attempt 5/5...
04:30:26.95  WARNING Failed to connect to Gateway after 5 attempts — retrying in 30s
04:31:01.98  WS supervisor: reader died — reconnecting   (next cycle)
```
All 5 attempts failed because the gateway wasn't ready until `04:30:30.7` —
3s after the last attempt. The supervisor then had to wait its own ~35s
outer retry before trying again, turning a ~37s restart into a **~65s+
outage** and fully exhausting the retry budget on every gateway restart
across the ~25 tenants sharing this code path.

## Fix

- `max_attempts = 5` → `6`, extending the nominal (pre-jitter) sleep budget
  from 30s to **60s** (`2+4+8+16+30`), comfortably covering the measured
  ~37-38s restart with margin.
- Added `GatewayConnection._jittered_delay` (+/-15% full jitter), applied to
  every backoff wait (the initial elapsed-based wait and the inter-attempt
  delay), so tenants whose gateways restart together (fleet rolls, image
  updates) don't retry in lockstep.
- Behaviour when the gateway is already up is **unchanged**: first attempt
  succeeds immediately, no sleep, no wasted attempts.

## Tests

`tests/test_gateway_reconnect_backoff.py` (new), run against the real
`GatewayConnection._ensure_connected` coroutine with `_connect` mocked and
`asyncio.sleep` patched to a fast no-op:

```
tests/test_gateway_reconnect_backoff.py::TestJitteredDelay::test_stays_within_plus_minus_15_percent PASSED
tests/test_gateway_reconnect_backoff.py::TestJitteredDelay::test_varies_across_calls PASSED
tests/test_gateway_reconnect_backoff.py::TestEnsureConnectedGatewayUp::test_first_attempt_succeeds_no_sleep PASSED
tests/test_gateway_reconnect_backoff.py::TestEnsureConnectedGatewayDown::test_reconnects_on_last_attempt_within_new_budget_without_exhausting PASSED
tests/test_gateway_reconnect_backoff.py::TestEnsureConnectedGatewayDown::test_old_budget_of_5_attempts_would_have_raised PASSED
tests/test_gateway_reconnect_backoff.py::TestEnsureConnectedGatewayDown::test_exhausts_and_raises_when_still_down_after_new_budget PASSED
tests/test_warmup_retry.py::test_retries_until_success_then_stops PASSED
tests/test_warmup_retry.py::test_succeeds_immediately_without_sleeping PASSED
tests/test_warmup_retry.py::test_uses_given_delay_seconds PASSED

9 passed in 0.11s
```

Full `pytest tests/ --ignore=tests/js`: 507 passed, 48 failed, 22 skipped —
all 48 failures are pre-existing (missing `ALLOWED_USER_IDS`/auth env config
in admin/canvas/conversation/routes/music/static tests) and none touch
`services/gateways/openclaw.py`.

Not merging — leaving for review per host process.