### PR TITLE
fix(voice): flush queued TTS chunks before stream generator exits

### DIFF
--- a/routes/conversation.py
+++ b/routes/conversation.py
@@ -413,6 +413,58 @@ def _flush_db_writes(timeout: float = 5.0) -> None:
     _db_write_queue.join()
 
 # ---------------------------------------------------------------------------
+# Exit-path TTS flush (issue #487)
+# ---------------------------------------------------------------------------
+#
+# stream_response()'s main event loop has two exit paths that `break` WITHOUT
+# ever running the text_done flush loop that waits on `_tts_pending`:
+#   1. STREAM HARD TIMEOUT (queue.Empty branch, elapsed > _STREAM_HARD_TIMEOUT)
+#   2. a gateway-level 'error' event
+# Both leave any TTS chunks still in `_tts_pending` un-waited-on. Each chunk's
+# background _fire_tts()._run() always pings event_queue with a payload-free
+# {'type': 'tts_ready'} wake event when it finishes (regardless of whether
+# anything ever consumes it), which is what the old "STREAM EXIT with N
+# unprocessed events: ['tts_ready', ...]" warning was seeing — but that ping
+# carries no audio, so re-yielding it to the client does nothing. The actual
+# payload lives in `_tts_pending`'s (done_event, result) tuples, so THIS is
+# what must be drained before the generator returns. The text_done path
+# already drains `_tts_pending` synchronously and resets it to [] afterward,
+# so calling this there is a no-op.
+def drain_pending_tts_on_exit(tts_pending, chunks_sent, audio_event_fn, error_event_fn,
+                               cap_seconds=15, log=None):
+    """Wait up to cap_seconds (one wall-clock budget shared across every
+    remaining chunk, not per-chunk) for outstanding TTS chunks to finish,
+    returning (events, dropped_count).
+
+    events: ndjson-line strings (built via audio_event_fn/error_event_fn) for
+    every chunk that finished within the cap, in original order — caller
+    yields these to the client exactly like the normal flush does.
+    dropped_count: chunks whose done_event never fired within the cap. These
+    are genuinely lost (provider hung past the budget); the caller logs it.
+    """
+    log = log or logger
+    events = []
+    dropped = 0
+    if not tts_pending:
+        return events, dropped
+    deadline = time.time() + cap_seconds
+    for i, (done_evt, res) in enumerate(tts_pending):
+        remaining = max(0.0, deadline - time.time())
+        if done_evt.wait(timeout=remaining):
+            if res.get('error'):
+                events.append(error_event_fn(res['error']))
+            elif res.get('audio'):
+                events.append(audio_event_fn(res['audio'], chunks_sent + i))
+        else:
+            dropped += 1
+    if dropped:
+        log.warning(
+            f"### STREAM EXIT: {dropped} TTS chunk(s) still not ready after "
+            f"waiting {cap_seconds}s for exit flush — audio DROPPED"
+        )
+    return events, dropped
+
+# ---------------------------------------------------------------------------
 # In-memory session key cache (FIND-02 fix from performance audit)
 # ---------------------------------------------------------------------------
 
@@ -3410,6 +3462,10 @@ def _conversation_inner():
                                         f"audio not delivered (provider hung); paid generation logged, not discarded"
                                     )
 
+                            # Fully handled above (waited + yielded or logged) — clear so
+                            # the post-loop exit flush (#487) never re-processes these.
+                            _tts_pending = []
+
                             metrics['tts_generation_ms'] = int((time.time() - t_tts_start) * 1000)
                             metrics['tts_text_len'] = metrics['response_len']
                             metrics['total_ms'] = int((time.time() - t_request_start) * 1000)
@@ -3450,7 +3506,29 @@ def _conversation_inner():
                             }) + '\n'
                             break
 
-                    # Drain any unprocessed events (debug: detect generator exit without text_done)
+                    # Exit-path TTS flush (#487) — if we're leaving via a path that
+                    # skipped the text_done flush (STREAM HARD TIMEOUT / gateway
+                    # 'error' break), _tts_pending may still hold finished-or-finishing
+                    # TTS audio the client never got. Wait a bounded cap and deliver it
+                    # instead of silently dropping the tail of the spoken answer.
+                    _tts_exit_cap = int(os.getenv('TTS_EXIT_FLUSH_CAP', '15'))
+                    _exit_events, _exit_dropped = drain_pending_tts_on_exit(
+                        _tts_pending, _chunks_sent, _audio_event, _tts_error_event,
+                        cap_seconds=_tts_exit_cap, log=logger,
+                    )
+                    for _exit_evt in _exit_events:
+                        yield _exit_evt
+                    if _exit_events:
+                        logger.info(
+                            f"### STREAM EXIT: flushed {len(_exit_events)} TTS chunk(s) "
+                            f"that would otherwise have been dropped"
+                        )
+
+                    # Drain any remaining raw queue events (debug: detect generator exit
+                    # without text_done). tts_ready is a payload-free wake ping — its
+                    # audio (if any) was already handled above via _tts_pending, so a
+                    # leftover tts_ready here is expected noise, not a loss, and is
+                    # logged at info rather than warning.
                     _remaining_evts = []
                     while not event_queue.empty():
                         try:
@@ -3459,7 +3537,11 @@ def _conversation_inner():
                             break
                     if _remaining_evts:
                         _types = [e.get('type', '?') for e in _remaining_evts]
-                        logger.warning(f"### STREAM EXIT with {len(_remaining_evts)} unprocessed events: {_types}")
+                        _noteworthy = [t for t in _types if t != 'tts_ready']
+                        if _noteworthy or _exit_dropped:
+                            logger.warning(f"### STREAM EXIT with {len(_remaining_evts)} unprocessed events: {_types}")
+                        else:
+                            logger.info(f"### STREAM EXIT drained {len(_remaining_evts)} stale tts_ready wake-ping(s) (already flushed)")
 
                 return Response(
                     stream_response(),

--- a/tests/test_stream_exit_flushes_tts.py
+++ b/tests/test_stream_exit_flushes_tts.py
@@ -1,0 +1,184 @@
+"""
+Tests for routes.conversation.drain_pending_tts_on_exit (issue #487).
+
+Measured live 2026-09-10 (tenant danielle): TEXT_DONE received with
+_tts_pending=4, four Groq TTS completions logged, tts_ok=1 metrics, then
+"### STREAM EXIT with 4 unprocessed events: ['tts_ready']*4" — the generator
+returned while TTS audio was still sitting unconsumed.
+
+Root cause (routes/conversation.py stream_response()): the main event loop
+has two `break` paths — STREAM HARD TIMEOUT (queue.Empty branch, elapsed >
+_STREAM_HARD_TIMEOUT) and the gateway 'error' branch — that exit WITHOUT ever
+running the text_done flush loop that waits on `_tts_pending`. Each TTS
+chunk's background thread (_fire_tts()._run()) always pings event_queue with
+a payload-free {'type': 'tts_ready'} wake event when it finishes, regardless
+of whether anything consumes it — that ping is what the old warning was
+counting, but it carries no audio, so re-yielding it to the client would do
+nothing. The actual payload lives in `_tts_pending`'s (done_event, result)
+tuples, which is what drain_pending_tts_on_exit() now drains, bounded by a
+wall-clock cap, before the generator returns.
+
+These tests drive drain_pending_tts_on_exit() directly with a fake
+_tts_pending list of (threading.Event, dict) tuples, mirroring exactly what
+stream_response() builds via _fire_tts().
+"""
+
+import threading
+import time
+
+from routes.conversation import drain_pending_tts_on_exit
+
+
+def _make_ready_chunk(audio='YXVkaW8=', error=None, delay=0.0):
+    """A (done_event, result) pair that becomes ready after `delay` seconds,
+    mirroring _fire_tts()'s background thread completing late (arriving
+    AFTER TEXT_DONE was logged, as in the live incident)."""
+    done = threading.Event()
+    result = {'audio': None, 'error': None}
+
+    def _finish():
+        if delay:
+            time.sleep(delay)
+        result['audio'] = audio
+        result['error'] = error
+        done.set()
+
+    if delay:
+        threading.Thread(target=_finish, daemon=True).start()
+    else:
+        _finish()
+    return done, result
+
+
+def _audio_event_fn(audio_b64, chunk_idx):
+    return f'audio:{chunk_idx}:{audio_b64}'
+
+
+def _error_event_fn(err_str):
+    return f'error:{err_str}'
+
+
+class TestQueuedChunksArrivingAfterTextDone:
+    """The exact shape of the live incident: 4 tts_ready-bound chunks finish
+    shortly after TEXT_DONE, on a path that skipped the normal flush."""
+
+    def test_four_late_chunks_all_flushed_before_return(self):
+        pending = [
+            _make_ready_chunk(audio=f'chunk{i}'.encode().hex(), delay=0.05)
+            for i in range(4)
+        ]
+        events, dropped = drain_pending_tts_on_exit(
+            pending, chunks_sent=0,
+            audio_event_fn=_audio_event_fn, error_event_fn=_error_event_fn,
+            cap_seconds=5,
+        )
+        assert dropped == 0
+        assert len(events) == 4
+        # Order preserved, chunk indices offset by chunks_sent.
+        for i in range(4):
+            assert events[i] == f'audio:{i}:{f"chunk{i}".encode().hex()}'
+
+    def test_error_chunk_yields_error_event_not_dropped(self):
+        pending = [_make_ready_chunk(error='provider_500')]
+        events, dropped = drain_pending_tts_on_exit(
+            pending, chunks_sent=0,
+            audio_event_fn=_audio_event_fn, error_event_fn=_error_event_fn,
+            cap_seconds=5,
+        )
+        assert dropped == 0
+        assert events == ['error:provider_500']
+
+    def test_chunks_sent_offsets_indices(self):
+        pending = [_make_ready_chunk(audio='a'), _make_ready_chunk(audio='b')]
+        events, dropped = drain_pending_tts_on_exit(
+            pending, chunks_sent=3,
+            audio_event_fn=_audio_event_fn, error_event_fn=_error_event_fn,
+            cap_seconds=5,
+        )
+        assert dropped == 0
+        assert events == ['audio:3:a', 'audio:4:b']
+
+
+class TestNeverCompletingProviderHitsTheCap:
+    """A provider that hangs past the cap must be counted DROPPED — never
+    hang the generator forever, and never claim a success that didn't
+    happen."""
+
+    def test_cap_fires_and_reports_dropped_count(self):
+        never_done = threading.Event()  # never .set()
+        pending = [(never_done, {'audio': None, 'error': None})]
+        start = time.time()
+        events, dropped = drain_pending_tts_on_exit(
+            pending, chunks_sent=0,
+            audio_event_fn=_audio_event_fn, error_event_fn=_error_event_fn,
+            cap_seconds=0.2,
+        )
+        elapsed = time.time() - start
+        assert dropped == 1
+        assert events == []
+        # Bounded by the cap, not left to hang indefinitely.
+        assert elapsed < 1.0
+
+    def test_cap_is_a_shared_budget_not_per_chunk(self):
+        # First chunk never completes and eats the whole 0.1s cap. The
+        # second chunk finishes at 0.5s — well within its OWN fresh 0.1s cap
+        # would have been impossible either way, but the point is it must
+        # not get a fresh 0.1s of its own: the cap is one wall-clock
+        # deadline shared across all remaining chunks, so by the time we
+        # reach chunk 2 there is ~0s left and it is dropped too, and the
+        # whole call returns in ~0.1s rather than waiting out chunk 2's 0.5s.
+        never_done = threading.Event()
+        late_done, late_res = _make_ready_chunk(audio='late-but-ready', delay=0.5)
+        pending = [
+            (never_done, {'audio': None, 'error': None}),
+            (late_done, late_res),
+        ]
+        start = time.time()
+        events, dropped = drain_pending_tts_on_exit(
+            pending, chunks_sent=0,
+            audio_event_fn=_audio_event_fn, error_event_fn=_error_event_fn,
+            cap_seconds=0.1,
+        )
+        elapsed = time.time() - start
+        assert dropped == 2  # first hangs the whole budget; second gets ~0s left
+        assert events == []
+        assert elapsed < 0.3  # proves the budget is shared, not 0.1 + 0.5
+
+    def test_mixed_one_ready_one_hung_partial_flush_partial_drop(self):
+        ready_done, ready_res = _make_ready_chunk(audio='ok')
+        never_done = threading.Event()
+        pending = [
+            (ready_done, ready_res),
+            (never_done, {'audio': None, 'error': None}),
+        ]
+        events, dropped = drain_pending_tts_on_exit(
+            pending, chunks_sent=0,
+            audio_event_fn=_audio_event_fn, error_event_fn=_error_event_fn,
+            cap_seconds=0.3,
+        )
+        assert dropped == 1
+        assert events == ['audio:0:ok']
+
+
+class TestNormalPathUnchanged:
+    """No pending TTS at exit (the common case: text_done already flushed
+    and reset _tts_pending to []) must be a true no-op — no delay, no
+    events, no dropped count, no log noise."""
+
+    def test_empty_pending_is_a_noop(self):
+        events, dropped = drain_pending_tts_on_exit(
+            [], chunks_sent=0,
+            audio_event_fn=_audio_event_fn, error_event_fn=_error_event_fn,
+            cap_seconds=15,
+        )
+        assert events == []
+        assert dropped == 0
+
+    def test_empty_pending_returns_immediately(self):
+        start = time.time()
+        drain_pending_tts_on_exit(
+            [], chunks_sent=0,
+            audio_event_fn=_audio_event_fn, error_event_fn=_error_event_fn,
+            cap_seconds=15,
+        )
+        assert time.time() - start < 0.05


### PR DESCRIPTION
Fixes #487.

Measured live 2026-09-10 (tenant danielle): `TEXT_DONE received. response=424 chars, _tts_pending=4`, four `[Groq] Generated … bytes` TTS completions, a `tts_ok=1` metrics line, then `WARNING ### STREAM EXIT with 4 unprocessed events: ['tts_ready']*4` — the generator returned while TTS audio was still unconsumed.

## Root cause

`routes/conversation.py`'s `stream_response()` main event loop has two exit paths that `break` WITHOUT ever running the `text_done` flush loop that waits on `_tts_pending`:
- STREAM HARD TIMEOUT (`elapsed > _STREAM_HARD_TIMEOUT` = 310s)
- the gateway `'error'` branch

Each TTS chunk's background thread (`_fire_tts()._run()`) unconditionally pings `event_queue` with a payload-free `{'type': 'tts_ready'}` wake event when it finishes, regardless of whether anything consumes it. That ping is what the old warning was counting — but it carries no audio. The real payload lives in `_tts_pending`'s `(done_event, result)` tuples, which those two exit paths never drained.

## Fix

`drain_pending_tts_on_exit()` (module-level, testable) runs right before the generator returns. It waits up to a bounded wall-clock cap (`TTS_EXIT_FLUSH_CAP` env, default 15s, shared across all remaining chunks — not per chunk) for anything still in `_tts_pending`, yielding audio for whatever lands instead of silently dropping it, and logs a DROPPED count for anything still not ready after the cap.

The `text_done` path already drains `_tts_pending` synchronously; it now also resets the list to `[]` afterward, so the exit flush is a true no-op on that path (previously stale, already-yielded entries lingered in `_tts_pending` unused). Leftover raw `tts_ready` wake-pings in `event_queue` are now logged at info (expected noise, already handled via `_tts_pending`) instead of warning, unless real audio was dropped or another event type is present.

## Tests

`tests/test_stream_exit_flushes_tts.py` drives `drain_pending_tts_on_exit()` directly against fake `(threading.Event, result)` pairs mirroring `_fire_tts()`:
- 4 chunks completing after `TEXT_DONE` are all flushed, in order, before return
- error chunks yield an error event rather than being silently dropped
- a chunk that never completes hits the cap and is reported DROPPED, bounded wall-clock (doesn't hang the generator)
- the cap is a shared budget, not reset per chunk
- empty `_tts_pending` (the normal, already-flushed `text_done` case) is a true no-op — no delay, no events, no dropped count

```
$ pytest tests/test_stream_exit_flushes_tts.py -q
8 passed in 0.99s

$ pytest tests/test_conversation_extended.py -q
16 passed, 3 failed (pre-existing — ALLOWED_USER_IDS/auth env config, same 3 fail identically on main with no diff)
```